### PR TITLE
switch to not-yet-enabled groupsInfo API

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ import 'quasar-extras/animate'
 
 Quasar.start(async () => {
   sync(store, router)
-  store.dispatch('groups/fetchGroups')
+  store.dispatch('groups/fetchGroupsPreview')
 
   await store.dispatch('auth/check')
 

--- a/src/services/api/groupsInfo.js
+++ b/src/services/api/groupsInfo.js
@@ -1,0 +1,11 @@
+import axios from '@/services/axios'
+
+export default {
+  async get (groupId) {
+    return (await axios.get(`/api/groups-info/${groupId}/`)).data
+  },
+
+  async list () {
+    return (await axios.get('/api/groups-info/')).data
+  },
+}

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -1,4 +1,5 @@
 import groups from '@/services/api/groups'
+import groupsInfo from '@/services/api/groupsInfo'
 import router from '@/router'
 import { indexById, onlyHandleAPIError } from '@/store/helpers'
 import { Toast } from 'quasar'
@@ -161,11 +162,11 @@ export const actions = {
     commit(types.RECEIVE_GROUP, { group })
   },
 
-  async fetchGroups ({ commit }) {
+  async fetchGroupsPreview ({ commit }) {
     // fetch public group info
     commit(types.REQUEST_GROUPS)
     try {
-      commit(types.RECEIVE_GROUPS, { groups: await groups.list() })
+      commit(types.RECEIVE_GROUPS, { groups: await groupsInfo.list() })
     }
     catch (error) {
       commit(types.RECEIVE_GROUPS_ERROR, { error })

--- a/src/store/modules/groups.spec.js
+++ b/src/store/modules/groups.spec.js
@@ -1,13 +1,15 @@
-const mockFetchGroups = jest.fn()
+const mockFetchGroupsPreview = jest.fn()
 const mockJoin = jest.fn()
 const mockLeave = jest.fn()
 const mockConversation = jest.fn()
 const mockRouterPush = jest.fn()
 jest.mock('@/services/api/groups', () => ({
-  list: mockFetchGroups,
   join: mockJoin,
   leave: mockLeave,
   conversation: mockConversation,
+}))
+jest.mock('@/services/api/groupsInfo', () => ({
+  list: mockFetchGroupsPreview,
 }))
 jest.mock('@/router', () => ({ push: mockRouterPush }))
 
@@ -87,8 +89,8 @@ describe('groups', () => {
     })
 
     it('can fetch the group list', async () => {
-      mockFetchGroups.mockReturnValueOnce([group1])
-      await store.dispatch('groups/fetchGroups')
+      mockFetchGroupsPreview.mockReturnValueOnce([group1])
+      await store.dispatch('groups/fetchGroupsPreview')
       expect(store.getters['groups/all']).toEqual([enrich(group1)])
     })
 


### PR DESCRIPTION
Waiting for https://github.com/yunity/karrot-backend/pull/420 to get merged and pushed to production