### PR TITLE
Add markdown input/preview component

### DIFF
--- a/src/components/Group/GroupEdit.vue
+++ b/src/components/Group/GroupEdit.vue
@@ -22,24 +22,28 @@
           <q-field
             icon="fa-question"
             :label="$t('GROUP.PUBLIC_DESCRIPTION')">
-            <q-input
-              v-model="groupEdit.publicDescription"
-              type="textarea"
-              :min-rows="3"
-              :max-height="100"
-            />
+            <MarkdownInput :value="groupEdit.publicDescription">
+              <q-input
+                v-model="groupEdit.publicDescription"
+                type="textarea"
+                :min-rows="3"
+                :max-height="100"
+              />
+            </MarkdownInput>
           </q-field>
 
           <q-field
             icon="fa-question"
             :label="$t('GROUP.DESCRIPTION_VERBOSE')"
             >
-            <q-input
-              v-model="groupEdit.description"
-              type="textarea"
-              :min-rows="3"
-              :max-height="100"
-            />
+            <MarkdownInput :value="groupEdit.description">
+              <q-input
+                v-model="groupEdit.description"
+                type="textarea"
+                :min-rows="3"
+                :max-height="100"
+              />
+            </MarkdownInput>
           </q-field>
 
           <q-field
@@ -94,6 +98,7 @@
 import { QCard, QField, QInput, QBtn, QAutocomplete } from 'quasar'
 import StandardMap from '@/components/Map/StandardMap'
 import AddressPicker from '@/components/Address/AddressPicker'
+import MarkdownInput from '@/components/MarkdownInput'
 import { validationMixin } from 'vuelidate'
 import { required, minLength, maxLength } from 'vuelidate/lib/validators'
 
@@ -126,7 +131,7 @@ export default {
     requestError: { required: true },
   },
   components: {
-    QCard, QField, QInput, QBtn, QAutocomplete, StandardMap, AddressPicker,
+    QCard, QField, QInput, QBtn, QAutocomplete, StandardMap, AddressPicker, MarkdownInput,
   },
   data () {
     return {

--- a/src/components/MarkdownInput.vue
+++ b/src/components/MarkdownInput.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <q-tabs inverted align="right" position="bottom" v-model="tab">
+      <q-tab default name="edit" slot="title" :label="$t('BUTTON.EDIT')" :hidden="tab === 'edit'" />
+      <q-tab v-if="value" name="preview" slot="title" :label="$t('BUTTON.PREVIEW')" :hidden="tab === 'preview'" />
+      <q-tab-pane name="edit">
+        <slot />
+        <small v-if="!$q.platform.is.mobile && tab === 'edit'" class="row group pull-right light-paragraph">
+          <b>**{{ $t('MARKDOWN_INPUT.BOLD') }}**</b>
+          <i>_{{ $t('MARKDOWN_INPUT.ITALIC') }}_</i>
+          <span>~~{{ $t('MARKDOWN_INPUT.STRIKE') }}~~</span>
+          <span>&gt;{{ $t('MARKDOWN_INPUT.QUOTE') }}</span>
+          <a href="https://guides.github.com/features/mastering-markdown/">
+            <q-icon name="fa-question-circle" />
+            <q-tooltip>{{ $t('MARKDOWN_INPUT.HELP') }}</q-tooltip>
+          </a>
+        </small>
+      </q-tab-pane>
+      <q-tab-pane name="preview">
+        <Markdown v-if="value" :source="value" />
+      </q-tab-pane>
+    </q-tabs>
+  </div>
+</template>
+
+<script>
+import { QTabs, QTab, QTabPane, QIcon, QTooltip } from 'quasar'
+import Markdown from '@/components/Markdown'
+
+export default {
+  components: { QTabs, QTab, QTabPane, QIcon, QTooltip, Markdown },
+  props: {
+    value: { required: true },
+  },
+  data () {
+    return {
+      tab: 'edit',
+    }
+  },
+}
+</script>
+

--- a/src/components/MarkdownInput.vue
+++ b/src/components/MarkdownInput.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <q-tabs inverted align="right" position="bottom" v-model="tab">
-      <q-tab default name="edit" slot="title" :label="$t('BUTTON.EDIT')" :hidden="tab === 'edit'" />
-      <q-tab v-if="value" name="preview" slot="title" :label="$t('BUTTON.PREVIEW')" :hidden="tab === 'preview'" />
+    <q-tabs class="markdown-input" inverted align="right" position="top" v-model="tab">
+      <q-tab class="markdown-input-tab" default name="edit" slot="title" :label="$t('BUTTON.EDIT')"/>
+      <q-tab class="markdown-input-tab" v-if="value" name="preview" slot="title" :label="$t('BUTTON.PREVIEW')"/>
       <q-tab-pane name="edit">
         <slot />
         <small v-if="!$q.platform.is.mobile && tab === 'edit'" class="row group pull-right light-paragraph">
@@ -15,6 +15,7 @@
             <q-tooltip>{{ $t('MARKDOWN_INPUT.HELP') }}</q-tooltip>
           </a>
         </small>
+        <div style="clear: both"/>
       </q-tab-pane>
       <q-tab-pane name="preview">
         <Markdown v-if="value" :source="value" />
@@ -39,4 +40,15 @@ export default {
   },
 }
 </script>
+<!-- UNSCOPED -->
+<style lang="stylus">
+.markdown-input > .q-tabs-head
+  min-height 36px !important
+</style>
 
+<style scoped lang="stylus">
+.markdown-input-tab
+  min-height 20px !important
+  padding 6px 10px !important
+  font-size .87em !important
+</style>

--- a/src/components/Settings/ProfileEdit.vue
+++ b/src/components/Settings/ProfileEdit.vue
@@ -10,7 +10,9 @@
     <q-field
       icon="info"
       :label="$t('USERDETAIL.DESCRIPTION')">
-      <q-input v-model="userEdit.description" type="textarea" :min-rows="1" :max-height="100" />
+      <MarkdownInput :value="userEdit.description">
+        <q-input v-model="userEdit.description" type="textarea" :min-rows="1" :max-height="100" />
+      </MarkdownInput>
     </q-field>
 
     <q-field
@@ -28,6 +30,7 @@
 <script>
 import { QDatetime, QInlineDatetime, QField, QSlider, QInput, QBtn, QSelect } from 'quasar'
 import AddressPicker from '@/components/Address/AddressPicker'
+import MarkdownInput from '@/components/MarkdownInput'
 
 import cloneDeep from 'clone-deep'
 import deepEqual from 'deep-equal'
@@ -38,7 +41,7 @@ export default {
     user: { required: true },
   },
   components: {
-    QDatetime, QInlineDatetime, QField, QSlider, QInput, QBtn, QSelect, AddressPicker,
+    QDatetime, QInlineDatetime, QField, QSlider, QInput, QBtn, QSelect, AddressPicker, MarkdownInput,
   },
   data () {
     return {

--- a/src/components/Store/StoreEdit.vue
+++ b/src/components/Store/StoreEdit.vue
@@ -20,7 +20,9 @@
           <q-field
             icon="fa-question"
             :label="$t('STOREEDIT.DESCRIPTION')">
-            <q-input v-model="storeEdit.description" type="textarea" :min-rows="3" :max-height="100" />
+            <MarkdownInput :value="storeEdit.description">
+              <q-input v-model="storeEdit.description" type="textarea" :min-rows="3" :max-height="100" />
+            </MarkdownInput>
           </q-field>
 
           <q-field
@@ -60,6 +62,7 @@
 import { QCard, QDatetime, QInlineDatetime, QField, QSlider, QOptionGroup, QInput, QBtn, QSelect } from 'quasar'
 import StandardMap from '@/components/Map/StandardMap'
 import AddressPicker from '@/components/Address/AddressPicker'
+import MarkdownInput from '@/components/MarkdownInput'
 import { validationMixin } from 'vuelidate'
 import { required, minLength, maxLength } from 'vuelidate/lib/validators'
 
@@ -89,7 +92,7 @@ export default {
     requestError: { required: true },
   },
   components: {
-    QCard, QDatetime, QInlineDatetime, QField, QSlider, QOptionGroup, QInput, QBtn, QSelect, StandardMap, AddressPicker,
+    QCard, QDatetime, QInlineDatetime, QField, QSlider, QOptionGroup, QInput, QBtn, QSelect, MarkdownInput, StandardMap, AddressPicker,
   },
   data () {
     return {


### PR DESCRIPTION
Closes #687 

There is a little bit of repetition by giving the markdown source code explicitly to the MarkdownInput, but that decouples the component nicely from the actual input component. Maybe it would be more fitting to call it `MarkdownPreview`...