### PR TITLE
Remove maxHeight from textarea input

### DIFF
--- a/src/components/Group/GroupEdit.vue
+++ b/src/components/Group/GroupEdit.vue
@@ -27,7 +27,6 @@
                 v-model="groupEdit.publicDescription"
                 type="textarea"
                 :min-rows="3"
-                :max-height="100"
               />
             </MarkdownInput>
           </q-field>
@@ -41,7 +40,6 @@
                 v-model="groupEdit.description"
                 type="textarea"
                 :min-rows="3"
-                :max-height="100"
               />
             </MarkdownInput>
           </q-field>

--- a/src/components/Settings/ProfileEdit.vue
+++ b/src/components/Settings/ProfileEdit.vue
@@ -11,7 +11,7 @@
       icon="info"
       :label="$t('USERDETAIL.DESCRIPTION')">
       <MarkdownInput :value="userEdit.description">
-        <q-input v-model="userEdit.description" type="textarea" :min-rows="1" :max-height="100" />
+        <q-input v-model="userEdit.description" type="textarea" :min-rows="1" />
       </MarkdownInput>
     </q-field>
 

--- a/src/components/Store/StoreEdit.vue
+++ b/src/components/Store/StoreEdit.vue
@@ -21,7 +21,7 @@
             icon="fa-question"
             :label="$t('STOREEDIT.DESCRIPTION')">
             <MarkdownInput :value="storeEdit.description">
-              <q-input v-model="storeEdit.description" type="textarea" :min-rows="3" :max-height="100" />
+              <q-input v-model="storeEdit.description" type="textarea" :min-rows="3" />
             </MarkdownInput>
           </q-field>
 


### PR DESCRIPTION
Quasar doesn't support scrolling inside a limited-height textarea out-of-box, so the easiest solution seems to remove the height limit.

Closes #702