### PR TITLE
Multiline pickup description

### DIFF
--- a/src/components/Pickups/PickupEdit.vue
+++ b/src/components/Pickups/PickupEdit.vue
@@ -41,7 +41,7 @@
         :error="hasError('description')"
         :error-label="firstError('description')"
         >
-        <q-input v-model="edit.description" type="textarea" :min-rows="1" :max-height="100" />
+        <q-input v-model="edit.description" type="textarea" />
       </q-field>
 
       <div class="text-negative">{{ firstError('nonFieldErrors') }}</div>

--- a/src/components/Pickups/PickupEdit.vue
+++ b/src/components/Pickups/PickupEdit.vue
@@ -38,10 +38,8 @@
         icon="info"
         :label="$t('CREATEPICKUP.COMMENT')"
         :helper="$t('CREATEPICKUP.COMMENT_HELPER')"
-        :error="hasError('description')"
-        :error-label="firstError('description')"
         >
-        <q-input v-model="edit.description" type="textarea" />
+        <q-input v-model="edit.description" type="textarea" max-length="500" />
       </q-field>
 
       <div class="text-negative">{{ firstError('nonFieldErrors') }}</div>

--- a/src/components/Pickups/PickupItem.vue
+++ b/src/components/Pickups/PickupItem.vue
@@ -7,9 +7,7 @@
           <span class="featured-text">{{ $d(pickup.date, 'timeShort') }}</span>
           <slot>Date or Store Slot</slot>
         </div>
-        <div class="people" v-if="pickup.description">
-          {{ pickup.description }}
-        </div>
+        <div class="description multiline" v-if="pickup.description">{{ pickup.description }}</div>
         <div class="people full-width">
           <PickupUsers
             :pickup="pickup"
@@ -112,6 +110,8 @@ $lighterGreen = #F0FFF0
       margin-right .5em
   .people
     padding: .3em
+.description
+  padding: .3em
 .content.isEmpty
   background repeating-linear-gradient(
     135deg,

--- a/src/components/Pickups/PickupSeriesEdit.vue
+++ b/src/components/Pickups/PickupSeriesEdit.vue
@@ -41,7 +41,7 @@
         :error="hasError('description')"
         :error-label="firstError('description')"
         >
-        <q-input v-model="edit.description" type="textarea" :min-rows="1" :max-height="100" />
+        <q-input v-model="edit.description" type="textarea" />
       </q-field>
 
       <div class="text-negative">{{ firstError('nonFieldErrors') }}</div>

--- a/src/components/Pickups/PickupSeriesEdit.vue
+++ b/src/components/Pickups/PickupSeriesEdit.vue
@@ -38,10 +38,8 @@
         icon="info"
         :label="$t('CREATEPICKUP.COMMENT')"
         :helper="$t('CREATEPICKUP.COMMENT_HELPER')"
-        :error="hasError('description')"
-        :error-label="firstError('description')"
         >
-        <q-input v-model="edit.description" type="textarea" />
+        <q-input v-model="edit.description" type="textarea" max-length="500" />
       </q-field>
 
       <div class="text-negative">{{ firstError('nonFieldErrors') }}</div>

--- a/src/pages/Store/PickupsManage.vue
+++ b/src/pages/Store/PickupsManage.vue
@@ -20,12 +20,13 @@
 
       <q-list class="pickups" separator no-border highlight sparse>
         <q-collapsible v-for="series in pickupSeries"
+                       @open="makeVisible('series', series.id)"
                        :key="series.id"
                        :label="series.rule.byDay.slice().sort(sortByDay).map(dayNameForKey).join(', ')"
                        :sublabel="$d(series.startDate, 'timeShort')"
                        icon="fa-calendar" sparse>
 
-          <q-item>
+          <q-item v-if="visible.series[series.id]">
             <pickup-series-edit :value="series" @save="saveSeries" @destroy="destroySeries" @reset="resetPickup" :status="series.saveStatus" />
           </q-item>
 
@@ -33,10 +34,11 @@
             <q-list-header v-t="'PICKUPMANAGE.UPCOMING_PICKUPS_IN_SERIES'" />
 
             <q-collapsible v-for="pickup in series.pickups"
+                           @open="makeVisible('pickup', pickup.id)"
                            :key="pickup.id"
                            :label="seriesPickupLabel(series, pickup)"
                            icon="fa-calendar">
-              <pickup-edit :value="pickup" @save="savePickup" @destroy="destroyPickup" @reset="resetPickup" :status="pickup.saveStatus" />
+              <pickup-edit v-if="visible.pickup[pickup.id]" :value="pickup" @save="savePickup" @destroy="destroyPickup" @reset="resetPickup" :status="pickup.saveStatus" />
             </q-collapsible>
           </q-list>
 
@@ -64,11 +66,12 @@
 
       <q-list class="pickups" separator no-border>
         <q-collapsible v-for="pickup in oneTimePickups"
+                       @open="makeVisible('pickup', pickup.id)"
                        :key="pickup.id"
                        :label="$d(pickup.date, 'dateShort')"
                        :sublabel="$d(pickup.date, 'timeShort')"
                        icon="fa-calendar" sparse>
-          <pickup-edit :value="pickup" @save="savePickup" @destroy="destroyPickup" @reset="resetPickup" :status="pickup.saveStatus" />
+          <pickup-edit v-if="visible.pickup[pickup.id]" :value="pickup" @save="savePickup" @destroy="destroyPickup" @reset="resetPickup" :status="pickup.saveStatus" />
         </q-collapsible>
       </q-list>
     </q-card>
@@ -91,9 +94,18 @@ export default {
     return {
       newSeries: null,
       newPickup: null,
+      visible: {
+        series: {},
+        pickup: {},
+      },
     }
   },
   methods: {
+    makeVisible (type, id) {
+      // prevents rending q-collabsible children before they are displayed
+      // if we don't do this, the textarea in pickupEdit won't autogrow
+      this.$set(this.visible[type], id, true)
+    },
     dayNameForKey,
     sortByDay,
     seriesPickupLabel (series, pickup) {

--- a/src/themes/app.mat.styl
+++ b/src/themes/app.mat.styl
@@ -60,6 +60,9 @@ body.mobile .q-card
 body.desktop .desktop-margin
   margin 8px
 
+.multiline
+  white-space pre-line
+
 // For large bits of text inside a modal/dialog body (e.g. the agreement dialog)
 .modal-body
   white-space pre-line


### PR DESCRIPTION
Closes #728 

I implemented multiline support for pickup description with a frontend-only limit of 500 characters.

I found out that the pickupEdit and pickupSeriesEdit textarea didn't autogrow properly. The most likely reason is unfortunate: q-collapsible renders the child element and hides it, and the textarea has a q-resize-observable that doesn't work when hidden.
I worked around this issue by introducing a `visible` state into the pickupManage component. Not the best solution, maybe someone can come up with a better one?