### PR TITLE
Detect if keyboard is open and hide mobile nav

### DIFF
--- a/src/__mocks__/vue.js
+++ b/src/__mocks__/vue.js
@@ -1,3 +1,4 @@
 const vue = require.requireActual('vue')
 vue.config.productionTip = false
+vue.config.devtools = false
 module.exports = vue

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,11 @@ import './socket'
 import i18n from './i18n'
 import log from '@/services/log'
 import './raven'
-import { KeyboardPlugin } from '@/services/keyboard'
+import { DetectMobileKeyboardPlugin } from '@/services/detectMobileKeyboard'
 
 Vue.config.productionTip = false
 Vue.use(Quasar)
-Vue.use(KeyboardPlugin)
+Vue.use(DetectMobileKeyboardPlugin)
 
 if (process.env.NODE_ENV !== 'production') {
   log.setLevel('debug')

--- a/src/main.js
+++ b/src/main.js
@@ -20,9 +20,11 @@ import './socket'
 import i18n from './i18n'
 import log from '@/services/log'
 import './raven'
+import { KeyboardPlugin } from '@/services/keyboard'
 
 Vue.config.productionTip = false
 Vue.use(Quasar)
+Vue.use(KeyboardPlugin)
 
 if (process.env.NODE_ENV !== 'production') {
   log.setLevel('debug')

--- a/src/pages/MainLayout.vue
+++ b/src/pages/MainLayout.vue
@@ -31,7 +31,7 @@
         </div>
         <KFooter v-if="$q.platform.is.mobile && !isLoggedIn" />
 
-        <MobileNavigation v-if="$q.platform.is.mobile && isLoggedIn" slot="footer" />
+        <MobileNavigation v-if="$q.platform.is.mobile && isLoggedIn && !$keyboard.is.open" slot="footer" />
         <KFooter v-if="!$q.platform.is.mobile" slot="footer" />
       </q-layout>
     </div>

--- a/src/services/detectMobileKeyboard.js
+++ b/src/services/detectMobileKeyboard.js
@@ -32,7 +32,7 @@ const keyboard = new Vue({
 
 export default keyboard
 
-export const KeyboardPlugin = {
+export const DetectMobileKeyboardPlugin = {
   install (Vue, options) {
     Vue.prototype.$keyboard = keyboard
   },

--- a/src/services/detectMobileKeyboard.spec.js
+++ b/src/services/detectMobileKeyboard.spec.js
@@ -1,0 +1,76 @@
+import { dom } from 'quasar'
+const { height } = dom
+
+Object.defineProperty(window.navigator, 'userAgent', (userAgent => {
+  return {
+    get () {
+      return userAgent
+    },
+    set (newVal) {
+      userAgent = newVal
+    },
+  }
+})(window.navigator.userAgent))
+
+const desktopUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:56.0) Gecko/20100101 Firefox/56.0'
+const mobileUserAgent = 'Mozilla/5.0 (Linux; Android 4.4.2; de-de; SAMSUNG GT-I9195 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36'
+
+describe('detectMobileKeyboard', () => {
+  let originalWindowAddEventListener, detectMobileKeyboard
+
+  function loadWithUserAgent (userAgent) {
+    window.navigator.userAgent = userAgent
+    detectMobileKeyboard = require('./detectMobileKeyboard').default
+  }
+
+  beforeEach(() => {
+    originalWindowAddEventListener = window.addEventListener
+    window.addEventListener = jest.fn().mockImplementation(function () {
+      originalWindowAddEventListener.apply(window, arguments)
+    })
+  })
+
+  afterEach(() => {
+    window.addEventListener = originalWindowAddEventListener
+  })
+
+  beforeEach(() => jest.resetModules())
+
+  describe('desktop', () => {
+    beforeEach(() => loadWithUserAgent(desktopUserAgent))
+    it('defaults to closed', () => {
+      expect(detectMobileKeyboard.is.open).toBe(false)
+    })
+    it('does not register resize handler', () => {
+      expect(window.addEventListener).not.toBeCalledWith('resize', expect.any(Function))
+    })
+    it('says closed even if size changes by >150', async () => {
+      expect(detectMobileKeyboard.is.open).toBe(false)
+      window.innerHeight = height(window) - 151
+      window.dispatchEvent(new Event('resize'))
+      expect(detectMobileKeyboard.is.open).toBe(false)
+    })
+  })
+
+  describe('mobile', () => {
+    beforeEach(() => loadWithUserAgent(mobileUserAgent))
+    it('defaults to closed', () => {
+      expect(detectMobileKeyboard.is.open).toBe(false)
+    })
+    it('registers resize handler', () => {
+      expect(window.addEventListener).toBeCalledWith('resize', expect.any(Function))
+    })
+    it('says closed if size changes by <=150', async () => {
+      expect(detectMobileKeyboard.is.open).toBe(false)
+      window.innerHeight = height(window) - 150
+      window.dispatchEvent(new Event('resize'))
+      expect(detectMobileKeyboard.is.open).toBe(false)
+    })
+    it('says open if size changes by >150', async () => {
+      expect(detectMobileKeyboard.is.open).toBe(false)
+      window.innerHeight = height(window) - 151
+      window.dispatchEvent(new Event('resize'))
+      expect(detectMobileKeyboard.is.open).toBe(true)
+    })
+  })
+})

--- a/src/services/keyboard.js
+++ b/src/services/keyboard.js
@@ -1,8 +1,10 @@
 import Vue from 'vue'
 import { Platform, throttle, dom } from 'quasar'
-const { ready, height, width } = dom
+const { ready } = dom
 
-const getSize = () => height(window) + width(window)
+const getSize = () => {
+  return document.documentElement.clientHeight + document.documentElement.clientWidth
+}
 
 const size = {
   original: null,

--- a/src/services/keyboard.js
+++ b/src/services/keyboard.js
@@ -1,10 +1,8 @@
 import Vue from 'vue'
 import { Platform, throttle, dom } from 'quasar'
-const { ready } = dom
+const { ready, height, width } = dom
 
-const getSize = () => {
-  return document.documentElement.clientHeight + document.documentElement.clientWidth
-}
+const getSize = () => height(window) + width(window)
 
 const size = {
   original: null,
@@ -25,7 +23,8 @@ const keyboard = new Vue({
     if (!Platform.is.mobile) return
     ready(() => {
       window.addEventListener('resize', throttle(() => {
-        this.is.open = size.original !== getSize()
+        // if the window is >150px smaller than original, we guess it's the keyboard...
+        this.is.open = (size.original - getSize()) > 150
       }, 100))
     })
   },

--- a/src/services/keyboard.js
+++ b/src/services/keyboard.js
@@ -1,0 +1,38 @@
+import Vue from 'vue'
+import { Platform, throttle, dom } from 'quasar'
+const { ready, height, width } = dom
+
+const getSize = () => height(window) + width(window)
+
+const size = {
+  original: null,
+  current: null,
+}
+
+ready(() => { size.original = getSize() })
+
+const keyboard = new Vue({
+  data () {
+    return {
+      is: {
+        open: false,
+      },
+    }
+  },
+  created () {
+    if (!Platform.is.mobile) return
+    ready(() => {
+      window.addEventListener('resize', throttle(() => {
+        this.is.open = size.original !== getSize()
+      }, 100))
+    })
+  },
+})
+
+export default keyboard
+
+export const KeyboardPlugin = {
+  install (Vue, options) {
+    Vue.prototype.$keyboard = keyboard
+  },
+}


### PR DESCRIPTION
Fixes #731

Logic is (only if `Platform.is.mobile` is already true):
- collect the height+width of the window on load (using quasar height/width dom utils on the window)
- listen for resize changes on the window
- on resize look if we have a different height+width, if so we conclude it must be because the keyboard is open!

(calculating width+height is to handle the case of rotation, those that value will stay the same)

There might be a better way to use the information about client/window dimensions (see http://ryanve.com/lab/dimensions/) but this approach WorksForMe right now :)