### PR TITLE
Refactor auth (login, changeEmail, changePassword) to use meta module

### DIFF
--- a/src/components/General/LocaleSelect.spec.js
+++ b/src/components/General/LocaleSelect.spec.js
@@ -1,0 +1,30 @@
+jest.mock('@/store/plugins/persistedState', () => {
+  return () => {}
+})
+
+import LocaleSelect from './LocaleSelect'
+import { locales } from '@/i18n'
+import { mountWithDefaults, polyfillRequestAnimationFrame, mockActionOnce } from '>/helpers'
+
+import store from '@/store'
+
+polyfillRequestAnimationFrame()
+
+describe('LocaleSelect', () => {
+  it('renders all the available locales', () => {
+    let wrapper = mountWithDefaults(LocaleSelect, { store })
+    expect(wrapper.findAll('.q-item-label').length).toBe(locales.length)
+    for (let locale of locales) {
+      expect(wrapper.html()).toContain(locale.name)
+    }
+  })
+
+  it('can select a locale', () => {
+    mockActionOnce(store, 'auth/update')
+    let wrapper = mountWithDefaults(LocaleSelect, { store })
+    const locales = store.getters['i18n/localeOptions']
+    let idx = Math.floor(Math.random() * locales.length) // pick a random locale
+    wrapper.findAll('.q-item-label').at(idx).trigger('click')
+    expect(store.state.i18n.locale).toBe(locales[idx].value)
+  })
+})

--- a/src/components/Login/Login.vue
+++ b/src/components/Login/Login.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <form name="login" @submit.prevent="submit">
-      <div class="white-box" :class="{ shake: showShake }">
+      <div class="white-box" :class="{ shake: hasAnyError }">
         <q-field icon="fa-envelope">
           <q-input
           :autofocus="true"
@@ -13,7 +13,7 @@
           />
         </q-field>
       </div>
-      <div class="white-box" :class="{ shake: showShake }">
+      <div class="white-box" :class="{ shake: hasAnyError }">
         <q-field icon="fa-lock">
           <q-input
           :error="hasError('password')"
@@ -24,8 +24,8 @@
           />
         </q-field>
       </div>
-      <div class="error" v-if="errorMessage">
-        <i class="fa fa-exclamation-triangle"/>{{ errorMessage }}
+      <div class="error" v-if="hasAnyError">
+        <i class="fa fa-exclamation-triangle"/>{{ anyError }}
       </div>
       <div class="actions">
         <q-btn type="button" @click.prevent="$router.push({ name: 'passwordreset' })" flat>
@@ -34,7 +34,7 @@
         <q-btn type="button" @click.prevent="$router.push({ name: 'signup' })" flat>
           {{ $t('LOGIN.SIGNUP') }}
         </q-btn>
-        <q-btn type="submit" class="submit shadow-4" loader :value="status.isWaiting">
+        <q-btn type="submit" class="submit shadow-4" loader :value="isPending">
           {{ $t('LOGIN.SUBMIT') }}
         </q-btn>
       </div>
@@ -45,9 +45,11 @@
 
 <script>
 import { QField, QInput, QBtn } from 'quasar'
+import statusMixin from '@/mixins/statusMixin'
 
 export default {
   components: { QField, QInput, QBtn },
+  mixins: [statusMixin],
   data () {
     if (process.env.NODE_ENV !== 'production') {
       return {
@@ -62,27 +64,19 @@ export default {
       }
     }
   },
-  props: {
-    status: {
-      required: true,
-    },
-  },
   methods: {
-    hasError (field) {
-      return this.status.error && this.status.error[field]
-    },
     submit () {
-      // if (!this.status.isWaiting) {
       this.$emit('submit', { email: this.email, password: this.password })
-      // }
     },
   },
   computed: {
-    errorMessage () {
-      return this.status.error && this.status.error[Object.keys(this.status.error)[0]][0]
+    hasAnyError () {
+      return !!this.anyError
     },
-    showShake () {
-      return typeof this.errorMessage !== 'undefined' && this.errorMessage !== null
+    anyError () {
+      for (let field of ['email', 'password', 'nonFieldErrors', 'detail']) {
+        if (this.hasError(field)) return this.firstError(field)
+      }
     },
   },
 }

--- a/src/components/Settings/ChangeEmail.vue
+++ b/src/components/Settings/ChangeEmail.vue
@@ -5,13 +5,10 @@
     <q-field
       icon="fa-star"
       :label="$t('USERDATA.EMAIL')"
-      :error="hasError('email')"
-      :error-label="firstError('email')">
+      :error="hasAnyError"
+      :error-label="anyError">
       <q-input type="email" v-model="newEmail"/>
     </q-field>
-
-    <div v-if="hasError('nonFieldErrors')" class="text-negative">{{ firstError('nonFieldErrors') }}</div>
-    <div v-if="hasError('detail')" class="text-negative">{{ firstError('detail') }}</div>
 
     <q-btn color="primary" @click="save" loader :value="isPending">{{ $t('BUTTON.CHANGE_EMAIL') }}</q-btn>
 
@@ -41,6 +38,16 @@ export default {
     setEmail () {
       if (this.user) {
         this.newEmail = this.user.email ? this.user.email : this.user.unverifiedEmail
+      }
+    },
+  },
+  computed: {
+    hasAnyError () {
+      return !!this.anyError
+    },
+    anyError () {
+      for (let field of ['email', 'nonFieldErrors', 'detail']) {
+        if (this.hasError(field)) return this.firstError(field)
       }
     },
   },

--- a/src/components/Settings/ChangeEmail.vue
+++ b/src/components/Settings/ChangeEmail.vue
@@ -4,22 +4,28 @@
 
     <q-field
       icon="fa-star"
-      :label="$t('USERDATA.EMAIL')">
+      :label="$t('USERDATA.EMAIL')"
+      :error="hasError('email')"
+      :error-label="firstError('email')">
       <q-input type="email" v-model="newEmail"/>
     </q-field>
 
-    <q-btn color="primary" @click="save">{{ $t('BUTTON.CHANGE_EMAIL') }}</q-btn>
+    <div v-if="hasError('nonFieldErrors')" class="text-negative">{{ firstError('nonFieldErrors') }}</div>
+    <div v-if="hasError('detail')" class="text-negative">{{ firstError('detail') }}</div>
+
+    <q-btn color="primary" @click="save" loader :value="isPending">{{ $t('BUTTON.CHANGE_EMAIL') }}</q-btn>
 
   </div>
 </template>
 
 <script>
 import { QField, QInput, QBtn } from 'quasar'
-
+import statusMixin from '@/mixins/statusMixin'
 import VerificationWarning from '@/components/Settings/VerificationWarning'
 
 export default {
   components: { QField, QInput, QBtn, VerificationWarning },
+  mixins: [statusMixin],
   props: {
     user: { required: true },
   },

--- a/src/components/Settings/ChangePassword.vue
+++ b/src/components/Settings/ChangePassword.vue
@@ -3,20 +3,24 @@
 
     <q-field
       icon="fa-star"
-      :label="$t('USERDETAIL.PASSWORD')">
+      :label="$t('USERDETAIL.PASSWORD')"
+      :error="hasError('password')"
+      :error-label="firstError('password')">
       <q-input type="password" v-model="newPassword"/>
     </q-field>
 
-    <q-btn color="primary" @click="save">{{ $t('BUTTON.CHANGE_PASSWORD') }}</q-btn>
+    <q-btn color="primary" @click="save" loader :value="isPending">{{ $t('BUTTON.CHANGE_PASSWORD') }}</q-btn>
 
   </div>
 </template>
 
 <script>
 import { QField, QInput, QBtn } from 'quasar'
+import statusMixin from '@/mixins/statusMixin'
 
 export default {
   components: { QField, QInput, QBtn },
+  mixins: [statusMixin],
   data () {
     return {
       oldPassword: '',

--- a/src/components/Settings/ChangePassword.vue
+++ b/src/components/Settings/ChangePassword.vue
@@ -4,8 +4,8 @@
     <q-field
       icon="fa-star"
       :label="$t('USERDETAIL.PASSWORD')"
-      :error="hasError('password')"
-      :error-label="firstError('password')">
+      :error="hasAnyError"
+      :error-label="anyError">
       <q-input type="password" v-model="newPassword"/>
     </q-field>
 
@@ -31,6 +31,16 @@ export default {
     save () {
       const { oldPassword, newPassword } = this
       this.$emit('save', { oldPassword, newPassword })
+    },
+  },
+  computed: {
+    hasAnyError () {
+      return !!this.anyError
+    },
+    anyError () {
+      for (let field of ['password', 'nonFieldErrors', 'detail']) {
+        if (this.hasError(field)) return this.firstError(field)
+      }
     },
   },
 }

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -4,13 +4,13 @@ import Login from '@/components/Login/Login'
 
 export default connect({
   gettersToProps: {
-    status: 'auth/status',
+    status: 'auth/loginStatus',
   },
   actionsToEvents: {
     submit: 'auth/login',
   },
   lifecycle: {
-    destroyed: ({ dispatch }) => dispatch('auth/cleanStatus'),
+    mounted: ({ dispatch }) => dispatch('auth/meta/clear', ['login']),
   },
 })('Login', Login)
 </script>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -10,7 +10,7 @@ export default connect({
     submit: 'auth/login',
   },
   lifecycle: {
-    mounted: ({ dispatch }) => dispatch('auth/meta/clear', ['login']),
+    destroyed: ({ dispatch }) => dispatch('auth/clearLoginStatus'),
   },
 })('Login', Login)
 </script>

--- a/src/pages/Settings.story.js
+++ b/src/pages/Settings.story.js
@@ -11,7 +11,7 @@ storiesOf('Settings Page', module)
       return h(Settings)
     },
     created () {
-      store.commit('auth/Receive Login Status', { user: currentUserMock })
+      store.commit('auth/Set User', { user: currentUserMock })
     },
     i18n,
     store,

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -10,13 +10,13 @@
       <q-list-header>{{ $t('USERDATA.EMAIL') }}</q-list-header>
 
       <q-item>
-        <ChangeEmail :user="user" @save="changeEmail" />
+        <ChangeEmail :user="user" :status="changeEmailStatus" @save="changeEmail" />
       </q-item>
 
       <q-list-header>{{ $t('USERDATA.PASSWORD') }}</q-list-header>
 
       <q-item>
-        <ChangePassword @save="changePassword" />
+        <ChangePassword :status="changePasswordStatus" @save="changePassword" />
       </q-item>
 
     </q-list>
@@ -37,6 +37,8 @@ export default {
   computed: {
     ...mapGetters({
       user: 'auth/user',
+      changeEmailStatus: 'auth/changeEmailStatus',
+      changePasswordStatus: 'auth/changePasswordStatus',
     }),
   },
   methods: {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -41,6 +41,8 @@ export const getters = {
 }
 
 export const actions = {
+  clearLoginStatus: ({ dispatch }) => dispatch('meta/clear', ['login']),
+
   ...withMeta({
 
     async check ({ commit, dispatch }) {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,10 +1,14 @@
 import auth from '@/services/api/auth'
 import authUser from '@/services/api/authUser'
 import router from '@/router'
-import { onlyHandleAPIError } from '@/store/helpers'
 import { types as userTypes } from '@/store/modules/users'
+import { createMetaModule, withMeta, metaStatuses } from '@/store/helpers'
+
+export const modules = { meta: createMetaModule() }
 
 export const types = {
+  SET_USER: 'Set user',
+  CLEAR_USER: 'Clear user',
 
   SET_REDIRECT_TO: 'Set RedirectTo',
   CLEAR_REDIRECT_TO: 'Clear RedirectTo',
@@ -14,31 +18,11 @@ export const types = {
 
   SET_ACCEPT_INVITE_AFTER_LOGIN: 'Accept Invite After Login',
   CLEAR_ACCEPT_INVITE_AFTER_LOGIN: 'Clear Accept Invite After Login',
-
-  REQUEST_LOGIN_STATUS: 'Request Login Status',
-  RECEIVE_LOGIN_STATUS: 'Receive Login Status',
-  RECEIVE_LOGIN_STATUS_ERROR: 'Receive Login Status Error',
-
-  REQUEST_LOGIN: 'Login Request',
-  RECEIVE_LOGIN: 'Login Success',
-  RECEIVE_LOGIN_ERROR: 'Login Error',
-
-  REQUEST_LOGOUT: 'Logout Request',
-  RECEIVE_LOGOUT: 'Logout Success',
-  RECEIVE_LOGOUT_ERROR: 'Logout Failure',
-
-  RECEIVE_SAVE_ERROR: 'Receive Save Error',
-
-  CLEAN_STATUS: 'Clean Status',
 }
 
 function initialState () {
   return {
     user: null,
-    status: {
-      isWaiting: false,
-      error: null,
-    },
     redirectTo: null,
     joinGroupAfterLogin: null,
     acceptInviteAfterLogin: null,
@@ -53,9 +37,89 @@ export const getters = {
   userId: state => state.user && state.user.id,
   status: state => state.status,
   redirectTo: state => state.redirectTo,
+  ...metaStatuses(['login', 'update', 'changePassword', 'changeEmail']),
 }
 
 export const actions = {
+  ...withMeta({
+
+    async check ({ commit, dispatch }) {
+      try {
+        commit(types.SET_USER, { user: await authUser.get() })
+        dispatch('afterLoggedIn')
+      }
+      catch (error) {
+        commit(types.CLEAR_USER)
+        throw error
+      }
+    },
+
+    async login ({ state, commit, getters, dispatch, rootGetters }, data) {
+      const user = await auth.login(data)
+      commit(types.SET_USER, { user })
+      dispatch('afterLoggedIn')
+
+      if (state.acceptInviteAfterLogin) {
+        await dispatch('invitations/accept', state.acceptInviteAfterLogin, { root: true })
+      }
+      else if (state.joinGroupAfterLogin) {
+        const joinParams = state.joinGroupAfterLogin
+        if (rootGetters['groups/get'](joinParams.groupId).isMember) {
+          // go to group if already a member
+          router.push({ name: 'group', params: { groupId: joinParams.id } })
+        }
+        else {
+          await dispatch('groups/join', joinParams, { root: true })
+          if (rootGetters['groups/joinStatus'].error) {
+            // go back to goup preview if error occured
+            // it should show the error status on the page, thanks to persistent state!
+            router.push({ name: 'groupInfo', params: { groupInfoId: joinParams.id } })
+          }
+        }
+      }
+      else if (getters.redirectTo) {
+        router.push(getters.redirectTo)
+      }
+      else {
+        router.push('/')
+      }
+      commit(types.CLEAR_ACCEPT_INVITE_AFTER_LOGIN)
+      commit(types.CLEAR_JOIN_GROUP_AFTER_LOGIN)
+      commit(types.CLEAR_REDIRECT_TO)
+    },
+
+    async logout ({ commit }) {
+      commit(types.CLEAR_USER, { user: await auth.logout() })
+      router.push({ name: 'groupsGallery' })
+    },
+
+    async update ({ commit, state, dispatch }, data) {
+      let user = state.user
+      if (!user) return
+
+      // TODO use objectDiff in component, remove from here
+      let changed = Object.keys(data).some(key => user[key] !== data[key])
+
+      if (!changed) {
+        return
+      }
+
+      const savedUser = await authUser.save({ ...data })
+
+      commit(types.SET_USER, { user: savedUser })
+      commit(`users/${userTypes.RECEIVE_USER}`, { user: savedUser }, { root: true })
+    },
+
+    async changePassword ({ commit, state, dispatch }, { newPassword }) {
+      await authUser.save({ password: newPassword })
+      dispatch('logout')
+    },
+
+    async changeEmail ({ commit, dispatch }, email) {
+      const savedUser = await authUser.save({ email })
+      commit(types.SET_USER, { user: savedUser })
+    },
+  }),
 
   setRedirectTo ({ commit }, redirectTo) {
     commit(types.SET_REDIRECT_TO, { redirectTo })
@@ -69,131 +133,19 @@ export const actions = {
     commit(types.SET_ACCEPT_INVITE_AFTER_LOGIN, { token })
   },
 
-  async check ({ commit, dispatch }) {
-    commit(types.REQUEST_LOGIN_STATUS)
-    try {
-      commit(types.RECEIVE_LOGIN_STATUS, { user: await authUser.get() })
-      dispatch('afterLoggedIn')
-    }
-    catch (error) {
-      commit(types.RECEIVE_LOGIN_STATUS_ERROR, { error })
-    }
-  },
-
-  async login ({ state, commit, getters, dispatch, rootGetters }, data) {
-    commit(types.REQUEST_LOGIN)
-    let user = null
-    try {
-      user = await auth.login(data)
-    }
-    catch (error) {
-      onlyHandleAPIError(error, data => commit(types.RECEIVE_LOGIN_ERROR, data))
-      return
-    }
-
-    commit(types.RECEIVE_LOGIN, { user })
-
-    dispatch('afterLoggedIn')
-
-    if (state.acceptInviteAfterLogin) {
-      await dispatch('invitations/accept', state.acceptInviteAfterLogin, { root: true })
-    }
-    else if (state.joinGroupAfterLogin) {
-      const joinParams = state.joinGroupAfterLogin
-      if (rootGetters['groups/get'](joinParams.groupId).isMember) {
-        // go to group if already a member
-        router.push({ name: 'group', params: { groupId: joinParams.id } })
-      }
-      else {
-        await dispatch('groups/join', joinParams, { root: true })
-        if (rootGetters['groups/joinStatus'].error) {
-          // go back to goup preview if error occured
-          // it should show the error status on the page, thanks to persistent state!
-          router.push({ name: 'groupInfo', params: { groupInfoId: joinParams.id } })
-        }
-      }
-    }
-    else if (getters.redirectTo) {
-      router.push(getters.redirectTo)
-    }
-    else {
-      router.push('/')
-    }
-    commit(types.CLEAR_ACCEPT_INVITE_AFTER_LOGIN)
-    commit(types.CLEAR_JOIN_GROUP_AFTER_LOGIN)
-    commit(types.CLEAR_REDIRECT_TO)
-  },
-
   afterLoggedIn ({ state, dispatch }) {
     const { user } = state
     dispatch('i18n/setLocale', user.language || 'en', { root: true })
   },
-
-  async logout ({ commit }) {
-    commit(types.REQUEST_LOGOUT)
-    try {
-      commit(types.RECEIVE_LOGOUT, { user: await auth.logout() })
-      router.push({ name: 'groupsGallery' })
-    }
-    catch (error) {
-      onlyHandleAPIError(error, data => commit(types.RECEIVE_LOGOUT_ERROR, data))
-    }
-  },
-
-  async update ({ commit, state, dispatch }, data) {
-    let user = state.user
-    if (!user) return
-
-    let changed = Object.keys(data).some(key => user[key] !== data[key])
-
-    if (!changed) {
-      return
-    }
-
-    let savedUser
-    try {
-      savedUser = await authUser.save({ ...data })
-    }
-    catch (error) {
-      onlyHandleAPIError(error, data => commit(types.RECEIVE_SAVE_ERROR, data))
-      return
-    }
-
-    commit(types.RECEIVE_LOGIN_STATUS, { user: savedUser })
-    commit(`users/${userTypes.RECEIVE_USER}`, { user: savedUser }, { root: true })
-  },
-
-  async changePassword ({ commit, state, dispatch }, { newPassword }) {
-    let savedUser
-    try {
-      savedUser = await authUser.save({ password: newPassword })
-    }
-    catch (error) {
-      onlyHandleAPIError(error, data => commit(types.RECEIVE_SAVE_ERROR, data))
-      return
-    }
-    commit(types.RECEIVE_LOGIN_STATUS, { user: savedUser })
-    dispatch('logout')
-  },
-
-  async changeEmail ({ commit, dispatch }, email) {
-    let savedUser
-    try {
-      savedUser = await authUser.save({ email })
-    }
-    catch (error) {
-      onlyHandleAPIError(error, data => commit(types.RECEIVE_SAVE_ERROR, data))
-      return
-    }
-    commit(types.RECEIVE_LOGIN_STATUS, { user: savedUser })
-  },
-
-  cleanStatus ({ commit }) {
-    commit(types.CLEAN_STATUS)
-  },
 }
 
 export const mutations = {
+  [types.SET_USER] (state, { user }) {
+    state.user = user
+  },
+  [types.CLEAR_USER] (state) {
+    state.user = null
+  },
 
   // Redirect
   [types.SET_REDIRECT_TO] (state, { redirectTo }) {
@@ -217,83 +169,5 @@ export const mutations = {
   },
   [types.CLEAR_ACCEPT_INVITE_AFTER_LOGIN] (state) {
     state.acceptInviteAfterLogin = null
-  },
-
-  // Check
-
-  [types.REQUEST_LOGIN_STATUS] (state) {
-    state.status = {
-      isWaiting: false,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGIN_STATUS] (state, { user }) {
-    state.user = user
-    state.status = {
-      isWaiting: true,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGIN_STATUS_ERROR] (state, { error }) {
-    state.status = {
-      isWaiting: false,
-      error: error,
-    }
-  },
-
-  // Login
-
-  [types.REQUEST_LOGIN] (state) {
-    state.status = {
-      isWaiting: true,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGIN] (state, { user }) {
-    state.user = user
-    state.status = {
-      isWaiting: false,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGIN_ERROR] (state, { error }) {
-    state.status = {
-      isWaiting: false,
-      error: error,
-    }
-  },
-
-  // Logout
-
-  [types.REQUEST_LOGOUT] (state) {
-    state.status = {
-      isWaiting: true,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGOUT] (state) {
-    state.user = null
-    state.status = {
-      isWaiting: false,
-      error: null,
-    }
-  },
-  [types.RECEIVE_LOGOUT_ERROR] (state, { error }) {
-    state.user = null
-    state.status = {
-      isWaiting: false,
-      error: error,
-    }
-  },
-
-  [types.RECEIVE_SAVE_ERROR] (state, { error }) {
-    state.status.error = error
-  },
-
-  [types.CLEAN_STATUS] (state) {
-    state.status = {
-      isWaiting: false,
-      error: null,
-    }
   },
 }

--- a/src/store/modules/auth.spec.js
+++ b/src/store/modules/auth.spec.js
@@ -5,7 +5,7 @@ jest.mock('@/router', () => ({ push: mockRouterPush }))
 jest.mock('@/services/api/auth', () => ({ login: mockLogin }))
 jest.mock('@/services/api/authUser', () => ({ get: mockStatus }))
 
-import { createStore, throws } from '>/helpers'
+import { createStore, createValidationError, throws } from '>/helpers'
 
 describe('auth', () => {
   let store
@@ -39,21 +39,21 @@ describe('auth', () => {
   it('can login', async () => {
     mockLogin.mockReturnValueOnce(user())
     await store.dispatch('auth/login')
-    expect(store.getters['auth/loginStatus'].error).toBeUndefined()
+    expect(store.getters['auth/loginStatus'].validationErrors).toEqual({})
     expect(store.getters['auth/isLoggedIn']).toBe(true)
     expect(store.getters['auth/user']).toBeDefined()
     expect(mockRouterPush).toBeCalledWith('/')
   })
 
   it('will not be logged when status throws', async () => {
-    mockStatus.mockImplementation(throws({ response: { data: { foo: 'some error info' }, status: 401 } }))
+    mockStatus.mockImplementation(throws(createValidationError({ foo: 'some error info' })))
     await store.dispatch('auth/check')
     expect(store.getters['auth/isLoggedIn']).toBe(false)
     expect(store.getters['auth/user']).toBeNull()
   })
 
   it('will not be logged in when login throws', async () => {
-    mockLogin.mockImplementationOnce(throws({ response: { data: { foo: 'some error info' }, status: 403 } }))
+    mockLogin.mockImplementationOnce(throws(createValidationError({ foo: 'some error info' })))
     await store.dispatch('auth/login')
     expect(store.getters['auth/isLoggedIn']).toBe(false)
     expect(store.getters['auth/loginStatus'].validationErrors).toEqual({ foo: 'some error info' })

--- a/src/store/modules/auth.spec.js
+++ b/src/store/modules/auth.spec.js
@@ -39,14 +39,14 @@ describe('auth', () => {
   it('can login', async () => {
     mockLogin.mockReturnValueOnce(user())
     await store.dispatch('auth/login')
-    expect(store.getters['auth/status'].error).toBeNull()
+    expect(store.getters['auth/loginStatus'].error).toBeUndefined()
     expect(store.getters['auth/isLoggedIn']).toBe(true)
     expect(store.getters['auth/user']).toBeDefined()
     expect(mockRouterPush).toBeCalledWith('/')
   })
 
   it('will not be logged when status throws', async () => {
-    mockStatus.mockImplementation(throws(() => new Error('some error')))
+    mockStatus.mockImplementation(throws({ response: { data: { foo: 'some error info' }, status: 401 } }))
     await store.dispatch('auth/check')
     expect(store.getters['auth/isLoggedIn']).toBe(false)
     expect(store.getters['auth/user']).toBeNull()
@@ -56,7 +56,7 @@ describe('auth', () => {
     mockLogin.mockImplementationOnce(throws({ response: { data: { foo: 'some error info' }, status: 403 } }))
     await store.dispatch('auth/login')
     expect(store.getters['auth/isLoggedIn']).toBe(false)
-    expect(store.getters['auth/status'].error).toEqual({ foo: 'some error info' })
+    expect(store.getters['auth/loginStatus'].validationErrors).toEqual({ foo: 'some error info' })
     expect(store.getters['auth/user']).toBeNull()
   })
 })


### PR DESCRIPTION
Transition to the new code went smoothly.

Closes #658 

I figured that in case of simple forms (just one or two fields), it makes sense to handle all errors (field-related, nonField, permission) in one place, called `anyError`. I wonder if it makes sense to have a mixin for this, on the other hand it's not super repetitive.

I added some more spinner buttons when submitting the form (unfortunately it changes the button size, might need a layout tweak in the future).