### PR TITLE
Add group pickuplist

### DIFF
--- a/src/components/Layout/MobileNavigationUI.vue
+++ b/src/components/Layout/MobileNavigationUI.vue
@@ -4,6 +4,10 @@
         <template slot="icon"><i class="fa fa-home q-tab-icon" /></template>
         <template>{{$t('GROUP.GROUP')}}</template>
       </KTab>
+      <KTab slot="title" :to="{name: 'groupPickups', params: {groupId: activeGroupId}}" name="pickups">
+        <template slot="icon"><i class="fa fa-shopping-basket q-tab-icon" /></template>
+        <template>{{$t('GROUP.PICKUPS')}}</template>
+      </KTab>
       <KTab slot="title" :to="{name: 'stores', params: {groupId: activeGroupId}}" name="stores">
         <template slot="icon"><i class="fa fa-shopping-cart q-tab-icon" /></template>
         <template>{{$t('GROUP.STORES')}}</template>

--- a/src/components/Pickups/PickupList.vue
+++ b/src/components/Pickups/PickupList.vue
@@ -1,24 +1,14 @@
 <template>
   <div>
-    <div class="topbar">
-      <router-link v-if="options.showCreate" :to="{ name: 'storePickupsManage', params: { storeId: store.id } }">
-        <q-btn style="background-color: white">
-          <i class="fa fa-clock-o on-left"/>
-          {{$t('STOREDETAIL.MANAGE')}}
-        </q-btn>
-      </router-link>
-    </div>
-    <div>
-      <PickupItem
-        v-for="pickup in pickups"
-        :key="pickup.id"
-        :pickup="pickup"
-        @join="$emit('join', arguments[0])"
-        @leave="$emit('leave', arguments[0])"
-        >
-        {{ $d(pickup.date, 'dateLongWithDayName') }}
-      </PickupItem>
-    </div>
+    <PickupItem
+      v-for="pickup in pickups"
+      :key="pickup.id"
+      :pickup="pickup"
+      @join="$emit('join', arguments[0])"
+      @leave="$emit('leave', arguments[0])"
+      >
+      {{ $d(pickup.date, 'dateLongWithDayName') }}
+    </PickupItem>
   </div>
 </template>
 
@@ -28,17 +18,7 @@ import PickupItem from './PickupItem'
 
 export default {
   props: {
-    options: {
-      required: false,
-      default () {
-        return {
-          showStore: false, // either time or store
-          showCreate: true,
-        }
-      },
-    },
     pickups: { required: true },
-    store: { required: true },
   },
   components: {
     QCardTitle, QCard, QCardMain, QCardSeparator, QCardActions, QBtn, QIcon, PickupItem,
@@ -47,9 +27,4 @@ export default {
 </script>
 
 <style scoped lang="stylus">
-.topbar
-  padding 8px
-  q-btn
-    display inline-block
-    padding .3em
 </style>

--- a/src/components/Sidenav/SidenavGroup.vue
+++ b/src/components/Sidenav/SidenavGroup.vue
@@ -18,6 +18,14 @@
             {{ $t("GROUP.WALL")}}
           </q-item-main>
         </q-item>
+        <q-item :to="{name: 'groupPickups'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-shopping-basket" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.PICKUPS")}}
+          </q-item-main>
+        </q-item>
         <q-item :to="{name: 'groupDescription'}">
           <q-item-side class="text-center">
             <q-icon name="fa-vcard" />

--- a/src/pages/Group/Pickups.vue
+++ b/src/pages/Group/Pickups.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <PickupItem
+      v-for="pickup in pickups"
+      :key="pickup.id"
+      :pickup="pickup"
+      @join="$emit('join', arguments[0])"
+      @leave="$emit('leave', arguments[0])"
+      >
+      <strong v-if="pickup.store">
+        <router-link :to="{ name: 'store', params: { storeId: pickup.store.id }}">{{ pickup.store.name }}</router-link>
+      </strong> {{ $d(pickup.date, 'dateWithDayName') }}
+    </PickupItem>
+    <KNotice v-if="pickups && pickups.length == 0" >
+      <template slot="icon">
+        <i class="fa fa-bed"/>
+      </template>
+      {{ $t('PICKUPLIST.NONE') }}
+      <template slot="desc">
+        {{ $t('PICKUPLIST.NONE_HINT') }}
+      </template>
+    </KNotice>
+  </div>
+</template>
+
+<script>
+import PickupItem from '@/components/Pickups/PickupItem'
+import KNotice from '@/components/General/KNotice'
+
+import {
+  mapGetters,
+  mapActions,
+} from 'vuex'
+
+export default {
+  components: { PickupItem, KNotice },
+  methods: {
+    ...mapActions({
+      join: 'pickups/join',
+      leave: 'pickups/leave',
+    }),
+  },
+  computed: {
+    ...mapGetters({
+      pickups: 'pickups/all',
+    }),
+  },
+}
+</script>
+
+<style scoped lang="stylus">
+.card
+  margin 0
+.padding
+  padding 1em
+.notice
+  .icon
+    margin .1em 0 0 0
+    .fa
+      font-size 10vw
+  padding 2em 3em
+  transform: translateZ(1px) rotate(-3deg);
+  h5
+    padding 0
+.manage
+  padding 8px
+  q-btn
+    display inline-block
+    padding .3em
+</style>

--- a/src/pages/Store/Pickups.vue
+++ b/src/pages/Store/Pickups.vue
@@ -9,8 +9,15 @@
         <Markdown v-if="store.description" :source="store.description" />
       </div>
     </q-card>
+    <div class="manage">
+      <router-link :to="{ name: 'storePickupsManage', params: { storeId: store.id } }">
+        <q-btn style="background-color: white">
+          <i class="fa fa-clock-o on-left"/>
+          {{$t('STOREDETAIL.MANAGE')}}
+        </q-btn>
+      </router-link>
+    </div>
     <PickupList
-      :store="store"
       :pickups="pickups"
       @join="join"
       @leave="leave"
@@ -71,4 +78,9 @@ export default {
   transform: translateZ(1px) rotate(-3deg);
   h5
     padding 0
+.manage
+  padding 8px
+  q-btn
+    display inline-block
+    padding .3em
 </style>

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -1,5 +1,6 @@
 const GroupLayout = () => import('@/components/Layout/GroupLayout')
 const GroupWall = () => import('@/pages/Group/Wall')
+const GroupPickups = () => import('@/pages/Group/Pickups')
 const GroupMap = () => import('@/pages/Map')
 const GroupEdit = () => import('@/pages/Group/Edit')
 const GroupManageAgreement = () => import('@/pages/Group/ManageAgreement')
@@ -91,6 +92,19 @@ export default [
         path: 'wall',
         components: {
           default: GroupWall,
+          sidenav: GroupGroupSidenav,
+        },
+      },
+      {
+        name: 'groupPickups',
+        path: 'pickups',
+        meta: {
+          breadcrumbs: [
+            { translation: 'GROUP.PICKUPS', route: { name: 'groupPickups' } },
+          ],
+        },
+        components: {
+          default: GroupPickups,
           sidenav: GroupGroupSidenav,
         },
       },


### PR DESCRIPTION
As requested in #741 

@tiltec and me created a new page, which displayes an overview over _all_ upcoming pickups.

![image](https://user-images.githubusercontent.com/17573771/32908647-6ec031fa-cb04-11e7-95c5-0f4717ad5d6c.png)

For mobile there is a new button in the bottom bar (because we couldn't think of anything better for now...)

![screen shot 2017-11-16 at 19 20 38](https://user-images.githubusercontent.com/17573771/32908690-98249b8a-cb04-11e7-80c9-c820bb27aae3.png)