### PR TITLE
Apply outside changes to edited values instead of replacing them

### DIFF
--- a/src/mixins/editMixin.js
+++ b/src/mixins/editMixin.js
@@ -13,10 +13,8 @@ export default {
   },
   watch: {
     value (current, previous) {
-      // we want to make sure it's _really_ changed or we risk undoing the users changes
-      if (current !== previous || !deepEqual(current, previous)) {
-        this.reset()
-      }
+      const changes = objectDiff(previous, current)
+      this.edit = cloneDeep({ ...this.edit, ...changes })
     },
   },
   computed: {


### PR DESCRIPTION
Closes #771
Prevents flickering of values while sending. Somehow it also fixes the spinner on q-button after sending.