### PR TITLE
Add hooks to trigger actions on route enter and leave

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,6 +1,7 @@
 - [FAQ](faq.md)
 - [Backend introduction](backend-introduction.md)
 - [Forms](forms.md)
+- [Pages and Routes](pages.md)
 - [Build](build.md)
 - [Mobile](mobile.md)
   - [Android SDK](android-sdk.md)

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,69 @@
+# Pages and Routes
+
+Pages are the views of the app, each of them is defined in a route object. It carries some important data:
+
+```js
+{
+  name: 'groupInfo',
+  path: '/groupInfo/:groupInfoId',
+  meta: {
+    // custom properties like data loading and breadcrumb definitions
+  },
+  components: {
+    default: GroupInfo,
+  },
+},
+```
+
+## Loading data on page load
+
+Quite often, you will find that a page needs data from the API to show something meaningful. We use a declarative approach to do this. By specifying a vuex action `beforeEnter` properties on the route `meta` object, the action will run before the page loads.
+
+The action gets the route `params` object passed as first argument. In the example below, you can use the `groupInfoId` in the action.
+
+```js
+{
+  name: 'groupInfo',
+  path: '/groupInfo/:groupInfoId',
+  meta: {
+    beforeEnter: 'groups/selectGroupInfo',
+    afterLeave: 'groups/clearGroupInfo',
+  },
+  components: {
+    default: GroupInfo,
+  },
+},
+```
+
+The `beforeEnter` action gets `await`ed, so it's guaranteed to complete before the page loads. Still, better make everything reactive anyways.
+
+If you have nested routes, the actions of the parent will run before the child ones. To pass data from parent to child (e.g. selected group), you can use the vuex state. All actions get the complete route `params` object.
+
+### Show a route error page
+
+If the `beforeEnter` action determines that the route can't be accesses (e.g. because of invalid IDs in the URL), it can throw a special `routeError` to show an error page.
+
+You can pass a message to the user along with the error:
+
+```js
+if (hasError) {
+  throw createRouteError({ translation: 'NOT_FOUND.EXPLANATION' })
+}
+```
+
+## Clean up after yourself when leaving a page
+
+Similar to `beforeEnter`, you specify an `afterLeave` property on the `meta` object. That makes it possible to clear form errors that should not persist page reloads.
+
+```js
+{
+  name: 'groupInfo',
+  path: '/groupInfo/:groupInfoId',
+  meta: {
+    afterLeave: 'groups/clearGroupInfo',
+  },
+  components: {
+    default: GroupInfo,
+  },
+},
+```

--- a/src/pages/Group/Create.vue
+++ b/src/pages/Group/Create.vue
@@ -14,8 +14,5 @@ export default connect({
   methodsToEvents: {
     reset: ({ dispatch }) => dispatch('meta/clear', ['create']),
   },
-  lifecycle: {
-    mounted: ({ dispatch }) => dispatch('groups/fetchTimezones'),
-  },
 })('GroupCreate', GroupEdit)
 </script>

--- a/src/pages/Group/Edit.vue
+++ b/src/pages/Group/Edit.vue
@@ -15,8 +15,5 @@ export default connect({
   methodsToEvents: {
     reset: ({ dispatch }, id) => dispatch('groups/meta/clear', ['save', id]),
   },
-  lifecycle: {
-    mounted: ({ dispatch }) => dispatch('groups/fetchTimezones'),
-  },
 })('GroupEdit', GroupEdit)
 </script>

--- a/src/pages/Group/Invitations.vue
+++ b/src/pages/Group/Invitations.vue
@@ -11,8 +11,5 @@ export default connect({
   actionsToEvents: {
     submit: 'invitations/send',
   },
-  lifecycle: {
-    mounted: ({ dispatch }) => dispatch('invitations/fetch'),
-  },
 })('GroupInvitations', InvitationsUI)
 </script>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -9,8 +9,5 @@ export default connect({
   actionsToEvents: {
     submit: 'auth/login',
   },
-  lifecycle: {
-    destroyed: ({ dispatch }) => dispatch('auth/clearLoginStatus'),
-  },
 })('Login', Login)
 </script>

--- a/src/pages/PasswordReset.vue
+++ b/src/pages/PasswordReset.vue
@@ -10,8 +10,5 @@ export default connect({
   actionsToEvents: {
     submit: 'users/resetPassword',
   },
-  lifecycle: {
-    destroyed: ({ dispatch }) => dispatch('users/cleanPasswordreset'),
-  },
 })('PasswordReset', PasswordReset)
 </script>

--- a/src/pages/Signup.vue
+++ b/src/pages/Signup.vue
@@ -15,8 +15,5 @@ export default connect({
   actionsToEvents: {
     submit: 'users/signup',
   },
-  lifecycle: {
-    destroyed: ({ dispatch }) => dispatch('users/cleanSignup'),
-  },
 })('Signup', Signup)
 </script>

--- a/src/pages/Store/PickupsManage.vue
+++ b/src/pages/Store/PickupsManage.vue
@@ -189,12 +189,6 @@ export default {
       seriesCreateStatus: 'pickupSeries/createStatus',
     }),
   },
-  mounted () {
-    this.$store.dispatch('pickupSeries/fetchListForActiveStore')
-  },
-  destroyed () {
-    this.$store.dispatch('pickupSeries/clearList')
-  },
 }
 </script>
 

--- a/src/pages/VerifyMail.vue
+++ b/src/pages/VerifyMail.vue
@@ -10,7 +10,6 @@ export default connect({
   lifecycle: {
     // when page is loaded, use the `?key` route parameter to trigger verification
     mounted: ({ getters, dispatch }) => dispatch('verifymail/verify', getters['route/query'].key),
-    destroyed: ({ dispatch }) => dispatch('verifymail/clean'),
   },
 })('VerifyMail', VerifyMail)
 </script>

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -48,8 +48,7 @@ export default [
         { type: 'activeGroupInfo' },
       ],
       beforeEnter: 'groups/selectGroupInfo',
-      onError: 'group id not found',
-      onLeave: 'groups/clearGroupInfo',
+      afterLeave: 'groups/clearGroupInfo',
     },
     components: {
       default: GroupInfo,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -89,6 +89,7 @@ export default [
       breadcrumbs: [
         { type: 'activeGroup' },
       ],
+      beforeEnter: 'groups/selectGroup',
     },
     components: {
       default: GroupLayout,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -47,6 +47,9 @@ export default [
         { translation: 'JOINGROUP.ALL_GROUPS', route: { name: 'groupsGallery' } },
         { type: 'activeGroupInfo' },
       ],
+      beforeEnter: 'groups/selectGroupInfo',
+      onError: 'group id not found',
+      onLeave: 'groups/clearGroupInfo',
     },
     components: {
       default: GroupInfo,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -63,6 +63,7 @@ export default [
         { translation: 'JOINGROUP.ALL_GROUPS', route: { name: 'groupsGallery' } },
         { translation: 'GROUP.CREATE_TITLE', route: { name: 'groupCreate' } },
       ],
+      beforeEnter: 'groups/fetchTimezones',
     },
     components: {
       default: GroupCreate,
@@ -165,6 +166,7 @@ export default [
           breadcrumbs: [
             { translation: 'GROUP.INVITE_TITLE', route: { name: 'groupInvitations' } },
           ],
+          beforeEnter: 'invitations/fetch',
         },
         components: {
           default: GroupInvitations,
@@ -178,6 +180,7 @@ export default [
           breadcrumbs: [
             { translation: 'GROUP.EDIT', route: { name: 'groupEdit' } },
           ],
+          beforeEnter: 'groups/fetchTimezones',
         },
         components: {
           default: GroupEdit,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -330,6 +330,8 @@ export default [
       breadcrumbs: [
         { type: 'activeUser' },
       ],
+      beforeEnter: 'users/selectUser',
+      afterLeave: 'users/clearSelectedUser',
     },
     components: {
       default: User,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -262,6 +262,8 @@ export default [
               breadcrumbs: [
                 { translation: 'PICKUPMANAGE.TITLE', route: { name: 'storePickupsManage' } },
               ],
+              beforeEnter: 'pickupSeries/fetchListForActiveStore',
+              afterLeave: 'pickupSeries/clearList',
             },
           },
           {

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -228,6 +228,8 @@ export default [
           breadcrumbs: [
             { type: 'activeStore' },
           ],
+          beforeEnter: 'stores/selectStore',
+          afterLeave: 'stores/clearSelectedStore',
         },
         props: {
           sidenav: true,

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -79,6 +79,8 @@ export default [
       breadcrumbs: [
         { translation: 'HISTORY.DETAILS', route: { name: 'historyDetail' } },
       ],
+      beforeEnter: 'history/setActive',
+      afterLeave: 'history/clearActive',
     },
   },
   {

--- a/src/routes/splash.js
+++ b/src/routes/splash.js
@@ -16,6 +16,7 @@ export default [
       breadcrumbs: [
         { translation: 'LOGIN.TITLE', route: { name: 'login' } },
       ],
+      afterLeave: 'auth/clearLoginStatus',
     },
     components: {
       default: Login,
@@ -30,6 +31,7 @@ export default [
       breadcrumbs: [
         { translation: 'PASSWORDRESET.TITLE', route: { name: 'passwordreset' } },
       ],
+      afterLeave: 'users/cleanPasswordreset',
     },
     components: {
       default: PasswordReset,
@@ -44,6 +46,7 @@ export default [
       breadcrumbs: [
         { translation: 'VERIFYMAIL.TITLE', route: { name: 'verifymail' } },
       ],
+      afterLeave: 'verifymail/clean',
     },
     components: {
       default: VerifyMail,
@@ -58,6 +61,7 @@ export default [
       breadcrumbs: [
         { translation: 'SIGNUP.TITLE', route: { name: 'signup' } },
       ],
+      afterLeave: 'users/cleanSignup',
     },
     components: {
       default: Signup,

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -169,3 +169,10 @@ export function metaStatuses (actions) {
   }
   return result
 }
+
+export function createRouteError (data) {
+  return Object.assign(new Error(), {
+    type: 'RouteError',
+    data,
+  })
+}

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -90,7 +90,7 @@ export const actions = {
 
   ...withMeta({
 
-    async selectGroup ({ commit, state, dispatch, getters, rootState }, groupId) {
+    async selectGroup ({ commit, state, dispatch, getters, rootState }, { groupId }) {
       if (state.activeGroupId === groupId) return
 
       commit(types.SET_ACTIVE, { groupId })
@@ -99,9 +99,8 @@ export const actions = {
       const hasError = getters['meta/status']('fetchGroup', groupId).hasValidationErrors
       if (hasError) {
         const groupExists = !!getters.get(groupId)
-        const error = { translation: groupExists ? 'GROUP.NONMEMBER_REDIRECT' : 'NOT_FOUND.EXPLANATION' }
-        dispatch('routeError/set', error, { root: true })
-        return
+        const data = { translation: groupExists ? 'GROUP.NONMEMBER_REDIRECT' : 'NOT_FOUND.EXPLANATION' }
+        throw createRouteError(data)
       }
 
       dispatch('pickups/clear', {}, { root: true })

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -1,7 +1,7 @@
 import groups from '@/services/api/groups'
 import groupsInfo from '@/services/api/groupsInfo'
 import router from '@/router'
-import { indexById, withMeta, createMetaModule, withPrefixedIdMeta, metaStatusesWithId, metaStatuses } from '@/store/helpers'
+import { indexById, withMeta, createMetaModule, withPrefixedIdMeta, metaStatusesWithId, metaStatuses, createRouteError } from '@/store/helpers'
 
 export const modules = { meta: createMetaModule() }
 
@@ -200,7 +200,7 @@ export const actions = {
 
   selectGroupInfo ({ commit, getters, dispatch }, { groupInfoId }) {
     if (!getters.get(groupInfoId)) {
-      throw new Error('no group found')
+      throw createRouteError({ translation: 'no group found' })
     }
     commit(types.SET_ACTIVE_PREVIEW, { groupPreviewId: groupInfoId })
   },

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -198,11 +198,14 @@ export const actions = {
 
   }),
 
-  selectGroupInfo ({ commit, getters, dispatch }, groupPreviewId) {
-    if (!getters.get(groupPreviewId)) {
-      dispatch('routeError/set', null, { root: true })
+  selectGroupInfo ({ commit, getters, dispatch }, { groupInfoId }) {
+    if (!getters.get(groupInfoId)) {
+      throw new Error('no group found')
     }
-    commit(types.SET_ACTIVE_PREVIEW, { groupPreviewId })
+    commit(types.SET_ACTIVE_PREVIEW, { groupPreviewId: groupInfoId })
+  },
+  clearGroupInfo ({ commit }) {
+    commit(types.SET_ACTIVE_PREVIEW, { groupPreviewId: null })
   },
 
 }

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -192,9 +192,10 @@ export const actions = {
 
   }),
 
-  selectGroupInfo ({ commit, getters, dispatch }, { groupInfoId }) {
+  async selectGroupInfo ({ commit, getters, dispatch }, { groupInfoId }) {
     if (!getters.get(groupInfoId)) {
-      throw createRouteError({ translation: 'no group found' })
+      console.log('throw')
+      throw createRouteError()
     }
     commit(types.SET_ACTIVE_PREVIEW, { groupPreviewId: groupInfoId })
   },

--- a/src/store/modules/groups.spec.js
+++ b/src/store/modules/groups.spec.js
@@ -101,12 +101,6 @@ describe('groups', () => {
     },
   }
 
-  const routeError = {
-    actions: {
-      set: jest.fn(),
-    },
-  }
-
   describe('logged out', () => {
     beforeEach(() => {
       store = createStore({
@@ -226,25 +220,28 @@ describe('groups', () => {
         auth,
         pickups,
         conversations,
-        routeError,
       })
     })
 
     it('can select a group', async () => {
       mockConversation.mockReturnValueOnce({ id: 66 })
       mockGet.mockReturnValueOnce(group2)
-      await store.dispatch('groups/selectGroup', group2.id)
+      await store.dispatch('groups/selectGroup', { groupId: group2.id })
       expect(store.getters['groups/myGroups'].map(e => e.id)).toEqual([])
       expect(pickups.actions.clear).toBeCalled()
       expect(pickups.actions.fetchListByGroupId.mock.calls[0][1]).toBe(group2.id)
       expect(conversations.actions.setActive.mock.calls[0][1]).toEqual({ id: 66 })
-      expect(routeError.actions.set).not.toBeCalled()
     })
 
-    it('sets routeError if not group does not exist or user is not member of the group', async () => {
+    it('throws routeError if not group does not exist or user is not member of the group', async () => {
+      expect.assertions(1)
       mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-      await store.dispatch('groups/selectGroup', 9999)
-      expect(routeError.actions.set).toBeCalled()
+      try {
+        await store.dispatch('groups/selectGroup', { groupId: 9999 })
+      }
+      catch (e) {
+        expect(e.type).toEqual('RouteError')
+      }
     })
   })
 
@@ -252,13 +249,17 @@ describe('groups', () => {
     beforeEach(() => {
       store = createStore({
         groups: require('./groups'),
-        routeError,
       })
     })
 
-    it('sets routeError if group does not exist', async () => {
-      await store.dispatch('groups/selectGroupInfo', 9999)
-      expect(routeError.actions.set).toBeCalled()
+    it('throws routeError if group does not exist', async () => {
+      expect.assertions(2)
+      try {
+        await store.dispatch('groups/selectGroupInfo', { groupInfoId: 9999 })
+      }
+      catch (e) {
+        expect(e.type).toEqual('RouteError')
+      }
       expect(store.getters['groups/activeGroupInfo']).toBeUndefined()
     })
   })

--- a/src/store/modules/groups.spec.js
+++ b/src/store/modules/groups.spec.js
@@ -234,14 +234,8 @@ describe('groups', () => {
     })
 
     it('throws routeError if not group does not exist or user is not member of the group', async () => {
-      expect.assertions(1)
       mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-      try {
-        await store.dispatch('groups/selectGroup', { groupId: 9999 })
-      }
-      catch (e) {
-        expect(e.type).toEqual('RouteError')
-      }
+      await expect(store.dispatch('groups/selectGroup', { groupId: 9999 })).rejects.toHaveProperty('type', 'RouteError')
     })
   })
 
@@ -252,14 +246,9 @@ describe('groups', () => {
       })
     })
 
-    it('throws routeError if group does not exist', async () => {
-      expect.assertions(2)
-      try {
-        await store.dispatch('groups/selectGroupInfo', { groupInfoId: 9999 })
-      }
-      catch (e) {
-        expect(e.type).toEqual('RouteError')
-      }
+    it.only('throws routeError if group does not exist', async () => {
+      await expect(store.dispatch('groups/selectGroupInfo', { groupInfoId: 9999 }))
+        .rejects.toHaveProperty('type', 'RouteError')
       expect(store.getters['groups/activeGroupInfo']).toBeUndefined()
     })
   })

--- a/src/store/modules/history.js
+++ b/src/store/modules/history.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import historyAPI from '@/services/api/history'
-import { indexById } from '@/store/helpers'
+import { indexById, createRouteError } from '@/store/helpers'
 import i18n from '@/i18n'
 
 export const types = {
@@ -58,6 +58,9 @@ export const actions = {
     }
     commit(types.SET_ACTIVE, { id })
   },
+  clearActive ({ commit }) {
+    commit(types.SET_ACTIVE, { id: null })
+  },
   async fetchForGroup ({ dispatch, rootGetters }, group) {
     dispatch('fetchFiltered', { group: group.id })
   },
@@ -83,8 +86,14 @@ export const actions = {
   },
   async fetchById ({ commit, state }, id) {
     // add entry by ID, keep cursor the same as before
-    const entry = await historyAPI.get(id)
-    commit(types.RECEIVE, { entries: [entry], cursor: state.cursor })
+    try {
+      const entry = await historyAPI.get(id)
+      commit(types.RECEIVE, { entries: [entry], cursor: state.cursor })
+    }
+    catch (error) {
+      throw createRouteError()
+    }
+
   },
 
   async fetchMore ({ state, commit }) {

--- a/src/store/modules/history.js
+++ b/src/store/modules/history.js
@@ -52,11 +52,11 @@ export const getters = {
 }
 
 export const actions = {
-  async setActive ({ commit, dispatch, state }, id) {
-    if (!state.entries.id) {
-      await dispatch('fetchById', id)
+  async setActive ({ commit, dispatch, state }, { historyId }) {
+    if (!state.entries[historyId]) {
+      await dispatch('fetchById', historyId)
     }
-    commit(types.SET_ACTIVE, { id })
+    commit(types.SET_ACTIVE, { id: historyId })
   },
   clearActive ({ commit }) {
     commit(types.SET_ACTIVE, { id: null })

--- a/src/store/modules/history.js
+++ b/src/store/modules/history.js
@@ -93,7 +93,6 @@ export const actions = {
     catch (error) {
       throw createRouteError()
     }
-
   },
 
   async fetchMore ({ state, commit }) {

--- a/src/store/modules/history.spec.js
+++ b/src/store/modules/history.spec.js
@@ -15,14 +15,9 @@ describe('history module', () => {
   })
 
   it('throws routeError if historyId is not available', async () => {
-    expect.assertions(2)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-    try {
-      await store.dispatch('history/setActive', { historyId: 9999 })
-    }
-    catch (e) {
-      expect(e.type).toEqual('RouteError')
-    }
+    await expect(store.dispatch('history/setActive', { historyId: 9999 }))
+      .rejects.toHaveProperty('type', 'RouteError')
     expect(store.getters['history/active']).toBeUndefined()
   })
 })

--- a/src/store/modules/history.spec.js
+++ b/src/store/modules/history.spec.js
@@ -1,0 +1,28 @@
+const mockGet = jest.fn()
+jest.mock('@/services/api/history', () => ({ get: mockGet }))
+
+import { createStore, throws, createValidationError } from '>/helpers'
+
+describe('history module', () => {
+  beforeEach(() => jest.resetModules())
+
+  let store
+
+  beforeEach(() => {
+    store = createStore({
+      history: require('./history'),
+    })
+  })
+
+  it('throws routeError if historyId is not available', async () => {
+    expect.assertions(2)
+    mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
+    try {
+      await store.dispatch('history/setActive', { historyId: 9999 })
+    }
+    catch (e) {
+      expect(e.type).toEqual('RouteError')
+    }
+    expect(store.getters.active).toBeUndefined()
+  })
+})

--- a/src/store/modules/history.spec.js
+++ b/src/store/modules/history.spec.js
@@ -23,6 +23,6 @@ describe('history module', () => {
     catch (e) {
       expect(e.type).toEqual('RouteError')
     }
-    expect(store.getters.active).toBeUndefined()
+    expect(store.getters['history/active']).toBeUndefined()
   })
 })

--- a/src/store/modules/stores.js
+++ b/src/store/modules/stores.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import stores from '@/services/api/stores'
-import { indexById, onlyHandleAPIError } from '@/store/helpers'
+import { indexById, onlyHandleAPIError, createRouteError } from '@/store/helpers'
 import router from '@/router'
 
 export const types = {
@@ -46,15 +46,14 @@ export const getters = {
 }
 
 export const actions = {
-  async selectStore ({ commit, state, dispatch, getters, rootState }, storeId) {
+  async selectStore ({ commit, state, dispatch, getters, rootState }, { storeId }) {
     if (!getters.get(storeId)) {
       try {
         const store = await stores.get(storeId)
         commit(types.RECEIVE_ITEM, { store })
       }
       catch (error) {
-        dispatch('routeError/set', null, { root: true })
-        return
+        throw createRouteError()
       }
     }
     dispatch('pickups/setStoreFilter', storeId, {root: true})

--- a/src/store/modules/stores.spec.js
+++ b/src/store/modules/stores.spec.js
@@ -33,14 +33,8 @@ describe('stores module', () => {
   })
 
   it('throws routeError if store is not accessible', async () => {
-    expect.assertions(2)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-    try {
-      await store.dispatch('stores/selectStore', { storeId: 9999 })
-    }
-    catch (e) {
-      expect(e.type).toEqual('RouteError')
-    }
+    await expect(store.dispatch('stores/selectStore', { storeId: 9999 })).rejects.toHaveProperty('type', 'RouteError')
     expect(pickups.actions.setStoreFilter).not.toBeCalled()
   })
 })

--- a/src/store/modules/stores.spec.js
+++ b/src/store/modules/stores.spec.js
@@ -9,12 +9,6 @@ const pickups = {
   },
 }
 
-const routeError = {
-  actions: {
-    set: jest.fn(),
-  },
-}
-
 describe('stores module', () => {
   beforeEach(() => jest.resetModules())
 
@@ -25,7 +19,6 @@ describe('stores module', () => {
     store = createStore({
       stores: require('./stores'),
       pickups,
-      routeError,
     })
   })
 
@@ -39,10 +32,15 @@ describe('stores module', () => {
     store.commit('stores/Receive Stores', { stores: [store1, store2, store3] })
   })
 
-  it('sets routeError if store is not accessible', () => {
+  it('throws routeError if store is not accessible', async () => {
+    expect.assertions(2)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-    store.dispatch('stores/selectStore', 9999)
-    expect(routeError.actions.set).toBeCalled()
+    try {
+      await store.dispatch('stores/selectStore', { storeId: 9999 })
+    }
+    catch (e) {
+      expect(e.type).toEqual('RouteError')
+    }
     expect(pickups.actions.setStoreFilter).not.toBeCalled()
   })
 })

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import users from '@/services/api/users'
 import authUser from '@/services/api/authUser'
-import { indexById, onlyHandleAPIError } from '@/store/helpers'
+import { indexById, onlyHandleAPIError, createRouteError } from '@/store/helpers'
 
 export const types = {
 
@@ -94,12 +94,15 @@ export const actions = {
         commit(types.RECEIVE_USER, { user })
       }
       catch (error) {
-        const message = { translation: 'PROFILE.INACCESSIBLE_OR_DELETED' }
-        dispatch('routeError/set', message, { root: true })
-        return
+        const data = { translation: 'PROFILE.INACCESSIBLE_OR_DELETED' }
+        throw createRouteError(data)
       }
     }
     commit(types.SELECT_USER, { userId })
+  },
+
+  clearSelectedUser ({ commit }) {
+    commit(types.SELECT_USER, { userId: null })
   },
 
   async signup ({ commit, dispatch }, userData) {

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -88,7 +88,7 @@ export const getters = {
 }
 
 export const actions = {
-  async selectUser ({ commit, getters, dispatch }, userId) {
+  async selectUser ({ commit, getters, dispatch }, { userId }) {
     if (!getters.get(userId).id) {
       try {
         const user = await users.get(userId)

--- a/src/store/modules/users.spec.js
+++ b/src/store/modules/users.spec.js
@@ -13,6 +13,7 @@ const auth = {
 
 describe('users', () => {
   beforeEach(() => jest.resetModules())
+  beforeEach(() => jest.resetAllMocks())
 
   let store
 
@@ -56,22 +57,14 @@ describe('users', () => {
   })
 
   it('can select user', async () => {
-    expect.assertions(1)
     mockGet.mockReturnValueOnce(user1)
     await store.dispatch('users/selectUser', { userId: user1.id })
     expect(store.getters['users/activeUser'].id).toEqual(user1.id)
-    mockGet.mockReset()
   })
 
   it('throws routeError if user is not accessible', async () => {
-    expect.assertions(1)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-    try {
-      await store.dispatch('users/selectUser', { userId: 9999 })
-    }
-    catch (e) {
-      expect(e.type).toEqual('RouteError')
-    }
-    mockGet.mockReset()
+    await expect(store.dispatch('users/selectUser', { userId: 9999 }))
+      .rejects.toHaveProperty('type', 'RouteError')
   })
 })

--- a/src/store/modules/users.spec.js
+++ b/src/store/modules/users.spec.js
@@ -55,6 +55,14 @@ describe('users', () => {
     expect(store.getters['users/byActiveGroup'].map(e => e.id)).toEqual([user1.id, user2.id])
   })
 
+  it('can select user', async () => {
+    expect.assertions(1)
+    mockGet.mockReturnValueOnce(user1)
+    await store.dispatch('users/selectUser', { userId: user1.id })
+    expect(store.getters['users/activeUser'].id).toEqual(user1.id)
+    mockGet.mockReset()
+  })
+
   it('throws routeError if user is not accessible', async () => {
     expect.assertions(1)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
@@ -64,5 +72,6 @@ describe('users', () => {
     catch (e) {
       expect(e.type).toEqual('RouteError')
     }
+    mockGet.mockReset()
   })
 })

--- a/src/store/modules/users.spec.js
+++ b/src/store/modules/users.spec.js
@@ -11,12 +11,6 @@ const auth = {
   },
 }
 
-const routeError = {
-  actions: {
-    set: jest.fn(),
-  },
-}
-
 describe('users', () => {
   beforeEach(() => jest.resetModules())
 
@@ -27,7 +21,6 @@ describe('users', () => {
     store = createStore({
       users: require('./users'),
       auth,
-      routeError,
       groups: {
         getters: {
           activeGroup: () => ({ members: [1, 2] }),
@@ -62,9 +55,14 @@ describe('users', () => {
     expect(store.getters['users/byActiveGroup'].map(e => e.id)).toEqual([user1.id, user2.id])
   })
 
-  it('sets routeError if user is not accessible', () => {
+  it('throws routeError if user is not accessible', async () => {
+    expect.assertions(1)
     mockGet.mockImplementationOnce(throws(createValidationError({ detail: 'Not found' })))
-    store.dispatch('users/selectUser', 9999)
-    expect(routeError.actions.set).toBeCalled()
+    try {
+      await store.dispatch('users/selectUser', { userId: 9999 })
+    }
+    catch (e) {
+      expect(e.type).toEqual('RouteError')
+    }
   })
 })

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -77,10 +77,6 @@ export default store => {
     }
     store.dispatch('breadcrumbs/setAll', findBreadcrumbs(to.matched) || [])
 
-    if (to.params.historyId) {
-      store.dispatch('history/setActive', parseInt(to.params.historyId, 10))
-    }
-
     /* If:
         - the group is not mentioned in the URL
         - we do not have an active group

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -78,9 +78,6 @@ export default store => {
     store.dispatch('breadcrumbs/setAll', findBreadcrumbs(to.matched) || [])
 
     // save active group/store/user
-    if (to.params.groupId) {
-      await store.dispatch('groups/selectGroup', parseInt(to.params.groupId, 10))
-    }
     if (to.params.storeId) {
       store.dispatch('stores/selectStore', parseInt(to.params.storeId, 10))
     }

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -52,19 +52,21 @@ export default store => {
   router.beforeEach(async (to, from, next) => {
     for (let m of from.matched) {
       if (m.meta.afterLeave) {
-        console.log('onLeave', m.meta.afterLeave)
-        store.dispatch(m.meta.afterLeave)
+        console.log('afterLeave', m.meta.afterLeave)
+        await store.dispatch(m.meta.afterLeave)
       }
     }
     for (let m of to.matched) {
       if (m.meta.beforeEnter) {
         try {
           console.log('beforeEnter', to.params)
-          store.dispatch(m.meta.beforeEnter, parseAsIntegers(to.params))
+          await store.dispatch(m.meta.beforeEnter, parseAsIntegers(to.params))
         }
         catch (error) {
           if (error.type === 'RouteError') {
-            store.dispatch('routeError/set', error.data)
+            await store.dispatch('routeError/set', error.data)
+            // no further loading needed
+            return
           }
           else {
             // can't be handled here

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -77,9 +77,6 @@ export default store => {
     }
     store.dispatch('breadcrumbs/setAll', findBreadcrumbs(to.matched) || [])
 
-    if (to.params.userId) {
-      store.dispatch('users/selectUser', parseInt(to.params.userId, 10))
-    }
     if (to.params.historyId) {
       store.dispatch('history/setActive', parseInt(to.params.historyId, 10))
     }

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -63,7 +63,7 @@ export default store => {
      */
     if (!to.params.groupId && !hasActiveGroup() && isLoggedIn()) {
       let groupId = getUserGroupId()
-      if (groupId) store.dispatch('groups/selectGroup', groupId)
+      if (groupId) store.dispatch('groups/selectGroup', { groupId })
     }
 
     next()

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -51,22 +51,25 @@ export default store => {
 
   router.beforeEach(async (to, from, next) => {
     for (let m of from.matched) {
-      if (m.meta.onLeave) {
-        console.log('onLeave', m.meta.onLeave)
-        store.dispatch(m.meta.onLeave)
+      if (m.meta.afterLeave) {
+        console.log('onLeave', m.meta.afterLeave)
+        store.dispatch(m.meta.afterLeave)
       }
     }
     for (let m of to.matched) {
       if (m.meta.beforeEnter) {
         try {
-          console.log('beforeEnter', to.params.groupInfoId)
-          // TODO parse all params, assuming that all are integer
-          const params = { groupInfoId: parseInt(to.params.groupInfoId, 10) }
-          store.dispatch(m.meta.beforeEnter, params)
+          console.log('beforeEnter', to.params)
+          store.dispatch(m.meta.beforeEnter, parseAsIntegers(to.params))
         }
         catch (error) {
-          console.log('onError', m.meta.onError)
-          store.dispatch('routeError/set', { translation: m.meta.onError })
+          if (error.type === 'RouteError') {
+            store.dispatch('routeError/set', error.data)
+          }
+          else {
+            // can't be handled here
+            throw error
+          }
         }
       }
     }
@@ -121,4 +124,10 @@ export function findBreadcrumbs (matched) {
     }
     return acc
   }, [])
+}
+
+export function parseAsIntegers (obj) {
+  return Object.entries(obj).reduce((acc, [k, v]) => {
+    acc[k] = parseInt(v, 10)
+  }, {})
 }

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -77,13 +77,6 @@ export default store => {
     }
     store.dispatch('breadcrumbs/setAll', findBreadcrumbs(to.matched) || [])
 
-    // save active group/store/user
-    if (to.params.storeId) {
-      store.dispatch('stores/selectStore', parseInt(to.params.storeId, 10))
-    }
-    else {
-      store.dispatch('stores/clearSelectedStore')
-    }
     if (to.params.userId) {
       store.dispatch('users/selectUser', parseInt(to.params.userId, 10))
     }

--- a/src/store/plugins/router.js
+++ b/src/store/plugins/router.js
@@ -50,14 +50,31 @@ export default store => {
   })
 
   router.beforeEach(async (to, from, next) => {
+    for (let m of from.matched) {
+      if (m.meta.onLeave) {
+        console.log('onLeave', m.meta.onLeave)
+        store.dispatch(m.meta.onLeave)
+      }
+    }
+    for (let m of to.matched) {
+      if (m.meta.beforeEnter) {
+        try {
+          console.log('beforeEnter', to.params.groupInfoId)
+          // TODO parse all params, assuming that all are integer
+          const params = { groupInfoId: parseInt(to.params.groupInfoId, 10) }
+          store.dispatch(m.meta.beforeEnter, params)
+        }
+        catch (error) {
+          console.log('onError', m.meta.onError)
+          store.dispatch('routeError/set', { translation: m.meta.onError })
+        }
+      }
+    }
     store.dispatch('breadcrumbs/setAll', findBreadcrumbs(to.matched) || [])
 
     // save active group/store/user
     if (to.params.groupId) {
       await store.dispatch('groups/selectGroup', parseInt(to.params.groupId, 10))
-    }
-    if (to.params.groupInfoId) {
-      store.dispatch('groups/selectGroupInfo', parseInt(to.params.groupInfoId, 10))
     }
     if (to.params.storeId) {
       store.dispatch('stores/selectStore', parseInt(to.params.storeId, 10))

--- a/src/store/plugins/router.spec.js
+++ b/src/store/plugins/router.spec.js
@@ -1,0 +1,124 @@
+import Vue from 'vue'
+import { createStore, throws } from '>/helpers'
+import { createRouteError } from '@/store/helpers'
+import VueRouter from 'vue-router'
+import { maybeDispatchActions } from './router'
+
+jest.mock('@/router')
+
+function makeTestModule () {
+  return {
+    actions: {
+      beforeEnter: jest.fn(),
+      afterLeave: jest.fn(),
+      beforeEnterChild: jest.fn(),
+      afterLeaveChild: jest.fn(),
+    },
+  }
+}
+
+function makeRouteErrorModule () {
+  return {
+    actions: {
+      set: jest.fn(),
+    },
+  }
+}
+
+describe('router plugin / beforeEnter & afterLeave meta options', () => {
+  beforeEach(() => jest.resetModules())
+
+  let store, router, test, routeError
+  beforeEach(() => {
+    test = makeTestModule()
+    routeError = makeRouteErrorModule()
+
+    store = createStore(
+      {
+        routeError,
+        test,
+      },
+    )
+
+    const routes = [
+      {
+        name: 'route1',
+        path: '/route1/:testId',
+        meta: {
+          beforeEnter: 'test/beforeEnter',
+          afterLeave: 'test/afterLeave',
+        },
+        children: [
+          {
+            name: 'child',
+            path: '/child/:childId',
+            meta: {
+              beforeEnter: 'test/beforeEnterChild',
+              afterLeave: 'test/afterLeaveChild',
+            },
+          },
+        ],
+      },
+      {
+        name: 'route2',
+        path: '/route2',
+      },
+    ]
+
+    router = new VueRouter({ routes })
+    router.beforeEach(async (to, from, next) => {
+      await maybeDispatchActions(store, to, from)
+      next()
+    })
+  })
+
+  it('triggers beforeEnter action on route enter', async () => {
+    router.push({ name: 'route1', params: { testId: '42' } })
+    await Vue.nextTick()
+    expect(test.actions.beforeEnter.mock.calls.length).toBe(1)
+    expect(test.actions.beforeEnter.mock.calls[0][1]).toEqual({ testId: 42 })
+    expect(test.actions.afterLeave).not.toBeCalled()
+    expect(routeError.actions.set).not.toBeCalled()
+  })
+
+  it('triggers afterLeave action on route leave', async () => {
+    router.push({ name: 'route1', params: { testId: '42' } })
+    await Vue.nextTick()
+    router.push({ name: 'route2' })
+    await Vue.nextTick()
+    expect(test.actions.afterLeave).toBeCalled()
+    expect(routeError.actions.set).not.toBeCalled()
+  })
+
+  it('sets routeError if beforeEnter throws', async () => {
+    test.actions.beforeEnter.mockImplementation(throws(createRouteError('message')))
+    router.push({ name: 'route1', params: { testId: '42' } })
+    await Vue.nextTick()
+    expect(test.actions.beforeEnter).toBeCalled()
+    expect(routeError.actions.set).toBeCalled()
+    expect(routeError.actions.set.mock.calls[0][1]).toEqual('message')
+  })
+
+  it('calls parent enter action first and leave action last', async () => {
+    let callOrder = []
+    test.actions.beforeEnter.mockImplementationOnce(() => callOrder.push('parentEnter'))
+    test.actions.beforeEnterChild.mockImplementationOnce(() => callOrder.push('childEnter'))
+    test.actions.afterLeave.mockImplementationOnce(() => callOrder.push('parentLeave'))
+    test.actions.afterLeaveChild.mockImplementationOnce(() => callOrder.push('childLeave'))
+    router.push({ name: 'child', params: { testId: '42', 'childId': '44' } })
+    await Vue.nextTick(); await Vue.nextTick()
+    router.push({ name: 'route2' })
+    await Vue.nextTick()
+    expect(test.actions.beforeEnter.mock.calls[0][1]).toEqual({ testId: 42, childId: 44 })
+    expect(test.actions.beforeEnterChild.mock.calls[0][1]).toEqual({ testId: 42, childId: 44 })
+    expect(callOrder).toEqual(['parentEnter', 'childEnter', 'childLeave', 'parentLeave'])
+  })
+
+  it('dont call child enter action if parent throws', async () => {
+    test.actions.beforeEnter.mockImplementation(throws(createRouteError()))
+    router.push({ name: 'child', params: { testId: '42', 'childId': '44' } })
+    await Vue.nextTick(); await Vue.nextTick()
+    expect(routeError.actions.set).toBeCalled()
+    expect(test.actions.beforeEnterChild).not.toBeCalled()
+  })
+})


### PR DESCRIPTION
My first try at #726, quite basic for now.

This is the interface:

```javascript
meta: {
      beforeEnter: 'groups/selectGroupInfo', // triggers vuex action, passing route params as argument
      afterLeave: 'groups/clearGroupInfo', // triggers vuex action
}
```

I think it fulfills most of our requirements, I think could get away without functions in beforeEnter etc for quite a while. Eventually I think they might become necessary though.
I like the implicit way of passing in the route params into the action, although it assumes that all params are integers, which might change in the mid-term future. Wouldn't worry about that now.

---

- [x] remove console.log
- [ ] see if historyList can also get refactored
- [x] add tests
- [x] add docs
- [x] fix failing tests
- [x] test all changed bits by clicking around