### PR TITLE
add storyshots

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,12 +6,13 @@ import '../src/themes/app.mat.styl'
 import Vue from 'vue'
 import Quasar from 'quasar'
 import Vuex from 'vuex'
-import VueI18n from 'vue-i18n'
+import MockRouterLink from '>/MockRouterLink'
 
 Vue.config.productionTip = false
 Vue.use(Quasar) // Install Quasar Framework
 Vue.use(Vuex) // Install Vuex
-Vue.use(VueI18n)
+
+Vue.component('router-link', MockRouterLink)
 
 import 'quasar-extras/roboto-font'
 import 'quasar-extras/material-icons'
@@ -22,10 +23,10 @@ import 'quasar-extras/animate'
 // Storybook config
 import { configure } from '@storybook/vue'
 
-const req = require.context("../src", true, /\.story\.js$/);
+const req = require.context('../src', true, /\.story\.js$/)
 
 function loadStories() {
-  req.keys().forEach(filename => req(filename));
+  req.keys().forEach(filename => req(filename))
 }
 
 configure(loadStories, module)

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -16,8 +16,8 @@ module.exports = (baseConfig, env) => {
   // set Storybook entrypoint
   mergedConfig.entry = storybookConfig.entry
 
-  // allow relative module resolution as used in Storybook
-  mergedConfig.resolve.modules = storybookConfig.resolve.modules
+  // remove absolute node_modules path, it causes errors with some storybook dependency
+  mergedConfig.resolve.modules = mergedConfig.resolve.modules.filter(e => !e.includes('/node_modules'))
 
   // only use Quasars loaders
   mergedConfig.module.rules = quasarConfig.module.rules

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "build": "node build/script.build.js",
     "build:cordova": "CORDOVA=true node build/script.build.js",
     "serve": "node build/script.serve.js",
-    "test": "jest",
-    "test:update": "jest --verbose --updateSnapshot",
-    "test:watch": "jest --verbose --watchAll --notify",
+    "test": "node test/jestUTC.js",
+    "test:update": "node test/jestUTC.js --verbose --updateSnapshot",
+    "test:watch": "node test/jestUTC.js --verbose --watchAll --notify",
     "e2e": "node e2e/testcafe.js",
     "lint": "eslint --ext .js,.vue src",
     "fix": "eslint --ext .js,.vue --fix src",
@@ -171,7 +171,6 @@
     "setupFiles": [
       "<rootDir>/test/setup/unhandledPromiseRejectionHandler.js",
       "<rootDir>/test/setup/mockRandom.js",
-      "<rootDir>/test/setup/setUTC.js",
       "jest-localstorage-mock"
     ],
     "globals": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build:cordova": "CORDOVA=true node build/script.build.js",
     "serve": "node build/script.serve.js",
     "test": "jest",
+    "test:update": "jest --verbose --updateSnapshot",
+    "test:watch": "jest --verbose --watchAll --notify",
     "e2e": "node e2e/testcafe.js",
     "lint": "eslint --ext .js,.vue src",
     "fix": "eslint --ext .js,.vue --fix src",
@@ -107,6 +109,7 @@
     "jest": "^21.2.1",
     "jest-junit": "^3.4.0",
     "jest-localstorage-mock": "^2.1.0",
+    "jest-serializer-vue": "^0.3.0",
     "jest-vue-preprocessor": "^1.1.0",
     "json-loader": "^0.5.7",
     "lolex": "^2.3.0",
@@ -123,9 +126,10 @@
     "testcafe-browser-provider-saucelabs": "^1.3.0",
     "url-loader": "^0.6.2",
     "vue-loader": "~13.5.0",
+    "vue-server-renderer": "^2.5.11",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "~2.5.9",
-    "vue-test-utils": "1.0.0-beta.6",
+    "vue-test-utils": "1.0.0-beta.8",
     "webpack": "^3.10.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.2",
@@ -134,6 +138,10 @@
   "jest": {
     "roots": [
       "<rootDir>/src/"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "<rootDir>/src"
     ],
     "moduleNameMapper": {
       "@/(.*)$": "<rootDir>/src/$1",
@@ -152,13 +160,17 @@
       "^.+\\.js$": "babel-jest",
       ".*\\.(vue)$": "jest-vue-preprocessor"
     },
+    "snapshotSerializers": [
+      "jest-serializer-vue"
+    ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!quasar-framework)"
+      "/node_modules/(?!(@storybook|quasar-framework))"
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "setupFiles": [
       "<rootDir>/test/setup/unhandledPromiseRejectionHandler.js",
+      "<rootDir>/test/setup/mockRandom.js",
       "jest-localstorage-mock"
     ],
     "globals": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "setupFiles": [
       "<rootDir>/test/setup/unhandledPromiseRejectionHandler.js",
       "<rootDir>/test/setup/mockRandom.js",
+      "<rootDir>/test/setup/setUTC.js",
       "jest-localstorage-mock"
     ],
     "globals": {

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -107,7 +107,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:43 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:43 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -127,7 +127,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:47 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:47 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -147,7 +147,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:47 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:47 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -167,7 +167,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:49 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:49 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -187,7 +187,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:51 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:51 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -207,7 +207,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:52 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -227,7 +227,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:52 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -247,7 +247,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:52 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -267,7 +267,7 @@ exports[`Storyshots Conversation Conversation 1`] = `
                         <div class="q-item- row light-paragraph" style="padding-top:5px;">
                             <small>
                                 <div>
-                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 3:52 PM</span></div>
                             </small>
                         </div>
                     </div>
@@ -583,7 +583,7 @@ exports[`Storyshots GroupEdit create 1`] = `
                                 <div class="q-if-inner col row no-wrap items-center relative-position">
                                     <!---->
                                     <!---->
-                                    <input type="text" value="Europe/Berlin" class="col q-input-target text-left">
+                                    <input type="text" value="UTC" class="col q-input-target text-left">
                                     <!---->
                                     <!---->
                                     <!---->
@@ -1581,12 +1581,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1604,12 +1604,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1627,12 +1627,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:15 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1650,12 +1650,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:12 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:12 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1673,12 +1673,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:12 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 9:12 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1689,12 +1689,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 10:00 AM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 8:00 AM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 10:00 AM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 8:00 AM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1730,12 +1730,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:28 PM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:28 PM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1753,12 +1753,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:28 PM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:28 PM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1776,12 +1776,12 @@ exports[`Storyshots History List Default 1`] = `
                                     <div class="q-item-"><span class="content">did something</span></div>
                                     <div class="q-item-stamp mobile-only light-paragraph">
                                         <div>
-                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:27 PM</span></div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:27 PM</span></div>
                                     </div>
                                 </div>
                                 <div class="q-item-side q-item-side-right q-item-section desktop-only">
                                     <div>
-                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:27 PM</span></div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 4:27 PM</span></div>
                                 </div>
                             </div>
                         </div>
@@ -2496,7 +2496,7 @@ exports[`Storyshots PickupItem Full 1`] = `
 <div class="q-card full">
     <div class="q-card-main q-card-container row inline no-padding justify-between content">
         <div class="column padding full-width">
-            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div><span class="featured-text">8:00 AM</span> Date or Store Slot</div>
             <div class="description multiline">this pickup is already full!</div>
             <div class="people full-width">
                 <div class="row justify-start">
@@ -2540,7 +2540,7 @@ exports[`Storyshots PickupItem Join 1`] = `
 <div class="q-card">
     <div class="q-card-main q-card-container row inline no-padding justify-between content">
         <div class="column padding full-width">
-            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div><span class="featured-text">8:00 AM</span> Date or Store Slot</div>
             <div class="description multiline">you can join this pickup</div>
             <div class="people full-width">
                 <div class="row justify-start">
@@ -2589,7 +2589,7 @@ exports[`Storyshots PickupItem Leave 1`] = `
 <div class="q-card">
     <div class="q-card-main q-card-container row inline no-padding justify-between content isUserMember">
         <div class="column padding full-width">
-            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div><span class="featured-text">8:00 AM</span> Date or Store Slot</div>
             <div class="description multiline">you are collector and can leave this pickup</div>
             <div class="people full-width">
                 <div class="row justify-start">
@@ -2637,7 +2637,7 @@ exports[`Storyshots PickupItem pending 1`] = `
 <div class="q-card">
     <div class="q-card-main q-card-container row inline no-padding justify-between content">
         <div class="column padding full-width">
-            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div><span class="featured-text">8:00 AM</span> Date or Store Slot</div>
             <div class="description multiline">you can join this pickup</div>
             <div class="people full-width">
                 <div class="row justify-start">
@@ -2685,7 +2685,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card">
         <div class="q-card-main q-card-container row inline no-padding justify-between content">
             <div class="column padding full-width">
-                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                <div><span class="featured-text">8:00 AM</span> Saturday, August 12, 2017
                 </div>
                 <div class="description multiline">you can join this pickup</div>
                 <div class="people full-width">
@@ -2732,7 +2732,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card">
         <div class="q-card-main q-card-container row inline no-padding justify-between content isUserMember">
             <div class="column padding full-width">
-                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                <div><span class="featured-text">8:00 AM</span> Saturday, August 12, 2017
                 </div>
                 <div class="description multiline">you are collector and can leave this pickup</div>
                 <div class="people full-width">
@@ -2778,7 +2778,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card full">
         <div class="q-card-main q-card-container row inline no-padding justify-between content">
             <div class="column padding full-width">
-                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                <div><span class="featured-text">8:00 AM</span> Saturday, August 12, 2017
                 </div>
                 <div class="description multiline">this pickup is already full!</div>
                 <div class="people full-width">
@@ -2820,7 +2820,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card">
         <div class="q-card-main q-card-container row inline no-padding justify-between content isEmpty">
             <div class="column padding full-width">
-                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                <div><span class="featured-text">8:00 AM</span> Saturday, August 12, 2017
                 </div>
                 <div class="description multiline">this pickup is fresh and empty</div>
                 <div class="people full-width">
@@ -2872,13 +2872,13 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                         <div class="q-if-inner col row no-wrap items-center relative-position">
                             <!---->
                             <!---->
-                            <div class="col row items-center q-input-target justify-start">10:00 AM</div>
+                            <div class="col row items-center q-input-target justify-start">8:00 AM</div>
                             <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
                                 <div class="q-datetime inline row no-border text-primary">
                                     <div class="q-datetime-header column col-xs-12 col-md-4 justify-center">
                                         <!---->
                                         <div class="q-datetime-time row flex-center">
-                                            <div class="q-datetime-clockstring col-auto col-md-12"><span class="q-datetime-link col-auto col-md-12 active"> 10 </span> <span style="opacity:0.6;">:</span> <span class="q-datetime-link col-auto col-md-12"> 00 </span></div>
+                                            <div class="q-datetime-clockstring col-auto col-md-12"><span class="q-datetime-link col-auto col-md-12 active">   9 </span> <span style="opacity:0.6;">:</span> <span class="q-datetime-link col-auto col-md-12"> 00 </span></div>
                                             <div class="q-datetime-ampm column col-auto col-md-12 justify-around">
                                                 <div class="q-datetime-link active">AM</div>
                                                 <div class="q-datetime-link">PM</div>
@@ -2894,7 +2894,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                                                 <div class="q-datetime-clock cursor-pointer">
                                                     <div class="q-datetime-clock-circle full-width full-height">
                                                         <div class="q-datetime-clock-center"></div>
-                                                        <div class="q-datetime-clock-pointer" style="transform:rotate(120deg);-webkit-transform:rotate(120deg);-moz-transform:rotate(120deg);-ms-transform:rotate(120deg);-o-transform:rotate(120deg);"><span></span></div>
+                                                        <div class="q-datetime-clock-pointer" style="transform:rotate(90deg);-webkit-transform:rotate(90deg);-moz-transform:rotate(90deg);-ms-transform:rotate(90deg);-o-transform:rotate(90deg);"><span></span></div>
                                                         <div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-1"><span>1</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-2"><span>2</span></div>
@@ -2904,8 +2904,8 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-6"><span>6</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-7"><span>7</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-8"><span>8</span></div>
-                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-9"><span>9</span></div>
-                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-10 active"><span>10</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-9 active"><span>9</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-10"><span>10</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-11"><span>11</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-12"><span>12</span></div>
                                                         </div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2878,7 +2878,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                                     <div class="q-datetime-header column col-xs-12 col-md-4 justify-center">
                                         <!---->
                                         <div class="q-datetime-time row flex-center">
-                                            <div class="q-datetime-clockstring col-auto col-md-12"><span class="q-datetime-link col-auto col-md-12 active">   9 </span> <span style="opacity:0.6;">:</span> <span class="q-datetime-link col-auto col-md-12"> 00 </span></div>
+                                            <div class="q-datetime-clockstring col-auto col-md-12"><span class="q-datetime-link col-auto col-md-12 active">   8 </span> <span style="opacity:0.6;">:</span> <span class="q-datetime-link col-auto col-md-12"> 00 </span></div>
                                             <div class="q-datetime-ampm column col-auto col-md-12 justify-around">
                                                 <div class="q-datetime-link active">AM</div>
                                                 <div class="q-datetime-link">PM</div>
@@ -2894,7 +2894,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                                                 <div class="q-datetime-clock cursor-pointer">
                                                     <div class="q-datetime-clock-circle full-width full-height">
                                                         <div class="q-datetime-clock-center"></div>
-                                                        <div class="q-datetime-clock-pointer" style="transform:rotate(90deg);-webkit-transform:rotate(90deg);-moz-transform:rotate(90deg);-ms-transform:rotate(90deg);-o-transform:rotate(90deg);"><span></span></div>
+                                                        <div class="q-datetime-clock-pointer" style="transform:rotate(60deg);-webkit-transform:rotate(60deg);-moz-transform:rotate(60deg);-ms-transform:rotate(60deg);-o-transform:rotate(60deg);"><span></span></div>
                                                         <div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-1"><span>1</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-2"><span>2</span></div>
@@ -2903,8 +2903,8 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-5"><span>5</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-6"><span>6</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-7"><span>7</span></div>
-                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-8"><span>8</span></div>
-                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-9 active"><span>9</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-8 active"><span>8</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-9"><span>9</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-10"><span>10</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-11"><span>11</span></div>
                                                             <div class="q-datetime-clock-position q-datetime-clock-pos-12"><span>12</span></div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1,0 +1,5134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots AddressPicker Default 1`] = `
+<div>
+    <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+        <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+        <div class="q-if-inner col row no-wrap items-center relative-position">
+            <!---->
+            <!---->
+            <input placeholder="Search" type="text" value="" class="col q-input-target text-left">
+            <!---->
+            <!---->
+            <!---->
+            <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+            </div>
+            <!---->
+        </div>
+        <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
+    </div>
+    <div class="vue2leaflet-map map">
+        <div></div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots AddressPicker With map 1`] = `
+<div>
+    <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+        <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+        <div class="q-if-inner col row no-wrap items-center relative-position">
+            <!---->
+            <!---->
+            <input placeholder="Search" type="text" value="" class="col q-input-target text-left">
+            <!---->
+            <!---->
+            <!---->
+            <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+            </div>
+            <!---->
+        </div>
+        <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
+    </div>
+    <div class="vue2leaflet-map map">
+        <div></div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Conversation Conversation 1`] = `
+<div>
+    <!---->
+    <div class="q-infinite-scroll">
+        <div class="q-infinite-scroll-content">
+            <div class="bg-white desktop-margin q-list">
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section" style="margin-top:16px;">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Current User
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <div class="col row relative-position">
+                                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                            <div class="absolute-full overflow-hidden invisible">
+                                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                            </div>
+                                            <div class="absolute-full overflow-hidden invisible">
+                                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                            </div>
+                                        </div>
+                                        <textarea rows="2" class="col q-input-target q-input-shadow absolute-top"></textarea>
+                                        <textarea placeholder="Write a message..." rows="2" class="col q-input-target q-input-area"></textarea>
+                                    </div>
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">arrow_forward</i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Mira Bellenbaum</span></div> <span class="content">first messsage</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:43 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Max Mustermann</span></div> <span class="content">second messsage</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:47 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Max Mustermann</span></div> <span class="content">first messsage</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:47 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Max Mustermann</span></div> <span class="content">welcome to fs chat</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:49 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Karl Karlson</span></div> <span class="content">heyo!</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:51 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Max Mustermann</span></div> <span class="content">you made it!</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mona Mohnblume
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Mona Mohnblume</span></div> <span class="content">amazing!</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mona Mohnblume
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Mona Mohnblume</span></div> <span class="content">oh let me try something :)</span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-multiline">
+                    <div class="q-item-side q-item-side-left q-item-section">
+                        <div class="wrapper">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-">
+                            <div to="[object Object]"><span class="text-bold text-secondary uppercase">Max Mustermann</span></div> <span class="content">I dont think we need to implement another UI, this is fine right? </span></div>
+                        <div class="q-item- row light-paragraph" style="padding-top:5px;">
+                            <small>
+                                <div>
+                                    4 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Aug 11, 2017, 5:52 PM</span></div>
+                            </small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="q-infinite-scroll-message" style="display:none;">
+            <div style="width:100%;text-align:center;">
+                <svg fill="currentColor" width="40" height="40" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" class="q-spinner">
+                    <circle cx="15" cy="15" r="15">
+                        <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+                        <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+                    </circle>
+                    <circle cx="60" cy="15" r="9" fill-opacity=".3">
+                        <animate attributeName="r" from="9" to="9" begin="0s" dur="0.8s" values="9;15;9" calcMode="linear" repeatCount="indefinite"></animate>
+                        <animate attributeName="fill-opacity" from=".5" to=".5" begin="0s" dur="0.8s" values=".5;1;.5" calcMode="linear" repeatCount="indefinite"></animate>
+                    </circle>
+                    <circle cx="105" cy="15" r="15">
+                        <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+                        <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+                    </circle>
+                </svg>
+            </div>
+        </div>
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots General Components KBox 1`] = `
+<div class="wrapper">
+    <div class="row justify-between toolbar">
+        <div class="name">&quot;name&quot;-Slot</div>
+        <div>&quot;tools&quot;-Slot</div>
+    </div>
+    <div class="content">Primary Slot</div>
+</div>
+`;
+
+exports[`Storyshots General Components KBreadcrumb 1`] = `
+<div class="wrapper">
+    <div class="prevBread gt-xs">
+        <!---->
+        <div class="label"><span>Foodsharing Berlin</span></div>
+        <div>
+            <i class="fa fa-fw fa-angle-right"></i>
+        </div>
+    </div>
+    <div class="xs">
+        <!---->
+    </div>
+    <div>
+        <div class="label lastElement">SirPlus</div>
+    </div>
+    <div class="xs" style="min-width:20px;"></div>
+</div>
+`;
+
+exports[`Storyshots General Components Search 1`] = `
+<div class="wrapper">
+    <div separator="" class="q-if row no-wrap items-center relative-position q-input q-search lightgrey text-primary">
+        <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+        <div class="q-if-inner col row no-wrap items-center relative-position">
+            <!---->
+            <!---->
+            <input placeholder="Search" type="text" class="col q-input-target text-left">
+            <!---->
+            <!---->
+            <!---->
+            <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+            </div>
+            <!---->
+        </div>
+        <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupEdit create 1`] = `
+<div>
+    <div class="q-card">
+        <div class="edit">
+            <form>
+                <div class="q-field row no-wrap items-start q-field-with-error">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-star"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Title of this group</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div id="group-title" autocomplete="off" class="q-if row no-wrap items-center relative-position q-input q-if-error text-negative">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="text" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <div class="q-field-bottom row no-wrap q-field-no-input">
+                                <div class="q-field-error col">This field is required.</div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-question"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Text you see before joining the group</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-tabs flex no-wrap markdown-input q-tabs-position-top q-tabs-inverted">
+                                    <div class="q-tabs-head row q-tabs-align-right">
+                                        <div class="q-tabs-scroller row no-wrap">
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab active"><span class="q-tab-label">Edit</span>
+                                                <div class="q-tabs-bar"></div>
+                                            </div>
+                                            <div class="relative-position self-stretch q-tabs-global-bar-container highlight">
+                                                <div class="q-tabs-bar q-tabs-global-bar"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row flex-center q-tabs-left-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_left</i>
+                                        </div>
+                                        <div class="row flex-center q-tabs-right-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_right</i>
+                                        </div>
+                                    </div>
+                                    <div class="q-tabs-panes">
+                                        <!---->
+                                        <div class="q-tab-pane">
+                                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                                <!---->
+                                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                                    <!---->
+                                                    <!---->
+                                                    <div class="col row relative-position">
+                                                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                                            </div>
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                                            </div>
+                                                        </div>
+                                                        <textarea rows="3" class="col q-input-target q-input-shadow absolute-top">undefined</textarea>
+                                                        <textarea rows="3" class="col q-input-target q-input-area">undefined</textarea>
+                                                    </div>
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                </div>
+                                                <!---->
+                                            </div>
+                                            <small class="row group pull-right light-paragraph">
+                                                <b>**bold**</b>
+                                                <i>_italic_</i> <span>~~strike~~</span> <span>&gt;quote</span>
+                                                <a href="https://guides.github.com/features/mastering-markdown/">
+                                                    <i aria-hidden="true" class="q-icon fa fa-question-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">What is Markdown?</span></a>
+                                            </small>
+                                            <div style="clear:both;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-vcard"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Group description, visible for members</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-tabs flex no-wrap markdown-input q-tabs-position-top q-tabs-inverted">
+                                    <div class="q-tabs-head row q-tabs-align-right">
+                                        <div class="q-tabs-scroller row no-wrap">
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab active"><span class="q-tab-label">Edit</span>
+                                                <div class="q-tabs-bar"></div>
+                                            </div>
+                                            <div class="relative-position self-stretch q-tabs-global-bar-container highlight">
+                                                <div class="q-tabs-bar q-tabs-global-bar"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row flex-center q-tabs-left-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_left</i>
+                                        </div>
+                                        <div class="row flex-center q-tabs-right-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_right</i>
+                                        </div>
+                                    </div>
+                                    <div class="q-tabs-panes">
+                                        <!---->
+                                        <div class="q-tab-pane">
+                                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                                <!---->
+                                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                                    <!---->
+                                                    <!---->
+                                                    <div class="col row relative-position">
+                                                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                                            </div>
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                                            </div>
+                                                        </div>
+                                                        <textarea rows="3" class="col q-input-target q-input-shadow absolute-top">undefined</textarea>
+                                                        <textarea rows="3" class="col q-input-target q-input-area">undefined</textarea>
+                                                    </div>
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                </div>
+                                                <!---->
+                                            </div>
+                                            <small class="row group pull-right light-paragraph">
+                                                <b>**bold**</b>
+                                                <i>_italic_</i> <span>~~strike~~</span> <span>&gt;quote</span>
+                                                <a href="https://guides.github.com/features/mastering-markdown/">
+                                                    <i aria-hidden="true" class="q-icon fa fa-question-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">What is Markdown?</span></a>
+                                            </small>
+                                            <div style="clear:both;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-map"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Address</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+                                    <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+                                    <div class="q-if-inner col row no-wrap items-center relative-position">
+                                        <!---->
+                                        <!---->
+                                        <input placeholder="Search" type="text" class="col q-input-target text-left">
+                                        <!---->
+                                        <!---->
+                                        <!---->
+                                        <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                            <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                    <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
+                                </div>
+                                <div class="vue2leaflet-map map">
+                                    <div></div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-question"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Enter a password here if you want to make the group private</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="text" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start q-field-with-error">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-fw fa-globe"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Time zone of group</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-if row no-wrap items-center relative-position q-input q-if-error text-negative">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="text" value="Europe/Berlin" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                        <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+                                    </div>
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <div class="q-field-bottom row no-wrap q-field-no-input">
+                                <div class="q-field-error col">Enter a valid timezone.</div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!---->
+                <!---->
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position actionButton q-btn-rectangle q-btn-standard bg-primary text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Create
+         <!----></span></button>
+                <div style="clear:both;"></div>
+            </form>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupGallery signup view 1`] = `
+<div>
+    <div class="q-alert-container alert">
+        <div class="q-alert row no-wrap shadow-2 bg-info">
+            <div class="q-alert-icon row col-auto flex-center">
+                <i aria-hidden="true" class="q-icon material-icons">star</i>
+            </div>
+            <div class="q-alert-content col self-center"><span>You are currently logged out. <div place="login" to="[object Object]" class="underline">
+        Log in to see your groups!
+      </div></span>
+                <!---->
+            </div>
+            <!---->
+        </div>
+    </div>
+    <!---->
+    <!---->
+    <h4 class="text-primary">
+        Which group do you want to join?
+    </h4>
+    <div class="row">
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            05_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>This is the public description
+                                <br> It would make sense if it was markdown</p>
+                            <h1>then this would be a header</h1>
+                            <p>
+                                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            06_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      13 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            02_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      33 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            03_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      12 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            01_testgroup_with_maps_and_password
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      53 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            04_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>Hi there! This it the public description!</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupGallery switch and explore 1`] = `
+<div>
+    <div class="q-alert-container alert">
+        <div class="q-alert row no-wrap shadow-2 bg-info">
+            <div class="q-alert-icon row col-auto flex-center">
+                <i aria-hidden="true" class="q-icon material-icons">star</i>
+            </div>
+            <div class="q-alert-content col self-center"><span>You are currently logged out. <div place="login" to="[object Object]" class="underline">
+        Log in to see your groups!
+      </div></span>
+                <!---->
+            </div>
+            <!---->
+        </div>
+    </div>
+    <h4 class="text-primary">
+        My groups
+    </h4>
+    <div class="row">
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            05_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>This is the public description
+                                <br> It would make sense if it was markdown</p>
+                            <h1>then this would be a header</h1>
+                            <p>
+                                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        You are member of this group. Click here to switch to full view.
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            06_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      13 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        You are member of this group. Click here to switch to full view.
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            02_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      33 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        You are member of this group. Click here to switch to full view.
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h4 class="text-primary">
+        Which group do you want to join?
+    </h4>
+    <div class="row">
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            05_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>This is the public description
+                                <br> It would make sense if it was markdown</p>
+                            <h1>then this would be a header</h1>
+                            <p>
+                                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            06_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      13 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            02_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      33 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            03_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      12 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            01_testgroup_with_maps_and_password
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      53 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+            <div class="q-card groupPreviewCard">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                    <div class="col column">
+                        <div class="q-card-title">
+                            04_testgroup
+                        </div>
+                        <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+                    </div>
+                    <div class="col-auto self-center q-card-title-extra"></div>
+                </div>
+                <div class="q-card-main q-card-container fixed-height">
+                    <div class="smaller-text">
+                        <div class="parsed">
+                            <p>Hi there! This it the public description!</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-card-separator"></div>
+                <div class="q-card-actions q-card-actions-horiz row justify-start">
+                    <!---->
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                        <!---->
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupGalleryCard isMember = false 1`] = `
+<div class="q-card groupPreviewCard">
+    <div class="q-card-primary q-card-container row no-wrap ellipsis">
+        <div class="col column">
+            <div class="q-card-title">
+                05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+        </div>
+        <div class="col-auto self-center q-card-title-extra"></div>
+    </div>
+    <div class="q-card-main q-card-container fixed-height">
+        <div class="smaller-text">
+            <div class="parsed">
+                <p>This is the public description
+                    <br> It would make sense if it was markdown</p>
+                <h1>then this would be a header</h1>
+                <p>
+                    <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="q-card-separator"></div>
+    <div class="q-card-actions q-card-actions-horiz row justify-start">
+        <!---->
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+            <!---->
+            </span>
+        </button>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupGalleryCard isMember = true 1`] = `
+<div class="q-card groupPreviewCard">
+    <div class="q-card-primary q-card-container row no-wrap ellipsis">
+        <div class="col column">
+            <div class="q-card-title">
+                05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+        </div>
+        <div class="col-auto self-center q-card-title-extra"></div>
+    </div>
+    <div class="q-card-main q-card-container fixed-height">
+        <div class="smaller-text">
+            <div class="parsed">
+                <p>This is the public description
+                    <br> It would make sense if it was markdown</p>
+                <h1>then this would be a header</h1>
+                <p>
+                    <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="q-card-separator"></div>
+    <div class="q-card-actions q-card-actions-horiz row justify-start">
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        You are member of this group. Click here to switch to full view.
+      </span>
+            <!---->
+            </span>
+        </button>
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+            <!---->
+            </span>
+        </button>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupGalleryCard without public description 1`] = `
+<div class="q-card groupPreviewCard">
+    <div class="q-card-primary q-card-container row no-wrap ellipsis">
+        <div class="col column">
+            <div class="q-card-title">
+                05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+        </div>
+        <div class="col-auto self-center q-card-title-extra"></div>
+    </div>
+    <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+    <div class="q-card-separator"></div>
+    <div class="q-card-actions q-card-actions-horiz row justify-start">
+        <!---->
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+            <!---->
+            </span>
+        </button>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupPreviewUI error 1`] = `
+<div>
+    <div class="q-alert-container">
+        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
+            <div class="q-alert-icon row col-auto flex-center">
+                <i aria-hidden="true" class="q-icon material-icons">info</i>
+            </div>
+            <div class="q-alert-content col self-center">
+                By joining this group, your profile data will become visible to other group members.
+                <!---->
+            </div>
+            <!---->
+        </div>
+    </div>
+    <div class="q-card">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    01_testgroup_with_maps_and_password
+                </div>
+                <div class="q-card-subtitle"><span>
+        53 Members
+      </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            <div class="parsed">
+                <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
+    </div>
+    <div class="q-field-content col-xs-12 col-sm">
+        <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+            <!---->
+            <div class="q-if-inner col row no-wrap items-center relative-position">
+                <!---->
+                <!---->
+                <input type="password" value="" class="col q-input-target text-left">
+                <!---->
+                <!---->
+                <!---->
+                <!---->
+            </div>
+            <!---->
+        </div>
+        <div class="q-field-bottom row no-wrap q-field-no-input">
+            <div class="q-field-helper col">Enter password for private group</div>
+            <!---->
+        </div>
+    </div>
+</div>
+</div>
+<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard">
+    <div class="desktop-only q-focus-helper"></div>
+    <!----><span class="q-btn-inner row col flex-center"><!----> 
+            Join
+           <!----></span></button>
+</form>
+</span>
+<!---->
+</div>
+</div>
+</div>
+`;
+
+exports[`Storyshots GroupPreviewUI is member 1`] = `
+<div>
+    <!---->
+    <div class="q-card">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    05_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+        18 Members
+      </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            <div class="parsed">
+                <p>This is the public description
+                    <br> It would make sense if it was markdown</p>
+                <h1>then this would be a header</h1>
+                <p>
+                    <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                </p>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+          You are member of this group. Click here to switch to full view.
+        </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupPreviewUI is not member 1`] = `
+<div>
+    <div class="q-alert-container">
+        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
+            <div class="q-alert-icon row col-auto flex-center">
+                <i aria-hidden="true" class="q-icon material-icons">info</i>
+            </div>
+            <div class="q-alert-content col self-center">
+                By joining this group, your profile data will become visible to other group members.
+                <!---->
+            </div>
+            <!---->
+        </div>
+    </div>
+    <div class="q-card">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    05_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+        18 Members
+      </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            <div class="parsed">
+                <p>This is the public description
+                    <br> It would make sense if it was markdown</p>
+                <h1>then this would be a header</h1>
+                <p>
+                    <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+                </p>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><!----> <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard"><div class="desktop-only q-focus-helper"></div> <!----> <span class="q-btn-inner row col flex-center"><!----> 
+            Join
+           <!----></span></button>
+            </form>
+            </span>
+            <!---->
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots GroupPreviewUI pending 1`] = `
+<div>
+    <div class="q-alert-container">
+        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
+            <div class="q-alert-icon row col-auto flex-center">
+                <i aria-hidden="true" class="q-icon material-icons">info</i>
+            </div>
+            <div class="q-alert-content col self-center">
+                By joining this group, your profile data will become visible to other group members.
+                <!---->
+            </div>
+            <!---->
+        </div>
+    </div>
+    <div class="q-card">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    01_testgroup_with_maps_and_password
+                </div>
+                <div class="q-card-subtitle"><span>
+        53 Members
+      </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            <div class="parsed">
+                <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
+    </div>
+    <div class="q-field-content col-xs-12 col-sm">
+        <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+            <!---->
+            <div class="q-if-inner col row no-wrap items-center relative-position">
+                <!---->
+                <!---->
+                <input type="password" value="" class="col q-input-target text-left">
+                <!---->
+                <!---->
+                <!---->
+                <!---->
+            </div>
+            <!---->
+        </div>
+        <div class="q-field-bottom row no-wrap q-field-no-input">
+            <div class="q-field-helper col">Enter password for private group</div>
+            <!---->
+        </div>
+    </div>
+</div>
+</div>
+<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard">
+    <div class="desktop-only q-focus-helper"></div>
+    <!----><span class="q-btn-inner row col flex-center"><!----> 
+            Join
+           <!----></span></button>
+</form>
+</span>
+<!---->
+</div>
+</div>
+</div>
+`;
+
+exports[`Storyshots GroupPreviewUI without public description 1`] = `
+<div>
+    <!---->
+    <div class="q-card">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    05_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+        18 Members
+      </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container"><span class="text-italic">
+        (This group has no public description... yet)
+      </span></div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-home"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+          You are member of this group. Click here to switch to full view.
+        </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots History List Default 1`] = `
+<div class="q-card">
+    <!---->
+    <div class="q-card-main q-card-container">
+        <div class="q-infinite-scroll">
+            <div class="q-infinite-scroll-content">
+                <table class="q-table highlight striped-odd">
+                    <tbody>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:15 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mona Mohnblume
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Current User
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 11:12 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section"></div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 10:00 AM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 2, 2017, 10:00 AM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                                        <!---->
+                                    </div>
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                                        <!---->
+                                    </div>
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                                        <!---->
+                                    </div>
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mona Mohnblume
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:28 PM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="q-item q-item-division relative-position q-item-multiline q-item-link">
+                                <div class="q-item-side q-item-side-left q-item-section">
+                                    <div class="wrapper">
+                                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                                        <!---->
+                                    </div>
+                                </div>
+                                <div class="q-item-main q-item-section">
+                                    <div class="q-item-"><span class="content">did something</span></div>
+                                    <div class="q-item-stamp mobile-only light-paragraph">
+                                        <div>
+                                            3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:27 PM</span></div>
+                                    </div>
+                                </div>
+                                <div class="q-item-side q-item-side-right q-item-section desktop-only">
+                                    <div>
+                                        3 months ago<span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Oct 1, 2017, 6:27 PM</span></div>
+                                </div>
+                            </div>
+                        </div>
+                    </tbody>
+                </table>
+                <!---->
+                <!---->
+            </div>
+            <div class="q-infinite-scroll-message" style="display:none;">
+                <div style="width:100%;text-align:center;">
+                    <svg fill="currentColor" width="40" height="40" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" class="q-spinner">
+                        <circle cx="15" cy="15" r="15">
+                            <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+                            <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+                        </circle>
+                        <circle cx="60" cy="15" r="9" fill-opacity=".3">
+                            <animate attributeName="r" from="9" to="9" begin="0s" dur="0.8s" values="9;15;9" calcMode="linear" repeatCount="indefinite"></animate>
+                            <animate attributeName="fill-opacity" from=".5" to=".5" begin="0s" dur="0.8s" values=".5;1;.5" calcMode="linear" repeatCount="indefinite"></animate>
+                        </circle>
+                        <circle cx="105" cy="15" r="15">
+                            <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+                            <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+                        </circle>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Layout KFooter 1`] = `
+<div class="footer bg-neutral font-primary">
+    <div class="footer-max-width row generic-padding" style="margin-top:5em;">
+        <div class="generic-padding col-md-4" style="margin-top:-5em;text-align:center;">
+            <img src="~@/assets/carrot-logo.svg" class="shadow">
+        </div>
+        <div class="column col-md-4">
+            <div>
+                <a href="https://github.com/yunity/karrot-frontend">
+                    <i class="fa fa-fw fa-github on-left"></i> Development</a>
+            </div>
+            <div>
+                <a href="https://www.facebook.com/groups/foodsaving.worldwide/">
+                    <i class="fa fa-fw fa-facebook on-left"></i> Join our Facebook Group!</a>
+            </div>
+            <div>
+                <a href="mail:karrot@foodsaving.world">
+                    <i class="fa fa-fw fa-envelope on-left"></i>karrot@foodsaving.world</a>
+            </div>
+        </div>
+        <div class="column col-md-4">
+            <hr class="lt-md" style="width:3em;">
+            <div>karrot
+                <!---->
+            </div>
+            <div>made with
+                <i class="fa fa-heart"></i> by
+                <a href="https://foodsaving.world">foodsaving worldwide</a>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Layout KTopbar 1`] = `
+<div class="q-toolbar row no-wrap items-center relative-position q-toolbar-normal bg-primary">
+    <div to="[object Object]" class="logo">
+        <div>
+            <img src="~@/assets/carrot-logo.svg">
+        </div>
+    </div>
+    <div class="q-toolbar-title">
+        <div class="row justify-between no-wrap">
+            <div></div>
+            <div class="wrapper bread">
+                <!---->
+                <!---->
+                <!---->
+            </div>
+            <div></div>
+        </div>
+    </div>
+    <!---->
+    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+        <div class="desktop-only q-focus-helper"></div>
+        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-fw fa-search"> </i> <!----></span></button>
+    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+        <div class="desktop-only q-focus-helper"></div>
+        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="globe q-icon fa fa-globe"> </i>
+  en
+  <div class="q-popover animate-scale" style="transform-origin:top left 0px;"><div class="q-list"><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Deutsch
+            <small>(100%)</small></div> <div class="q-item-sublabel"><!----></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            English
+            <small>(100%)</small></div> <div class="q-item-sublabel"><!----></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            中文
+            <small>(99%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:99%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Español
+            <small>(86%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:86%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Français
+            <small>(52%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:52%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Svenska
+            <small>(52%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:52%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Esperanto
+            <small>(37%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:37%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Italiano
+            <small>(27%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:27%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Русский
+            <small>(26%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:26%;"> </div></div></div></div></div><div class="q-item q-item-division relative-position q-item-highlight"><div class="q-item-main q-item-section"><div class="q-item-label">
+            Čeština
+            <small>(3%)</small></div> <div class="q-item-sublabel"><div class="q-progress"><!----> <div class="q-progress-track" style="width:100%;"> </div> <div class="q-progress-model" style="width:3%;"> </div></div></div></div></div> <div class="q-item-separator-component"></div> <a href="https://www.transifex.com/yunity-1/karrot/dashboard/" target="_blank" rel="nofollow noopener noreferrer" class="q-item q-item-division relative-position"><div class="q-item-main q-item-section"><i aria-hidden="true" class="q-icon fa fa-external-link"> </i> <small>Add more languages!</small></div></a></div></div> <!----></span></button>
+    <div to="[object Object]" class="defaulthover">
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Current User
+        <i aria-hidden="true" class="q-icon fa fa-fw fa-user"> </i> <!----></span></button>
+    </div>
+    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+        <div class="desktop-only q-focus-helper"></div>
+        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-fw fa-ellipsis-v"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
+        <div class="q-popover animate-scale"
+            style="transform-origin:top left 0px;">
+            <div item-separator="" class="q-list q-list-link">
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <i aria-hidden="true" class="q-icon fa fa-home fa-fw" style="font-size:1em;"> </i>
+                    Change group
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <i aria-hidden="true" class="q-icon fa fa-cog fa-fw" style="font-size:1em;"> </i>
+                    Settings
+                </div>
+                <div class="q-item q-item-division relative-position">
+                    <i aria-hidden="true" class="q-icon fa fa-sign-out fa-fw" style="font-size:1em;"> </i>
+                    Logout
+                </div>
+            </div>
+        </div>
+        <!---->
+        </span>
+    </button>
+</div>
+`;
+
+exports[`Storyshots Login empty 1`] = `
+<div>
+    <form name="login">
+        <div class="white-box">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                <!---->
+                                <input type="email" value="foo@foo.com" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="white-box">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Password</div>
+                                <!---->
+                                <input type="password" value="foofoo" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <i aria-hidden="true" class="q-if-control q-icon material-icons">visibility_off</i>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!---->
+        <div class="actions">
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Forgot your password?
+       <!----></span></button>
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Sign up!
+       <!----></span></button>
+            <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Login
+       <!----></span></button>
+        </div>
+        <div style="clear:both;"></div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Login error 1`] = `
+<div>
+    <form name="login">
+        <div class="white-box shake">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label q-if-error text-negative">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                <!---->
+                                <input type="email" value="foo@foo.com" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="white-box shake">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Password</div>
+                                <!---->
+                                <input type="password" value="foofoo" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <i aria-hidden="true" class="q-if-control q-icon material-icons">visibility_off</i>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="error">
+            <i class="fa fa-exclamation-triangle"></i>
+        </div>
+        <div class="actions">
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Forgot your password?
+       <!----></span></button>
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Sign up!
+       <!----></span></button>
+            <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Login
+       <!----></span></button>
+        </div>
+        <div style="clear:both;"></div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Login pending 1`] = `
+<div>
+    <form name="login">
+        <div class="white-box">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                <!---->
+                                <input type="email" value="foo@foo.com" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="white-box">
+            <div class="q-field row no-wrap items-start q-field-no-label">
+                <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                <div class="row col">
+                    <!---->
+                    <div class="q-field-content col-xs-12 col-sm">
+                        <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                            <!---->
+                            <div class="q-if-inner col row no-wrap items-center relative-position">
+                                <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Password</div>
+                                <!---->
+                                <input type="password" value="foofoo" class="col q-input-target text-left">
+                                <!---->
+                                <!---->
+                                <!---->
+                            </div>
+                            <i aria-hidden="true" class="q-if-control q-icon material-icons">visibility_off</i>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!---->
+        <div class="actions">
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Forgot your password?
+       <!----></span></button>
+            <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Sign up!
+       <!----></span></button>
+            <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard disabled">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><q-spinner-undefined size="1rem"></q-spinner-undefined></span></button>
+        </div>
+        <div style="clear:both;"></div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Map Demo 1`] = `
+<div class="vue2leaflet-map" style="height:600px;">
+    <div></div>
+    <div popupcontent="&lt;a href=&quot;https://foodsaving.world&quot;&gt;go there&lt;/a&gt;">
+        <div></div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Map GroupMap (group has no location) 1`] = `
+<div class="container" style="height:200px;">
+    <div class="vue2leaflet-map" style="opacity:0.5;">
+        <div></div>
+    </div>
+    <div class="overlay row justify-center content-center">
+        <div to="[object Object]">
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-primary text-white">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Set location
+       <!----></span></button>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Map GroupMap (only group location) 1`] = `
+<div class="container" style="height:200px;">
+    <div class="vue2leaflet-map" style="opacity:1;">
+        <div></div>
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots Map GroupMap (selected store) 1`] = `
+<div class="container" style="height:200px;">
+    <div class="vue2leaflet-map" style="opacity:1;">
+        <div></div>
+        <div id="store_1" popupcontent="&lt;a href=&quot;/#/group/1/store/1&quot;&gt;Teststore1&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_60" popupcontent="&lt;a href=&quot;/#/group/1/store/60&quot;&gt;New Tienda&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_56" popupcontent="&lt;a href=&quot;/#/group/1/store/56&quot;&gt;Supermarkt Arheilgen&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_2" popupcontent="&lt;a href=&quot;/#/group/1/store/2&quot;&gt;asd&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_61" popupcontent="&lt;a href=&quot;/#/group/1/store/61&quot;&gt;Griesheimer Markt&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_1" popupcontent="&lt;a href=&quot;/#/user/1&quot;&gt;Mira Bellenbaum&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_2" popupcontent="&lt;a href=&quot;/#/user/2&quot;&gt;Max Mustermann&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_3" popupcontent="&lt;a href=&quot;/#/user/3&quot;&gt;Karl Karlson&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_4" popupcontent="&lt;a href=&quot;/#/user/4&quot;&gt;Mona Mohnblume&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_5" popupcontent="&lt;a href=&quot;/#/user/5&quot;&gt;Current User&lt;/a&gt;">
+            <div></div>
+        </div>
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots Map GroupMap (store has no location) 1`] = `
+<div class="container" style="height:200px;">
+    <div class="vue2leaflet-map" style="opacity:0.5;">
+        <div></div>
+        <div id="store_1" popupcontent="&lt;a href=&quot;/#/group/1/store/1&quot;&gt;Teststore1&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_60" popupcontent="&lt;a href=&quot;/#/group/1/store/60&quot;&gt;New Tienda&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_56" popupcontent="&lt;a href=&quot;/#/group/1/store/56&quot;&gt;Supermarkt Arheilgen&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_2" popupcontent="&lt;a href=&quot;/#/group/1/store/2&quot;&gt;asd&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_61" popupcontent="&lt;a href=&quot;/#/group/1/store/61&quot;&gt;Griesheimer Markt&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_1" popupcontent="&lt;a href=&quot;/#/user/1&quot;&gt;Mira Bellenbaum&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_2" popupcontent="&lt;a href=&quot;/#/user/2&quot;&gt;Max Mustermann&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_3" popupcontent="&lt;a href=&quot;/#/user/3&quot;&gt;Karl Karlson&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_4" popupcontent="&lt;a href=&quot;/#/user/4&quot;&gt;Mona Mohnblume&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_5" popupcontent="&lt;a href=&quot;/#/user/5&quot;&gt;Current User&lt;/a&gt;">
+            <div></div>
+        </div>
+    </div>
+    <div class="overlay row justify-center content-center">
+        <div to="[object Object]">
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-primary text-white">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> 
+        Set location
+       <!----></span></button>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Map GroupMap 1`] = `
+<div class="container" style="height:200px;">
+    <div class="vue2leaflet-map" style="opacity:1;">
+        <div></div>
+        <div id="store_1" popupcontent="&lt;a href=&quot;/#/group/1/store/1&quot;&gt;Teststore1&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_60" popupcontent="&lt;a href=&quot;/#/group/1/store/60&quot;&gt;New Tienda&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_56" popupcontent="&lt;a href=&quot;/#/group/1/store/56&quot;&gt;Supermarkt Arheilgen&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_2" popupcontent="&lt;a href=&quot;/#/group/1/store/2&quot;&gt;asd&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="store_61" popupcontent="&lt;a href=&quot;/#/group/1/store/61&quot;&gt;Griesheimer Markt&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_1" popupcontent="&lt;a href=&quot;/#/user/1&quot;&gt;Mira Bellenbaum&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_2" popupcontent="&lt;a href=&quot;/#/user/2&quot;&gt;Max Mustermann&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_3" popupcontent="&lt;a href=&quot;/#/user/3&quot;&gt;Karl Karlson&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_4" popupcontent="&lt;a href=&quot;/#/user/4&quot;&gt;Mona Mohnblume&lt;/a&gt;">
+            <div></div>
+        </div>
+        <div id="user_5" popupcontent="&lt;a href=&quot;/#/user/5&quot;&gt;Current User&lt;/a&gt;">
+            <div></div>
+        </div>
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots Map StandardMap (selected marker) 1`] = `
+<div class="vue2leaflet-map" style="height:600px;">
+    <div></div>
+    <div id="marker1"></div>
+    <div id="marker2"></div>
+</div>
+`;
+
+exports[`Storyshots Map StandardMap 1`] = `
+<div class="vue2leaflet-map" style="height:600px;">
+    <div></div>
+    <div></div>
+</div>
+`;
+
+exports[`Storyshots Map UserMapPreview 1`] = `
+<div class="userMapPreview" style="position:relative;height:600px;">
+    <div class="vue2leaflet-map">
+        <div></div>
+        <div id="user_1" popupcontent="&lt;a href=&quot;/#/user/1&quot;&gt;Mira Bellenbaum&lt;/a&gt;">
+            <div></div>
+        </div>
+    </div>
+    <div to="[object Object]" class="overlay"></div>
+</div>
+`;
+
+exports[`Storyshots Password Reset empty 1`] = `
+<div>
+    <form name="passwordreset">
+        <div>
+            <p>
+                Enter your mail address and we will send you a new password (if you have an account registered).
+            </p>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Mail address</div>
+                                    <!---->
+                                    <input type="email" value="" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to login page
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Get new password
+         <!----></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Password Reset error 1`] = `
+<div>
+    <form name="passwordreset">
+        <div>
+            <p>
+                Enter your mail address and we will send you a new password (if you have an account registered).
+            </p>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" error-label="some error" class="q-if row no-wrap items-center relative-position q-input q-if-has-label q-if-error text-negative">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Mail address</div>
+                                    <!---->
+                                    <input type="email" value="" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to login page
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Get new password
+         <!----></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Password Reset pending 1`] = `
+<div>
+    <form name="passwordreset">
+        <div>
+            <p>
+                Enter your mail address and we will send you a new password (if you have an account registered).
+            </p>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Mail address</div>
+                                    <!---->
+                                    <input type="email" value="" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to login page
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard disabled">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><q-spinner-undefined size="1rem"></q-spinner-undefined></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Password Reset success 1`] = `
+<div>
+    <p>
+        The request was successfully sent. Have a look at your mails!
+    </p>
+</div>
+`;
+
+exports[`Storyshots PickupItem Full 1`] = `
+<div class="q-card full">
+    <div class="q-card-main q-card-container row inline no-padding justify-between content">
+        <div class="column padding full-width">
+            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div class="description multiline">this pickup is already full!</div>
+            <div class="people full-width">
+                <div class="row justify-start">
+                    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                        </div>
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                        </div>
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                        <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <!---->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots PickupItem Join 1`] = `
+<div class="q-card">
+    <div class="q-card-main q-card-container row inline no-padding justify-between content">
+        <div class="column padding full-width">
+            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div class="description multiline">you can join this pickup</div>
+            <div class="people full-width">
+                <div class="row justify-start">
+                    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                        </div>
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                        </div>
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                        <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
+                        <div class="hoverHide"></div>
+                        <div class="hoverShow"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Join</span></span>
+                        </div>
+                    </div>
+                    <!---->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots PickupItem Leave 1`] = `
+<div class="q-card">
+    <div class="q-card-main q-card-container row inline no-padding justify-between content isUserMember">
+        <div class="column padding full-width">
+            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div class="description multiline">you are collector and can leave this pickup</div>
+            <div class="people full-width">
+                <div class="row justify-start">
+                    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                        </div>
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                        </div>
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                        <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <a class="user-slot-wrapper profilePic clickable" style="width:36px;height:36px;">
+                        <div class="hoverShow">
+                            <i class="fa fa-fw fa-times" style="font-size:27px;"></i>
+                        </div> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Leave</span></span>
+                        <div class="hoverHide"><span></span></div>
+                    </a>
+                    <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+                        <div></div>
+                        <!---->
+                    </div>
+                    <!---->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots PickupItem pending 1`] = `
+<div class="q-card">
+    <div class="q-card-main q-card-container row inline no-padding justify-between content">
+        <div class="column padding full-width">
+            <div><span class="featured-text">10:00 AM</span> Date or Store Slot</div>
+            <div class="description multiline">you can join this pickup</div>
+            <div class="people full-width">
+                <div class="row justify-start">
+                    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                        </div>
+                        <div class="absolute-full overflow-hidden invisible">
+                            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                        </div>
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="wrapper profilePic clickable">
+                        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                        <!---->
+                    </div>
+                    <div class="emptySlots profilePic" style="border-color:black;width:36px;height:36px;">
+                        <q-spinner-undefined size="1rem"></q-spinner-undefined>
+                    </div>
+                    <!---->
+                    <!---->
+                    <!---->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots PickupList Default 1`] = `
+<div>
+    <div class="q-card">
+        <div class="q-card-main q-card-container row inline no-padding justify-between content">
+            <div class="column padding full-width">
+                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                </div>
+                <div class="description multiline">you can join this pickup</div>
+                <div class="people full-width">
+                    <div class="row justify-start">
+                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                            </div>
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                            </div>
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                            <!---->
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                            <!---->
+                        </div>
+                        <!---->
+                        <!---->
+                        <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
+                            <div class="hoverHide"></div>
+                            <div class="hoverShow"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Join</span></span>
+                            </div>
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="q-card">
+        <div class="q-card-main q-card-container row inline no-padding justify-between content isUserMember">
+            <div class="column padding full-width">
+                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                </div>
+                <div class="description multiline">you are collector and can leave this pickup</div>
+                <div class="people full-width">
+                    <div class="row justify-start">
+                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                            </div>
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                            </div>
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                            <!---->
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                        <!---->
+                        <!---->
+                        <a class="user-slot-wrapper profilePic clickable" style="width:36px;height:36px;">
+                            <div class="hoverShow">
+                                <i class="fa fa-fw fa-times" style="font-size:27px;"></i>
+                            </div> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Leave</span></span>
+                            <div class="hoverHide"><span></span></div>
+                        </a>
+                        <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+                            <div></div>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="q-card full">
+        <div class="q-card-main q-card-container row inline no-padding justify-between content">
+            <div class="column padding full-width">
+                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                </div>
+                <div class="description multiline">this pickup is already full!</div>
+                <div class="people full-width">
+                    <div class="row justify-start">
+                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                            </div>
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                            </div>
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+                            <!---->
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+                            <!---->
+                        </div>
+                        <div class="wrapper profilePic clickable">
+                            <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+                            <!---->
+                        </div>
+                        <!---->
+                        <!---->
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="q-card">
+        <div class="q-card-main q-card-container row inline no-padding justify-between content isEmpty">
+            <div class="column padding full-width">
+                <div><span class="featured-text">10:00 AM</span> Saturday, August 12, 2017
+                </div>
+                <div class="description multiline">this pickup is fresh and empty</div>
+                <div class="people full-width">
+                    <div class="row justify-start">
+                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                            </div>
+                            <div class="absolute-full overflow-hidden invisible">
+                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                            </div>
+                        </div>
+                        <!---->
+                        <!---->
+                        <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
+                            <div class="hoverHide"></div>
+                            <div class="hoverShow"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Join</span></span>
+                            </div>
+                        </div>
+                        <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+                            <div></div>
+                            <!---->
+                        </div>
+                        <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+                            <div></div>
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots PickupSeriesEdit Default 1`] = `
+<div class="edit">
+    <form>
+        <div class="q-field row no-wrap items-start">
+            <i aria-hidden="true" class="q-field-icon q-field-margin q-icon material-icons">access_time</i>
+            <div class="row col">
+                <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                    <div class="q-field-label-inner row items-center"><span>Time</span> </div>
+                </div>
+                <div class="q-field-content col-xs-12 col-sm">
+                    <div tabindex="0" class="q-if row no-wrap items-center relative-position q-datetime-input q-if-focusable text-primary">
+                        <!---->
+                        <div class="q-if-inner col row no-wrap items-center relative-position">
+                            <!---->
+                            <!---->
+                            <div class="col row items-center q-input-target justify-start">10:00 AM</div>
+                            <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                <div class="q-datetime inline row no-border text-primary">
+                                    <div class="q-datetime-header column col-xs-12 col-md-4 justify-center">
+                                        <!---->
+                                        <div class="q-datetime-time row flex-center">
+                                            <div class="q-datetime-clockstring col-auto col-md-12"><span class="q-datetime-link col-auto col-md-12 active"> 10 </span> <span style="opacity:0.6;">:</span> <span class="q-datetime-link col-auto col-md-12"> 00 </span></div>
+                                            <div class="q-datetime-ampm column col-auto col-md-12 justify-around">
+                                                <div class="q-datetime-link active">AM</div>
+                                                <div class="q-datetime-link">PM</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-datetime-content col-xs-12 col-md-8 column">
+                                        <div class="q-datetime-selector auto row flex-center">
+                                            <!---->
+                                            <!---->
+                                            <!---->
+                                            <div class="column items-center content-center justify-center">
+                                                <div class="q-datetime-clock cursor-pointer">
+                                                    <div class="q-datetime-clock-circle full-width full-height">
+                                                        <div class="q-datetime-clock-center"></div>
+                                                        <div class="q-datetime-clock-pointer" style="transform:rotate(120deg);-webkit-transform:rotate(120deg);-moz-transform:rotate(120deg);-ms-transform:rotate(120deg);-o-transform:rotate(120deg);"><span></span></div>
+                                                        <div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-1"><span>1</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-2"><span>2</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-3"><span>3</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-4"><span>4</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-5"><span>5</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-6"><span>6</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-7"><span>7</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-8"><span>8</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-9"><span>9</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-10 active"><span>10</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-11"><span>11</span></div>
+                                                            <div class="q-datetime-clock-position q-datetime-clock-pos-12"><span>12</span></div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                        <div class="row q-datetime-controls modal-buttons-top">
+                                            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat text-primary">
+                                                <div class="desktop-only q-focus-helper"></div>
+                                                <!----><span class="q-btn-inner row col flex-center"><!----> <span>Clear</span>
+                                                <!---->
+                                                </span>
+                                            </button>
+                                            <div class="col"></div>
+                                            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat text-primary">
+                                                <div class="desktop-only q-focus-helper"></div>
+                                                <!----><span class="q-btn-inner row col flex-center"><!----> <span>Cancel</span>
+                                                <!---->
+                                                </span>
+                                            </button>
+                                            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat text-primary">
+                                                <div class="desktop-only q-focus-helper"></div>
+                                                <!----><span class="q-btn-inner row col flex-center"><!----> <span>Set</span>
+                                                <!---->
+                                                </span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                        <i aria-hidden="true" class="q-if-control q-icon material-icons">arrow_drop_down</i>
+                        <!---->
+                    </div>
+                    <div class="q-field-bottom row no-wrap q-field-no-input">
+                        <div class="q-field-helper col">When should the pick-up take place?</div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="q-field row no-wrap items-start">
+            <i aria-hidden="true" class="q-field-icon q-field-margin q-icon material-icons">today</i>
+            <div class="row col">
+                <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                    <div class="q-field-label-inner row items-center"><span>Weekdays</span> </div>
+                </div>
+                <div class="q-field-content col-xs-12 col-sm">
+                    <div tabindex="0" class="q-if row no-wrap items-center relative-position q-select q-if-focusable text-primary">
+                        <!---->
+                        <div class="q-if-inner col row no-wrap items-center relative-position">
+                            <!---->
+                            <!---->
+                            <div class="col row items-center q-input-target justify-start">Thursday, Sunday</div>
+                            <!---->
+                            <div class="q-popover animate-scale column no-wrap" style="transform-origin:top left 0px;">
+                                <div></div>
+                                <div class="no-border scroll q-list q-list-link">
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Monday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position">
+                                                    <input type="checkbox">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Tuesday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position">
+                                                    <input type="checkbox">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Wednesday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position">
+                                                    <input type="checkbox">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Thursday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position active text-primary">
+                                                    <input type="checkbox" checked="checked">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Friday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position">
+                                                    <input type="checkbox">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Saturday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position">
+                                                    <input type="checkbox">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="q-item q-item-division relative-position">
+                                        <div class="q-item-main q-item-section">
+                                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Sunday</div>
+                                        </div>
+                                        <div class="q-item-side q-item-side-right q-item-section">
+                                            <div tabindex="0" class="q-toggle q-option cursor-pointer no-outline q-focusable row inline no-wrap items-center">
+                                                <div class="q-option-inner relative-position active text-primary">
+                                                    <input type="checkbox" checked="checked">
+                                                    <div class="q-focus-helper"></div>
+                                                    <div class="q-toggle-base"></div>
+                                                    <div class="q-toggle-handle shadow-1 row flex-center">
+                                                        <!---->
+                                                        <div class="q-radial-ripple"></div>
+                                                    </div>
+                                                </div>
+                                                <!---->
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                        <i aria-hidden="true" class="q-if-control q-icon material-icons">arrow_drop_down</i>
+                        <!---->
+                    </div>
+                    <div class="q-field-bottom row no-wrap q-field-no-input">
+                        <div class="q-field-helper col">On which days should the pick-up take place?</div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="q-field row no-wrap items-start">
+            <i aria-hidden="true" class="q-field-icon q-field-margin q-icon material-icons">group</i>
+            <div class="row col">
+                <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                    <div class="q-field-label-inner row items-center"><span>Max Slots</span> </div>
+                </div>
+                <div class="q-field-content col-xs-12 col-sm">
+                    <div class="q-slider non-selectable label-always">
+                        <div class="q-slider-handle-container">
+                            <div class="q-slider-track"></div>
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                            <div class="q-slider-track active-track" style="width:11.11111111111111%;"></div>
+                            <div class="q-slider-handle" style="left:11.11111111111111%;border-radius:50%;">
+                                <div class="q-chip row no-wrap inline items-center q-slider-label no-pointer-events square pointing text-white pointing-down bg-primary label-always">
+                                    <!---->
+                                    <div class="q-chip-main"> 2 </div>
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <div class="q-slider-ring"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="q-field-bottom row no-wrap q-field-no-input">
+                        <div class="q-field-helper col">How many people should participate in the pick-up?</div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="q-field row no-wrap items-start">
+            <i aria-hidden="true" class="q-field-icon q-field-margin q-icon material-icons">info</i>
+            <div class="row col">
+                <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                    <div class="q-field-label-inner row items-center"><span>Additional information</span> </div>
+                </div>
+                <div class="q-field-content col-xs-12 col-sm">
+                    <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                        <!---->
+                        <div class="q-if-inner col row no-wrap items-center relative-position">
+                            <!---->
+                            <!---->
+                            <div class="col row relative-position">
+                                <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                    <div class="absolute-full overflow-hidden invisible">
+                                        <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                    </div>
+                                    <div class="absolute-full overflow-hidden invisible">
+                                        <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                    </div>
+                                </div>
+                                <textarea class="col q-input-target q-input-shadow absolute-top">a nice description for the series</textarea>
+                                <textarea maxlength="500" class="col q-input-target q-input-area">a nice description for the series</textarea>
+                            </div>
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                    <div class="q-field-bottom row no-wrap q-field-no-input">
+                        <div class="q-field-helper col">What should people know when signing up to this pick-up?</div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!---->
+        <div class="row">
+            <div class="col-6 actionButton">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position full-width q-btn-rectangle q-btn-standard disabled">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> Reset <!----></span></button>
+            </div>
+            <div class="col-6 actionButton">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position full-width q-btn-rectangle q-btn-standard bg-red text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> Delete <!----></span></button>
+            </div>
+        </div>
+        <!---->
+        <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position full-width actionButton q-btn-rectangle q-btn-standard disabled bg-primary text-white">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> Save changes <!----></span></button>
+    </form>
+</div>
+`;
+
+exports[`Storyshots PickupUsers empty 1`] = `
+<div class="row justify-start">
+    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+        </div>
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+        </div>
+    </div>
+    <!---->
+    <!---->
+    <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
+        <div class="hoverHide"></div>
+        <div class="hoverShow"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Join</span></span>
+        </div>
+    </div>
+    <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+        <div></div>
+        <!---->
+    </div>
+    <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+        <div></div>
+        <!---->
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots PickupUsers full 1`] = `
+<div class="row justify-start">
+    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+        </div>
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+        </div>
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+        <!---->
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+        <!---->
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+        <!---->
+    </div>
+    <!---->
+    <!---->
+    <!---->
+</div>
+`;
+
+exports[`Storyshots PickupUsers joinable 1`] = `
+<div class="row justify-start">
+    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+        </div>
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+        </div>
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+        <!---->
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+        <!---->
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Karl Karlson
+    </span></div>
+        <!---->
+    </div>
+    <!---->
+    <!---->
+    <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
+        <div class="hoverHide"></div>
+        <div class="hoverShow"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Join</span></span>
+        </div>
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots PickupUsers leavable 1`] = `
+<div class="row justify-start">
+    <div class="absolute-full overflow-hidden invisible" style="z-index:-1;width:100%;">
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+        </div>
+        <div class="absolute-full overflow-hidden invisible">
+            <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+        </div>
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+        <!---->
+    </div>
+    <div class="wrapper profilePic clickable">
+        <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Max Mustermann
+    </span></div>
+        <!---->
+    </div>
+    <!---->
+    <!---->
+    <a class="user-slot-wrapper profilePic clickable" style="width:36px;height:36px;">
+        <div class="hoverShow">
+            <i class="fa fa-fw fa-times" style="font-size:27px;"></i>
+        </div> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"><span>Leave</span></span>
+        <div class="hoverHide"><span></span></div>
+    </a>
+    <div class="user-slot-wrapper profilePic greyedOut" style="width:36px;height:36px;">
+        <div></div>
+        <!---->
+    </div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots ProfilePicture Profile Pictures 1`] = `
+<div class="wrapper">
+    <div to="[object Object]"><span></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+      Mira Bellenbaum
+    </span></div>
+    <!---->
+</div>
+`;
+
+exports[`Storyshots Settings Page Default 1`] = `
+<div class="grey-border">
+    <div class="q-list no-border">
+        <div class="q-list-header ">Profile</div>
+        <div class="q-item q-item-division relative-position">
+            <div class="edit">
+                <form>
+                    <div class="q-field row no-wrap items-start">
+                        <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+                        <div class="row col">
+                            <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                                <div class="q-field-label-inner row items-center"><span>Name</span> </div>
+                            </div>
+                            <div class="q-field-content col-xs-12 col-sm">
+                                <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                    <!---->
+                                    <div class="q-if-inner col row no-wrap items-center relative-position">
+                                        <!---->
+                                        <!---->
+                                        <input type="text" value="Current User" class="col q-input-target text-left">
+                                        <!---->
+                                        <!---->
+                                        <!---->
+                                        <!---->
+                                    </div>
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                    <div class="q-field row no-wrap items-start">
+                        <i aria-hidden="true" class="q-field-icon q-field-margin q-icon material-icons">info</i>
+                        <div class="row col">
+                            <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                                <div class="q-field-label-inner row items-center"><span>About you</span> </div>
+                            </div>
+                            <div class="q-field-content col-xs-12 col-sm">
+                                <div>
+                                    <div class="q-tabs flex no-wrap markdown-input q-tabs-position-top q-tabs-inverted">
+                                        <div class="q-tabs-head row q-tabs-align-right">
+                                            <div class="q-tabs-scroller row no-wrap">
+                                                <div class="q-tab column flex-center relative-position markdown-input-tab active"><span class="q-tab-label">Edit</span>
+                                                    <div class="q-tabs-bar"></div>
+                                                </div>
+                                                <div class="q-tab column flex-center relative-position markdown-input-tab"><span class="q-tab-label">Preview</span>
+                                                    <div class="q-tabs-bar" style="display:none;"></div>
+                                                </div>
+                                                <div class="relative-position self-stretch q-tabs-global-bar-container highlight">
+                                                    <div class="q-tabs-bar q-tabs-global-bar"></div>
+                                                </div>
+                                            </div>
+                                            <div class="row flex-center q-tabs-left-scroll">
+                                                <i aria-hidden="true" class="q-icon material-icons">chevron_left</i>
+                                            </div>
+                                            <div class="row flex-center q-tabs-right-scroll">
+                                                <i aria-hidden="true" class="q-icon material-icons">chevron_right</i>
+                                            </div>
+                                        </div>
+                                        <div class="q-tabs-panes">
+                                            <div class="q-tab-pane">
+                                                <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                                    <!---->
+                                                    <div class="q-if-inner col row no-wrap items-center relative-position">
+                                                        <!---->
+                                                        <!---->
+                                                        <div class="col row relative-position">
+                                                            <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                                                <div class="absolute-full overflow-hidden invisible">
+                                                                    <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                                                </div>
+                                                                <div class="absolute-full overflow-hidden invisible">
+                                                                    <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                                                </div>
+                                                            </div>
+                                                            <textarea rows="1" class="col q-input-target q-input-shadow absolute-top">I am the current User!</textarea>
+                                                            <textarea rows="1" class="col q-input-target q-input-area">I am the current User!</textarea>
+                                                        </div>
+                                                        <!---->
+                                                        <!---->
+                                                        <!---->
+                                                        <!---->
+                                                    </div>
+                                                    <!---->
+                                                </div>
+                                                <small class="row group pull-right light-paragraph">
+                                                    <b>**bold**</b>
+                                                    <i>_italic_</i> <span>~~strike~~</span> <span>&gt;quote</span>
+                                                    <a href="https://guides.github.com/features/mastering-markdown/">
+                                                        <i aria-hidden="true" class="q-icon fa fa-question-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">What is Markdown?</span></a>
+                                                </small>
+                                                <div style="clear:both;"></div>
+                                            </div>
+                                            <!---->
+                                        </div>
+                                    </div>
+                                </div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                    <div class="q-field row no-wrap items-start">
+                        <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-map"> </i>
+                        <div class="row col">
+                            <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                                <div class="q-field-label-inner row items-center"><span>Where you are from (not required)</span> </div>
+                            </div>
+                            <div class="q-field-content col-xs-12 col-sm">
+                                <div>
+                                    <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+                                        <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+                                        <div class="q-if-inner col row no-wrap items-center relative-position">
+                                            <!---->
+                                            <!---->
+                                            <input placeholder="Search" type="text" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="col q-input-target text-left">
+                                            <!---->
+                                            <!---->
+                                            <!---->
+                                            <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                                <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+                                            </div>
+                                            <!---->
+                                        </div>
+                                        <i aria-hidden="true" class="q-if-control q-icon material-icons">cancel</i>
+                                    </div>
+                                    <div class="vue2leaflet-map map">
+                                        <div></div>
+                                        <div></div>
+                                    </div>
+                                </div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                    <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled bg-primary text-white">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> Save changes <!----></span></button>
+                    <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> Reset <!----></span></button>
+                </form>
+            </div>
+        </div>
+        <div class="q-list-header ">Mail</div>
+        <div class="q-item q-item-division relative-position">
+            <div class="edit">
+                <!---->
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Mail</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="email" value="" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-primary text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> Change e-mail address <!----></span></button>
+            </div>
+        </div>
+        <div class="q-list-header ">Password</div>
+        <div class="q-item q-item-division relative-position">
+            <div class="edit">
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Enter your new password</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="password" value="" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-primary text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> Change password <!----></span></button>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Settings Page verification warning 1`] = `
+<div class="q-alert-container">
+    <div class="q-alert row no-wrap shadow-2 bg-warning">
+        <div class="q-alert-icon row col-auto flex-center">
+            <i aria-hidden="true" class="q-icon material-icons">priority_high</i>
+        </div>
+        <div class="q-alert-content col self-center">
+            <h6>current@user.de not verified</h6> <span>Please check your emails or <a place="resend" class="underline">resend verification email</a></span>
+            <!---->
+            <!---->
+        </div>
+        <!---->
+    </div>
+</div>
+`;
+
+exports[`Storyshots Sidenav Boxes Default 1`] = `
+<div class="wrapper">
+    <div class="row justify-between toolbar">
+        <div class="name">&quot;name&quot;-Slot</div>
+        <div>&quot;tools&quot;-Slot</div>
+    </div>
+    <div class="content">Primary Slot</div>
+</div>
+`;
+
+exports[`Storyshots Sidenav Boxes Group 1`] = `
+<div class="wrapper">
+    <div class="row justify-between toolbar">
+        <div class="name">
+            <div>
+                <i class="fa fa-fw fa-home"></i>Group</div>
+        </div>
+        <div>
+            <div>
+                <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="fa fa-ellipsis-v"></i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
+                    <div class="q-popover animate-scale"
+                        style="transform-origin:top left 0px;">
+                        <div item-separator="" class="q-list q-list-link">
+                            <div class="q-item q-item-division relative-position q-item-link">
+                                <i aria-hidden="true" class="q-icon fa fa-pencil fa-fw on-left" style="font-size:1em;"> </i>
+                                Edit group
+                            </div>
+                            <!---->
+                            <div class="q-item q-item-division relative-position q-item-link">
+                                <i aria-hidden="true" class="q-icon fa fa-info-circle fa-fw on-left" style="font-size:1em;"> </i>
+                                Show public group information
+                            </div>
+                            <div class="q-item q-item-division relative-position q-item-link">
+                                <i aria-hidden="true" class="q-icon fa fa-user-plus fa-fw on-left" style="font-size:1em;"> </i>
+                                Invite users to your group
+                            </div>
+                            <div class="q-item q-item-division relative-position">
+                                <i aria-hidden="true" class="q-icon fa fa-sign-out fa-fw on-left" style="font-size:1em;"> </i>
+                                Leave group...
+                            </div>
+                        </div>
+                    </div>
+                    <!---->
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="content">
+        <div>
+            <div class="q-list no-border q-list-highlight">
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-bullhorn"> </i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        Wall
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-shopping-basket"> </i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        Pickups
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-vcard"> </i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        Description
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-users"> </i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        Members
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-clock-o"> </i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        History
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Sidenav Boxes Map 1`] = `
+<div class="wrapper">
+    <div class="row justify-between toolbar">
+        <div class="name">
+            <div>
+                <i class="fa fa-fw fa-map"></i>Map</div>
+        </div>
+        <div>
+            <div class="tools">
+                <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-stack"><i class="fa fa-shopping-cart fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Hide stores
+      </span>
+                    <!---->
+                    </span>
+                </button>
+                <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-stack"><i class="fa fa-user fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Hide users
+      </span>
+                    <!---->
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="content">
+        <div class="container map">
+            <div class="vue2leaflet-map" style="opacity:1;">
+                <div></div>
+                <div id="store_1" popupcontent="&lt;a href=&quot;/#/group/1/store/1&quot;&gt;Teststore1&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="store_60" popupcontent="&lt;a href=&quot;/#/group/1/store/60&quot;&gt;New Tienda&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="store_56" popupcontent="&lt;a href=&quot;/#/group/1/store/56&quot;&gt;Supermarkt Arheilgen&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="store_2" popupcontent="&lt;a href=&quot;/#/group/1/store/2&quot;&gt;asd&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="store_61" popupcontent="&lt;a href=&quot;/#/group/1/store/61&quot;&gt;Griesheimer Markt&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="user_1" popupcontent="&lt;a href=&quot;/#/user/1&quot;&gt;Mira Bellenbaum&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="user_2" popupcontent="&lt;a href=&quot;/#/user/2&quot;&gt;Max Mustermann&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="user_3" popupcontent="&lt;a href=&quot;/#/user/3&quot;&gt;Karl Karlson&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="user_4" popupcontent="&lt;a href=&quot;/#/user/4&quot;&gt;Mona Mohnblume&lt;/a&gt;">
+                    <div></div>
+                </div>
+                <div id="user_5" popupcontent="&lt;a href=&quot;/#/user/5&quot;&gt;Current User&lt;/a&gt;">
+                    <div></div>
+                </div>
+            </div>
+            <!---->
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Sidenav Boxes Stores 1`] = `
+<div class="wrapper">
+    <div class="row justify-between toolbar">
+        <div class="name">
+            <div>
+                <i class="fa fa-fw fa-shopping-cart"></i>Stores</div>
+        </div>
+        <div>
+            <div>
+                <div to="[object Object]">
+                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position text-white q-btn-rectangle q-btn-small q-btn-flat">
+                        <div class="desktop-only q-focus-helper"></div>
+                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-plus-circle" style="font-size:1em;"> </i>
+        Create
+       <!----></span></button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="content">
+        <div>
+            <div class="q-list no-border q-list-highlight">
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-label">Teststore1</div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-label">New Tienda</div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-label">Supermarkt Arheilgen</div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-label">asd</div>
+                    </div>
+                </div>
+                <div class="q-item q-item-division relative-position q-item-link">
+                    <div class="q-item-side q-item-side-left q-item-section text-center">
+                        <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+                    </div>
+                    <div class="q-item-main q-item-section">
+                        <div class="q-item-label">Griesheimer Markt</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Signup empty 1`] = `
+<div>
+    <div class="q-card bg-tertiary margin-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    <i aria-hidden="true" class="q-icon fa fa-exclamation-triangle"> </i>
+                    Warning
+                </div>
+                <div class="q-card-subtitle"></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            This website is under active development and everything is subject to change. We can't guarantee for the safety and privacy of the data you enter (but we try our best).
+        </div>
+    </div>
+    <form name="signup">
+        <div class="content">
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-user"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Name</div>
+                                    <!---->
+                                    <input type="text" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                    <!---->
+                                    <input type="email" value="default@example.com" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Password</div>
+                                    <!---->
+                                    <input type="password" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to Login
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Join
+         <!----></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Signup error 1`] = `
+<div>
+    <div class="q-card bg-tertiary margin-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    <i aria-hidden="true" class="q-icon fa fa-exclamation-triangle"> </i>
+                    Warning
+                </div>
+                <div class="q-card-subtitle"></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            This website is under active development and everything is subject to change. We can't guarantee for the safety and privacy of the data you enter (but we try our best).
+        </div>
+    </div>
+    <form name="signup">
+        <div class="content">
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-user"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Name</div>
+                                    <!---->
+                                    <input type="text" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label q-field-with-error">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label q-if-error text-negative">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                    <!---->
+                                    <input type="email" value="default@example.com" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <div class="q-field-bottom row no-wrap q-field-no-input">
+                                <div class="q-field-error col">error message</div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Password</div>
+                                    <!---->
+                                    <input type="password" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to Login
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Join
+         <!----></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Signup pending 1`] = `
+<div>
+    <div class="q-card bg-tertiary margin-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+            <div class="col column">
+                <div class="q-card-title">
+                    <i aria-hidden="true" class="q-icon fa fa-exclamation-triangle"> </i>
+                    Warning
+                </div>
+                <div class="q-card-subtitle"></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container">
+            This website is under active development and everything is subject to change. We can't guarantee for the safety and privacy of the data you enter (but we try our best).
+        </div>
+    </div>
+    <form name="signup">
+        <div class="content">
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-user"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Name</div>
+                                    <!---->
+                                    <input type="text" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-envelope"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start q-if-label-above">Mail</div>
+                                    <!---->
+                                    <input type="email" value="default@example.com" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="white-box">
+                <div class="q-field row no-wrap items-start q-field-no-label">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i>
+                    <div class="row col">
+                        <!---->
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocorrect="off" autocapitalize="off" spellcheck="false" class="q-if row no-wrap items-center relative-position q-input q-if-has-label text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <div class="q-if-label ellipsis full-width absolute self-start">Password</div>
+                                    <!---->
+                                    <input type="password" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!---->
+            <div class="actions">
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Back to Login
+         <!----></span></button>
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position submit shadow-4 q-btn-rectangle q-btn-standard disabled">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><q-spinner-undefined size="1rem"></q-spinner-undefined></span></button>
+            </div>
+            <div style="clear:both;"></div>
+        </div>
+    </form>
+</div>
+`;
+
+exports[`Storyshots Statistics AmountBox 1`] = `
+<div style="padding:2em;">
+    <div class="amount shadow-1">
+        20<span>kg</span></div>
+</div>
+`;
+
+exports[`Storyshots Statistics AmountPicker 1`] = `
+<div style="padding:2em;">
+    <div class="wrapper"><span></span>
+        <div class="wrapper row">
+            <div class="amount shadow-1 amount">
+                3<span>kg</span></div>
+            <img src="test-file-stub">
+            <img src="test-file-stub">
+            <img src="test-file-stub">
+        </div>
+        <div>
+            <div class="q-slider non-selectable">
+                <div class="q-slider-handle-container">
+                    <div class="q-slider-track"></div>
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <!---->
+                    <div class="q-slider-track active-track" style="width:4.285714285714286%;"></div>
+                    <div class="q-slider-handle" style="left:4.285714285714286%;border-radius:50%;">
+                        <div class="q-chip row no-wrap inline items-center q-slider-label no-pointer-events square pointing text-white pointing-down bg-primary">
+                            <!---->
+                            <div class="q-chip-main"> 3 </div>
+                            <!---->
+                            <!---->
+                        </div>
+                        <div class="q-slider-ring"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Statistics PickupFeedback 1`] = `
+<div style="padding:2em;">
+    <div class="wrapper">
+        <div class="row justify-inbetween no-wrap image-and-text">
+            <div class="image-and-text-left">
+                <img src="test-file-stub" style="width:100%;">
+            </div>
+            <div class="image-and-text-right">
+                <h3>Thank you for your pickup!</h3>
+                <p>You can provide feedback for your pickup here</p>
+            </div>
+        </div>
+        <div class="wrapper"><span></span>
+            <div class="wrapper row">
+                <div class="amount shadow-1 amount">
+                    3<span>kg</span></div>
+                <img src="test-file-stub">
+                <img src="test-file-stub">
+                <img src="test-file-stub">
+            </div>
+            <div>
+                <div class="q-slider non-selectable">
+                    <div class="q-slider-handle-container">
+                        <div class="q-slider-track"></div>
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                        <div class="q-slider-track active-track" style="width:4.285714285714286%;"></div>
+                        <div class="q-slider-handle" style="left:4.285714285714286%;border-radius:50%;">
+                            <div class="q-chip row no-wrap inline items-center q-slider-label no-pointer-events square pointing text-white pointing-down bg-primary">
+                                <!---->
+                                <div class="q-chip-main"> 3 </div>
+                                <!---->
+                                <!---->
+                            </div>
+                            <div class="q-slider-ring"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="q-field row no-wrap items-start">
+            <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+            <div class="row col">
+                <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                    <div class="q-field-label-inner row items-center"><span>Comment</span> </div>
+                </div>
+                <div class="q-field-content col-xs-12 col-sm">
+                    <div autocomplete="off" class="q-if row no-wrap items-center relative-position q-input text-primary">
+                        <!---->
+                        <div class="q-if-inner col row no-wrap items-center relative-position">
+                            <!---->
+                            <!---->
+                            <input type="text" value="" class="col q-input-target text-left">
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                        </div>
+                        <!---->
+                    </div>
+                    <div class="q-field-bottom row no-wrap q-field-no-input">
+                        <div class="q-field-helper col">Was everything fine? Did everyone show up? Your comment here...</div>
+                        <!---->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Stores StoreEdit (with server error) 1`] = `
+<div>
+    <div class="q-card">
+        <div class="edit">
+            <form>
+                <div class="q-field row no-wrap items-start q-field-with-error">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Name</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocomplete="off" class="q-if row no-wrap items-center relative-position q-input q-if-error text-negative">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="text" value="Teststore1" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <div class="q-field-bottom row no-wrap q-field-no-input">
+                                <div class="q-field-error col">a nice server error</div>
+                                <!---->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-handshake-o"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Status</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div tabindex="0" class="q-if row no-wrap items-center relative-position q-select q-if-focusable text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <div class="col row items-center q-input-target justify-start"></div>
+                                    <!---->
+                                    <div class="q-popover animate-scale column no-wrap" style="transform-origin:top left 0px;">
+                                        <div></div>
+                                        <div class="no-border scroll q-list q-list-link">
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-gray">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle-o"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Just created</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-blue">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Negotiating</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-green">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Co-operating</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-red">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Don't want to cooperate</div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!---->
+                                </div>
+                                <i aria-hidden="true" class="q-if-control q-icon material-icons">arrow_drop_down</i>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-question"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Description</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-tabs flex no-wrap markdown-input q-tabs-position-top q-tabs-inverted">
+                                    <div class="q-tabs-head row q-tabs-align-right">
+                                        <div class="q-tabs-scroller row no-wrap">
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab active"><span class="q-tab-label">Edit</span>
+                                                <div class="q-tabs-bar"></div>
+                                            </div>
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab"><span class="q-tab-label">Preview</span>
+                                                <div class="q-tabs-bar" style="display:none;"></div>
+                                            </div>
+                                            <div class="relative-position self-stretch q-tabs-global-bar-container highlight">
+                                                <div class="q-tabs-bar q-tabs-global-bar"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row flex-center q-tabs-left-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_left</i>
+                                        </div>
+                                        <div class="row flex-center q-tabs-right-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_right</i>
+                                        </div>
+                                    </div>
+                                    <div class="q-tabs-panes">
+                                        <div class="q-tab-pane">
+                                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                                <!---->
+                                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                                    <!---->
+                                                    <!---->
+                                                    <div class="col row relative-position">
+                                                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                                            </div>
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                                            </div>
+                                                        </div>
+                                                        <textarea rows="3" class="col q-input-target q-input-shadow absolute-top">all the good stuff</textarea>
+                                                        <textarea rows="3" class="col q-input-target q-input-area">all the good stuff</textarea>
+                                                    </div>
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                </div>
+                                                <!---->
+                                            </div>
+                                            <small class="row group pull-right light-paragraph">
+                                                <b>**bold**</b>
+                                                <i>_italic_</i> <span>~~strike~~</span> <span>&gt;quote</span>
+                                                <a href="https://guides.github.com/features/mastering-markdown/">
+                                                    <i aria-hidden="true" class="q-icon fa fa-question-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">What is Markdown?</span></a>
+                                            </small>
+                                            <div style="clear:both;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-map"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Address</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+                                    <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+                                    <div class="q-if-inner col row no-wrap items-center relative-position">
+                                        <!---->
+                                        <!---->
+                                        <input placeholder="Search" type="text" value="Kranichstein, Darmstadt, Regierungsbezirk Darmstadt, Hesse, Germany" class="col q-input-target text-left">
+                                        <!---->
+                                        <!---->
+                                        <!---->
+                                        <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                            <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                    <i aria-hidden="true" class="q-if-control q-icon material-icons">cancel</i>
+                                </div>
+                                <div class="vue2leaflet-map map">
+                                    <div></div>
+                                    <div></div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-calendar"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>How many weeks in advance should recurring pickup dates be shown?</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-slider non-selectable label-always">
+                                <div class="q-slider-handle-container">
+                                    <div class="q-slider-track"></div>
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <div class="q-slider-track active-track" style="width:33.33333333333333%;"></div>
+                                    <div class="q-slider-handle" style="left:33.33333333333333%;border-radius:50%;">
+                                        <div class="q-chip row no-wrap inline items-center q-slider-label no-pointer-events square pointing text-white pointing-down bg-primary label-always">
+                                            <!---->
+                                            <div class="q-chip-main"> 4 </div>
+                                            <!---->
+                                            <!---->
+                                        </div>
+                                        <div class="q-slider-ring"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <!---->
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled bg-primary text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Save changes
+         <!----></span></button>
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Reset
+         <!----></span></button>
+                <!---->
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-red text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Archive
+         <!----></span></button>
+            </form>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Stores StoreEdit 1`] = `
+<div>
+    <div class="q-card">
+        <div class="edit">
+            <form>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-star"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Name</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div autocomplete="off" class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <input type="text" value="Teststore1" class="col q-input-target text-left">
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                </div>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-handshake-o"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Status</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div tabindex="0" class="q-if row no-wrap items-center relative-position q-select q-if-focusable text-primary">
+                                <!---->
+                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                    <!---->
+                                    <!---->
+                                    <div class="col row items-center q-input-target justify-start"></div>
+                                    <!---->
+                                    <div class="q-popover animate-scale column no-wrap" style="transform-origin:top left 0px;">
+                                        <div></div>
+                                        <div class="no-border scroll q-list q-list-link">
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-gray">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle-o"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Just created</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-blue">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Negotiating</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-green">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Co-operating</div>
+                                                </div>
+                                            </div>
+                                            <div class="q-item q-item-division relative-position">
+                                                <div class="q-item-side q-item-side-left q-item-section text-red">
+                                                    <i aria-hidden="true" class="q-item-icon q-icon fa fa-circle"> </i>
+                                                </div>
+                                                <div class="q-item-main q-item-section">
+                                                    <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Don't want to cooperate</div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!---->
+                                </div>
+                                <i aria-hidden="true" class="q-if-control q-icon material-icons">arrow_drop_down</i>
+                                <!---->
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-question"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Description</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-tabs flex no-wrap markdown-input q-tabs-position-top q-tabs-inverted">
+                                    <div class="q-tabs-head row q-tabs-align-right">
+                                        <div class="q-tabs-scroller row no-wrap">
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab active"><span class="q-tab-label">Edit</span>
+                                                <div class="q-tabs-bar"></div>
+                                            </div>
+                                            <div class="q-tab column flex-center relative-position markdown-input-tab"><span class="q-tab-label">Preview</span>
+                                                <div class="q-tabs-bar" style="display:none;"></div>
+                                            </div>
+                                            <div class="relative-position self-stretch q-tabs-global-bar-container highlight">
+                                                <div class="q-tabs-bar q-tabs-global-bar"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row flex-center q-tabs-left-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_left</i>
+                                        </div>
+                                        <div class="row flex-center q-tabs-right-scroll">
+                                            <i aria-hidden="true" class="q-icon material-icons">chevron_right</i>
+                                        </div>
+                                    </div>
+                                    <div class="q-tabs-panes">
+                                        <div class="q-tab-pane">
+                                            <div class="q-if row no-wrap items-center relative-position q-input text-primary">
+                                                <!---->
+                                                <div class="q-if-inner col row no-wrap items-center relative-position">
+                                                    <!---->
+                                                    <!---->
+                                                    <div class="col row relative-position">
+                                                        <div class="absolute-full overflow-hidden invisible" style="z-index:-1;">
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:100000px;height:100000px;"></div>
+                                                            </div>
+                                                            <div class="absolute-full overflow-hidden invisible">
+                                                                <div class="absolute-top-left transition-0" style="width:200%;height:200%;"></div>
+                                                            </div>
+                                                        </div>
+                                                        <textarea rows="3" class="col q-input-target q-input-shadow absolute-top">all the good stuff</textarea>
+                                                        <textarea rows="3" class="col q-input-target q-input-area">all the good stuff</textarea>
+                                                    </div>
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                    <!---->
+                                                </div>
+                                                <!---->
+                                            </div>
+                                            <small class="row group pull-right light-paragraph">
+                                                <b>**bold**</b>
+                                                <i>_italic_</i> <span>~~strike~~</span> <span>&gt;quote</span>
+                                                <a href="https://guides.github.com/features/mastering-markdown/">
+                                                    <i aria-hidden="true" class="q-icon fa fa-question-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">What is Markdown?</span></a>
+                                            </small>
+                                            <div style="clear:both;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-map"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>Address</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div>
+                                <div class="q-if row no-wrap items-center relative-position q-input q-search text-primary">
+                                    <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
+                                    <div class="q-if-inner col row no-wrap items-center relative-position">
+                                        <!---->
+                                        <!---->
+                                        <input placeholder="Search" type="text" value="Kranichstein, Darmstadt, Regierungsbezirk Darmstadt, Hesse, Germany" class="col q-input-target text-left">
+                                        <!---->
+                                        <!---->
+                                        <!---->
+                                        <div class="q-popover animate-scale" style="transform-origin:top left 0px;">
+                                            <div class="q-list no-border q-list-link" style="min-width:0;"></div>
+                                        </div>
+                                        <!---->
+                                    </div>
+                                    <i aria-hidden="true" class="q-if-control q-icon material-icons">cancel</i>
+                                </div>
+                                <div class="vue2leaflet-map map">
+                                    <div></div>
+                                    <div></div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <div class="q-field row no-wrap items-start">
+                    <i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-calendar"> </i>
+                    <div class="row col">
+                        <div class="q-field-label col-xs-12 q-field-margin col-sm-5">
+                            <div class="q-field-label-inner row items-center"><span>How many weeks in advance should recurring pickup dates be shown?</span> </div>
+                        </div>
+                        <div class="q-field-content col-xs-12 col-sm">
+                            <div class="q-slider non-selectable label-always">
+                                <div class="q-slider-handle-container">
+                                    <div class="q-slider-track"></div>
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <!---->
+                                    <div class="q-slider-track active-track" style="width:33.33333333333333%;"></div>
+                                    <div class="q-slider-handle" style="left:33.33333333333333%;border-radius:50%;">
+                                        <div class="q-chip row no-wrap inline items-center q-slider-label no-pointer-events square pointing text-white pointing-down bg-primary label-always">
+                                            <!---->
+                                            <div class="q-chip-main"> 4 </div>
+                                            <!---->
+                                            <!---->
+                                        </div>
+                                        <div class="q-slider-ring"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!---->
+                        </div>
+                    </div>
+                </div>
+                <!---->
+                <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled bg-primary text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Save changes
+         <!----></span></button>
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard disabled">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Reset
+         <!----></span></button>
+                <!---->
+                <button type="button" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard bg-red text-white">
+                    <div class="desktop-only q-focus-helper"></div>
+                    <!----><span class="q-btn-inner row col flex-center"><!----> 
+          Archive
+         <!----></span></button>
+            </form>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots Stores StoreList 1`] = `
+<div class="q-list no-border q-list-highlight">
+    <div class="q-item q-item-division relative-position q-item-link">
+        <div class="q-item-side q-item-side-left q-item-section text-center">
+            <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+        </div>
+        <div class="q-item-main q-item-section">
+            <div class="q-item-label">Teststore1</div>
+        </div>
+    </div>
+    <div class="q-item q-item-division relative-position q-item-link">
+        <div class="q-item-side q-item-side-left q-item-section text-center">
+            <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+        </div>
+        <div class="q-item-main q-item-section">
+            <div class="q-item-label">New Tienda</div>
+        </div>
+    </div>
+    <div class="q-item q-item-division relative-position q-item-link">
+        <div class="q-item-side q-item-side-left q-item-section text-center">
+            <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+        </div>
+        <div class="q-item-main q-item-section">
+            <div class="q-item-label">Supermarkt Arheilgen</div>
+        </div>
+    </div>
+    <div class="q-item q-item-division relative-position q-item-link">
+        <div class="q-item-side q-item-side-left q-item-section text-center">
+            <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+        </div>
+        <div class="q-item-main q-item-section">
+            <div class="q-item-label">asd</div>
+        </div>
+    </div>
+    <div class="q-item q-item-division relative-position q-item-link">
+        <div class="q-item-side q-item-side-left q-item-section text-center">
+            <i aria-hidden="true" class="q-icon fa fa-circle-o text-gray"> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">Just created</span></i>
+        </div>
+        <div class="q-item-main q-item-section">
+            <div class="q-item-label">Griesheimer Markt</div>
+        </div>
+    </div>
+</div>
+`;
+
+exports[`Storyshots VerifyMail error 1`] = `
+<div>
+    <div>
+        <h5>my@email.com</h5>
+        <!---->
+        <!---->
+        <p>
+            <i class="fa fa-exclamation-triangle"></i>
+            this error is returned by the server
+        </p>
+    </div>
+</div>
+`;
+
+exports[`Storyshots VerifyMail pending 1`] = `
+<div>
+    <div>
+        <h5>my@email.com</h5>
+        <q-spinner-undefined size="1rem"></q-spinner-undefined>
+        <!---->
+        <!---->
+    </div>
+</div>
+`;
+
+exports[`Storyshots VerifyMail success 1`] = `
+<div>
+    <div>
+        <h5>my@email.com</h5>
+        <!---->
+        <p>
+            Your e-mail address was successfully verified!
+        </p>
+        <!---->
+    </div>
+</div>
+`;

--- a/src/components/Address/AddressPicker.story.js
+++ b/src/components/Address/AddressPicker.story.js
@@ -1,10 +1,10 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
-import i18n from '@/i18n'
 
 import AddressPicker from './AddressPicker'
 
 storiesOf('AddressPicker', module)
-  .add('Default', () => ({
+  .add('Default', () => defaults({
     components: { AddressPicker },
     template: '<AddressPicker v-model="item" />',
     data () {
@@ -16,9 +16,8 @@ storiesOf('AddressPicker', module)
         },
       }
     },
-    i18n,
   }))
-  .add('With map', () => ({
+  .add('With map', () => defaults({
     components: { AddressPicker },
     template: '<AddressPicker v-model="item" :map="true" />',
     data () {
@@ -30,5 +29,4 @@ storiesOf('AddressPicker', module)
         },
       }
     },
-    i18n,
   }))

--- a/src/components/Conversation/Conversation.story.js
+++ b/src/components/Conversation/Conversation.story.js
@@ -2,9 +2,7 @@ import { storiesOf } from '@storybook/vue'
 
 import Conversation from './Conversation'
 import { messagesMock, currentUserMock } from '>/mockdata'
-import { statusMocks } from '>/helpers'
-import i18n from '@/i18n'
-import router from '@/router'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 const defaultProps = {
   data: {
@@ -19,10 +17,8 @@ const defaultProps = {
 }
 
 storiesOf('Conversation', module)
-  .add('Conversation', () => ({
+  .add('Conversation', () => defaults({
     render: h => h(Conversation, {
       props: defaultProps,
     }),
-    i18n,
-    router,
   }))

--- a/src/components/General/DateAsWords.spec.js
+++ b/src/components/General/DateAsWords.spec.js
@@ -14,7 +14,7 @@ describe('DateAsWords', () => {
     clock = clock.uninstall()
   })
 
-  it('renders 1 day ago', () => {
+  it('renders 1 second ago', () => {
     const wrapper = mountWithDefaults(DateAsWords, {
       propsData: { date },
     })

--- a/src/components/General/General.story.js
+++ b/src/components/General/General.story.js
@@ -3,8 +3,7 @@ import { storiesOf } from '@storybook/vue'
 import KBox from './KBox'
 import KBreadcrumb from './KBreadcrumb'
 import Search from './Search'
-import i18n from '@/i18n'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 import { groupsMock, storesMock, usersMock } from '>/mockdata'
 
 const store = createStore({
@@ -15,22 +14,19 @@ const store = createStore({
 })
 
 storiesOf('General Components', module)
-  .add('KBox', () => ({
+  .add('KBox', () => defaults({
     render: h => h(KBox),
-    i18n,
   }))
 
-  .add('KBreadcrumb', () => ({
+  .add('KBreadcrumb', () => defaults({
     render: h => h(KBreadcrumb, {
       props: {
         breadcrumbs: [{ name: 'Foodsharing Berlin' }, { name: 'SirPlus' }],
       },
     }),
-    i18n,
   }))
 
-  .add('Search', () => ({
+  .add('Search', () => defaults({
     render: h => h(Search),
-    i18n,
     store,
   }))

--- a/src/components/Group/GroupEdit.story.js
+++ b/src/components/Group/GroupEdit.story.js
@@ -1,9 +1,8 @@
 import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 import GroupEdit from './GroupEdit'
-import i18n from '@/i18n'
 
 import { groupsMock, timezones as tzlist } from '>/mockdata'
 
@@ -17,7 +16,7 @@ const timezones = {
 }
 
 storiesOf('GroupEdit', module)
-  .add('create', () => ({
+  .add('create', () => defaults({
     render: h => h(GroupEdit, {
       props: {
         group: groupsMock[0],
@@ -28,5 +27,4 @@ storiesOf('GroupEdit', module)
       },
       on: { save: methods.save },
     }),
-    i18n,
   }))

--- a/src/components/GroupJoin/GroupGallery.story.js
+++ b/src/components/GroupJoin/GroupGallery.story.js
@@ -1,9 +1,8 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import GroupGallery from './GroupGalleryUI'
-import i18n from '@/i18n'
-import router from '@/router'
 import { groupsMock } from '>/mockdata'
 
 const defaultOn = {
@@ -12,17 +11,15 @@ const defaultOn = {
 }
 
 storiesOf('GroupGallery', module)
-  .add('signup view', () => ({
+  .add('signup view', () => defaults({
     render: h => h(GroupGallery, {
       props: {
         otherGroups: groupsMock,
       },
       on: defaultOn,
     }),
-    i18n,
-    router,
   }))
-  .add('switch and explore', () => ({
+  .add('switch and explore', () => defaults({
     render: h => h(GroupGallery, {
       props: {
         myGroups: groupsMock.slice(0, 3),
@@ -30,6 +27,4 @@ storiesOf('GroupGallery', module)
       },
       on: defaultOn,
     }),
-    i18n,
-    router,
   }))

--- a/src/components/GroupJoin/GroupGalleryCard.story.js
+++ b/src/components/GroupJoin/GroupGalleryCard.story.js
@@ -1,8 +1,8 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import GroupGalleryCard from './GroupGalleryCard'
-import i18n from '@/i18n'
 
 import { groupsMock } from '>/mockdata'
 
@@ -12,21 +12,19 @@ const methods = {
 }
 
 storiesOf('GroupGalleryCard', module)
-  .add('isMember = true', () => ({
+  .add('isMember = true', () => defaults({
     components: { GroupGalleryCard },
     template: '<GroupGalleryCard :group="group" :isMember="true" @visit="visit" @preview="preview" />',
     data () { return { group: groupsMock[0] } },
     methods,
-    i18n,
   }))
-  .add('isMember = false', () => ({
+  .add('isMember = false', () => defaults({
     components: { GroupGalleryCard },
     template: '<GroupGalleryCard :group="group" :isMember="false" @preview="preview" />',
     data () { return { group: groupsMock[0] } },
     methods,
-    i18n,
   }))
-  .add('without public description', () => ({
+  .add('without public description', () => defaults({
     components: { GroupGalleryCard },
     template: '<GroupGalleryCard :group="group" :isMember="false" @preview="preview" />',
     data () {
@@ -35,5 +33,4 @@ storiesOf('GroupGalleryCard', module)
       }
     },
     methods,
-    i18n,
   }))

--- a/src/components/GroupJoin/GroupPreview.story.js
+++ b/src/components/GroupJoin/GroupPreview.story.js
@@ -1,8 +1,8 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import GroupPreviewUI from './GroupPreviewUI'
-import i18n from '@/i18n'
 
 import { groupsMock } from '>/mockdata'
 
@@ -12,7 +12,7 @@ const methods = {
 }
 
 storiesOf('GroupPreviewUI', module)
-  .add('is not member', () => ({
+  .add('is not member', () => defaults({
     render: h => h(GroupPreviewUI, {
       props: {
         group: { ...groupsMock[0], isMember: false },
@@ -20,9 +20,8 @@ storiesOf('GroupPreviewUI', module)
       },
       on: { join: methods.join },
     }),
-    i18n,
   }))
-  .add('is member', () => ({
+  .add('is member', () => defaults({
     render: h => h(GroupPreviewUI, {
       props: {
         group: { ...groupsMock[0], isMember: true },
@@ -30,9 +29,8 @@ storiesOf('GroupPreviewUI', module)
       },
       on: { visit: methods.visit },
     }),
-    i18n,
   }))
-  .add('without public description', () => ({
+  .add('without public description', () => defaults({
     render: h => h(GroupPreviewUI, {
       props: {
         group: { ...groupsMock[0], publicDescription: '', isMember: true },
@@ -40,9 +38,8 @@ storiesOf('GroupPreviewUI', module)
       },
       on: { visit: methods.visit },
     }),
-    i18n,
   }))
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(GroupPreviewUI, {
       props: {
         group: { ...groupsMock[4], isMember: false },
@@ -50,9 +47,8 @@ storiesOf('GroupPreviewUI', module)
       },
       on: { join: methods.join },
     }),
-    i18n,
   }))
-  .add('error', () => ({
+  .add('error', () => defaults({
     render: h => h(GroupPreviewUI, {
       props: {
         group: { ...groupsMock[4], isMember: false },
@@ -60,5 +56,4 @@ storiesOf('GroupPreviewUI', module)
       },
       on: { join: methods.join },
     }),
-    i18n,
   }))

--- a/src/components/History/HistoryList.story.js
+++ b/src/components/History/HistoryList.story.js
@@ -1,12 +1,11 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 import { historyMock } from '>/mockdata'
-import i18n from '@/i18n'
-import router from '@/router'
 
 import HistoryList from './HistoryList'
 
 storiesOf('History List', module)
-  .add('Default', () => ({
+  .add('Default', () => defaults({
     render: h => h(HistoryList, {
       props: {
         history: historyMock,
@@ -15,6 +14,4 @@ storiesOf('History List', module)
         fetchMore: () => {},
       },
     }),
-    i18n,
-    router,
   }))

--- a/src/components/Layout/Layout.story.js
+++ b/src/components/Layout/Layout.story.js
@@ -2,13 +2,11 @@ import { storiesOf } from '@storybook/vue'
 
 import KTopbar from './KTopbar'
 import KFooter from './KFooter'
-import i18n from '@/i18n'
-import router from '@/router'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 import { groupsMock, storesMock, usersMock, currentUserMock } from '>/mockdata'
 
 const store = createStore({
-  about: { actions: { fetch () {} } },
+  about: { getters: { get: () => ({}) }, actions: { fetch () {} } },
   groups: { getters: { all: () => groupsMock } },
   stores: { getters: { all: () => storesMock } },
   users: { getters: { all: () => usersMock } },
@@ -19,14 +17,11 @@ const store = createStore({
 })
 
 storiesOf('Layout', module)
-  .add('KTopbar', () => ({
+  .add('KTopbar', () => defaults({
     render: h => h(KTopbar),
-    i18n,
-    router,
     store,
   }))
-  .add('KFooter', () => ({
+  .add('KFooter', () => defaults({
     render: h => h(KFooter),
-    i18n,
     store,
   }))

--- a/src/components/Login/Login.story.js
+++ b/src/components/Login/Login.story.js
@@ -2,11 +2,10 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import Login from './Login'
-import i18n from '@/i18n'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 storiesOf('Login', module)
-  .add('empty', () => ({
+  .add('empty', () => defaults({
     render: h => h(Login, {
       props: {
         status: statusMocks.default(),
@@ -15,9 +14,8 @@ storiesOf('Login', module)
         submit: action('login'),
       },
     }),
-    i18n,
   }))
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(Login, {
       props: {
         status: statusMocks.pending(),
@@ -26,9 +24,8 @@ storiesOf('Login', module)
         submit: action('login'),
       },
     }),
-    i18n,
   }))
-  .add('error', () => ({
+  .add('error', () => defaults({
     render: h => h(Login, {
       props: {
         status: statusMocks.validationError('email', 'is missing'),
@@ -37,5 +34,4 @@ storiesOf('Login', module)
         submit: action('login'),
       },
     }),
-    i18n,
   }))

--- a/src/components/Login/LoginTitle.vue
+++ b/src/components/Login/LoginTitle.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import loginImage from '@/assets/people/cherry.png'
+import loginImage from 'assets/people/cherry.png'
 
 export default {
   components: { },

--- a/src/components/Login/PasswordReset.story.js
+++ b/src/components/Login/PasswordReset.story.js
@@ -2,15 +2,14 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import PasswordReset from './PasswordReset'
-import i18n from '@/i18n'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 const methods = {
   reset: action('send reset request'),
 }
 
 storiesOf('Password Reset', module)
-  .add('empty', () => ({
+  .add('empty', () => defaults({
     render: h => h(PasswordReset, {
       props: {
         status: statusMocks.default(),
@@ -20,9 +19,8 @@ storiesOf('Password Reset', module)
         submit: methods.reset,
       },
     }),
-    i18n,
   }))
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(PasswordReset, {
       props: {
         status: statusMocks.pending(),
@@ -32,9 +30,8 @@ storiesOf('Password Reset', module)
         submit: methods.reset,
       },
     }),
-    i18n,
   }))
-  .add('success', () => ({
+  .add('success', () => defaults({
     render: h => h(PasswordReset, {
       props: {
         status: statusMocks.default(),
@@ -44,9 +41,8 @@ storiesOf('Password Reset', module)
         submit: methods.reset,
       },
     }),
-    i18n,
   }))
-  .add('error', () => ({
+  .add('error', () => defaults({
     render: h => h(PasswordReset, {
       props: {
         status: statusMocks.validationError('email', 'some error'),
@@ -56,5 +52,4 @@ storiesOf('Password Reset', module)
         submit: methods.reset,
       },
     }),
-    i18n,
   }))

--- a/src/components/Login/Signup.story.js
+++ b/src/components/Login/Signup.story.js
@@ -2,15 +2,14 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import Signup from './Signup'
-import i18n from '@/i18n'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 const defaultProps = {
   prefillEmail: () => 'default@example.com',
 }
 
 storiesOf('Signup', module)
-  .add('empty', () => ({
+  .add('empty', () => defaults({
     render: h => h(Signup, {
       props: {
         ...defaultProps,
@@ -20,10 +19,9 @@ storiesOf('Signup', module)
         submit: action('signup'),
       },
     }),
-    i18n,
   }))
 
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(Signup, {
       props: {
         ...defaultProps,
@@ -33,10 +31,9 @@ storiesOf('Signup', module)
         submit: action('signup'),
       },
     }),
-    i18n,
   }))
 
-  .add('error', () => ({
+  .add('error', () => defaults({
     render: h => h(Signup, {
       props: {
         ...defaultProps,
@@ -46,5 +43,4 @@ storiesOf('Signup', module)
         submit: action('signup'),
       },
     }),
-    i18n,
   }))

--- a/src/components/Login/Signup.vue
+++ b/src/components/Login/Signup.vue
@@ -75,7 +75,7 @@
 
 <script>
 import { QCard, QCardTitle, QCardMain, QIcon, QField, QInput, QBtn, QSpinner } from 'quasar'
-import loginImage from '@/assets/people/cherry.png'
+import loginImage from 'assets/people/cherry.png'
 import statusMixin from '@/mixins/statusMixin'
 
 export default {

--- a/src/components/Login/SignupTitle.vue
+++ b/src/components/Login/SignupTitle.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import loginImage from '@/assets/people/cherry.png'
+import loginImage from 'assets/people/cherry.png'
 
 export default {
   components: { },

--- a/src/components/Login/VerifyMail.story.js
+++ b/src/components/Login/VerifyMail.story.js
@@ -1,11 +1,10 @@
 import { storiesOf } from '@storybook/vue'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 import VerifyMail from './VerifyMail'
-import i18n from '@/i18n'
 
 storiesOf('VerifyMail', module)
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(VerifyMail, {
       props: {
         status: statusMocks.pending(),
@@ -13,9 +12,8 @@ storiesOf('VerifyMail', module)
         user: { email: 'my@email.com' },
       },
     }),
-    i18n,
   }))
-  .add('success', () => ({
+  .add('success', () => defaults({
     render: h => h(VerifyMail, {
       props: {
         status: statusMocks.default(),
@@ -23,9 +21,8 @@ storiesOf('VerifyMail', module)
         user: { email: 'my@email.com' },
       },
     }),
-    i18n,
   }))
-  .add('error', () => ({
+  .add('error', () => defaults({
     render: h => h(VerifyMail, {
       props: {
         status: statusMocks.nonFieldError('this error is returned by the server'),
@@ -33,5 +30,4 @@ storiesOf('VerifyMail', module)
         user: { email: 'my@email.com' },
       },
     }),
-    i18n,
   }))

--- a/src/components/Map/GroupMap.spec.js
+++ b/src/components/Map/GroupMap.spec.js
@@ -26,7 +26,9 @@ describe('GroupMap', () => {
     })
     expect(wrapper.findAll(Vue2Leaflet.Map).length).toBe(1)
     expect(wrapper.findAll(Vue2Leaflet.Marker).length).toBe(usersMock.length + storesMock.length)
-    expect(wrapper.findAll(Vue2Leaflet.Marker).hasProp('visible', true)).toBe(true)
+    for (const marker of wrapper.findAll(Vue2Leaflet.Marker)) {
+      expect(marker.props().opacity).toEqual(1)
+    }
     expect(wrapper.findAll(Vue2Leaflet.Popup).length).toBe(usersMock.length + storesMock.length)
   })
 

--- a/src/components/Map/Map.story.js
+++ b/src/components/Map/Map.story.js
@@ -1,3 +1,4 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 
 import MapDemo from './MapDemo'
@@ -6,8 +7,6 @@ import UserMapPreview from './UserMapPreview'
 import StandardMap from './StandardMap'
 import { usersMock, storesMock } from '>/mockdata'
 import L from 'leaflet'
-import router from '@/router'
-import i18n from '@/i18n'
 
 const style = {
   height: '200px',
@@ -16,7 +15,7 @@ const style = {
 const currentGroup = { latitude: 52.5198535, longitude: 13.4385964 }
 
 storiesOf('Map', module)
-  .add('StandardMap', () => ({
+  .add('StandardMap', () => defaults({
     components: { StandardMap },
     template: '<StandardMap :markers="markers" style="height: 600px" />',
     data () {
@@ -35,7 +34,7 @@ storiesOf('Map', module)
       }
     },
   }))
-  .add('StandardMap (selected marker)', () => ({
+  .add('StandardMap (selected marker)', () => defaults({
     components: { StandardMap },
     template: '<StandardMap :markers="markers" :selectedMarkerIds="selectedMarkerIds" style="height: 600px" />',
     data () {
@@ -66,11 +65,11 @@ storiesOf('Map', module)
       }
     },
   }))
-  .add('Demo', () => ({
+  .add('Demo', () => defaults({
     components: { MapDemo },
     template: '<MapDemo style="height: 600px" />',
   }))
-  .add('GroupMap', () => ({
+  .add('GroupMap', () => defaults({
     render: h => h(GroupMap, {
       props: {
         users: usersMock,
@@ -81,10 +80,8 @@ storiesOf('Map', module)
       },
       style,
     }),
-    router,
-    i18n,
   }))
-  .add('GroupMap (selected store)', () => ({
+  .add('GroupMap (selected store)', () => defaults({
     render: h => h(GroupMap, {
       props: {
         users: usersMock,
@@ -96,10 +93,8 @@ storiesOf('Map', module)
       },
       style,
     }),
-    router,
-    i18n,
   }))
-  .add('GroupMap (store has no location)', () => ({
+  .add('GroupMap (store has no location)', () => defaults({
     render: h => h(GroupMap, {
       props: {
         users: usersMock,
@@ -111,10 +106,8 @@ storiesOf('Map', module)
       },
       style,
     }),
-    router,
-    i18n,
   }))
-  .add('GroupMap (group has no location)', () => ({
+  .add('GroupMap (group has no location)', () => defaults({
     render: h => h(GroupMap, {
       props: {
         users: [],
@@ -125,10 +118,8 @@ storiesOf('Map', module)
       },
       style,
     }),
-    router,
-    i18n,
   }))
-  .add('GroupMap (only group location)', () => ({
+  .add('GroupMap (only group location)', () => defaults({
     render: h => h(GroupMap, {
       props: {
         users: [],
@@ -139,13 +130,10 @@ storiesOf('Map', module)
       },
       style,
     }),
-    router,
-    i18n,
   }))
-  .add('UserMapPreview', () => ({
+  .add('UserMapPreview', () => defaults({
     components: { UserMapPreview },
     template: '<UserMapPreview :user="user" style="height: 600px" />',
-    router,
     data () {
       return {
         user: usersMock[0],

--- a/src/components/Pickups/PickupEdit.spec.js
+++ b/src/components/Pickups/PickupEdit.spec.js
@@ -33,7 +33,7 @@ describe('PickupEdit', () => {
     wrapper.vm.edit.maxCollectors++
     expect(wrapper.vm.hasChanged).toBe(true)
     return Vue.nextTick(() => {
-      expect(wrapper.hasClass('changed')).toBe(true)
+      expect(wrapper.classes()).toContain('changed')
     })
   })
 

--- a/src/components/Pickups/PickupItem.story.js
+++ b/src/components/Pickups/PickupItem.story.js
@@ -2,9 +2,7 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import PickupItem from './PickupItem'
-import i18n from '@/i18n'
-import router from '@/router'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 import { currentUserMock, joinablePickup, fullPickup, leavablePickup } from '>/mockdata'
 
 const store = createStore({
@@ -21,18 +19,16 @@ const methods = {
 }
 
 storiesOf('PickupItem', module)
-  .add('Join', () => ({
+  .add('Join', () => defaults({
     render: h => h(PickupItem, {
       props: {
         pickup: joinablePickup,
       },
       on: methods,
     }),
-    i18n,
     store,
-    router,
   }))
-  .add('pending', () => ({
+  .add('pending', () => defaults({
     render: h => h(PickupItem, {
       props: {
         pickup: {
@@ -45,29 +41,23 @@ storiesOf('PickupItem', module)
       },
       on: methods,
     }),
-    i18n,
     store,
-    router,
   }))
-  .add('Full', () => ({
+  .add('Full', () => defaults({
     render: h => h(PickupItem, {
       props: {
         pickup: fullPickup,
       },
       on: methods,
     }),
-    i18n,
     store,
-    router,
   }))
-  .add('Leave', () => ({
+  .add('Leave', () => defaults({
     render: h => h(PickupItem, {
       props: {
         pickup: leavablePickup,
       },
       on: methods,
     }),
-    i18n,
     store,
-    router,
   }))

--- a/src/components/Pickups/PickupList.story.js
+++ b/src/components/Pickups/PickupList.story.js
@@ -3,9 +3,7 @@ import { action } from '@storybook/addon-actions'
 
 import PickupList from './PickupList'
 import { pickupsMock, storesMock, currentUserMock } from '>/mockdata'
-import i18n from '@/i18n'
-import router from '@/router'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 
 const store = createStore({
   auth: {
@@ -16,7 +14,7 @@ const store = createStore({
 })
 
 storiesOf('PickupList', module)
-  .add('Default', () => ({
+  .add('Default', () => defaults({
     render: h => h(PickupList, {
       props: {
         pickups: pickupsMock,
@@ -27,7 +25,5 @@ storiesOf('PickupList', module)
         leave: action('leave'),
       },
     }),
-    i18n,
-    router,
     store,
   }))

--- a/src/components/Pickups/PickupSeriesEdit.spec.js
+++ b/src/components/Pickups/PickupSeriesEdit.spec.js
@@ -61,7 +61,7 @@ describe('PickupSeriesEdit', () => {
     wrapper.vm.edit.maxCollectors++
     expect(wrapper.vm.hasChanged).toBe(true)
     return Vue.nextTick(() => {
-      expect(wrapper.hasClass('changed')).toBe(true)
+      expect(wrapper.classes()).toContain('changed')
     })
   })
 

--- a/src/components/Pickups/PickupSeriesEdit.story.js
+++ b/src/components/Pickups/PickupSeriesEdit.story.js
@@ -2,12 +2,11 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import PickupSeriesEdit from './PickupSeriesEdit'
-import i18n from '@/i18n'
 import { pickupSeriesMock } from '>/mockdata'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 storiesOf('PickupSeriesEdit', module)
-  .add('Default', () => ({
+  .add('Default', () => defaults({
     render (h) {
       return h(PickupSeriesEdit, {
         props: {
@@ -21,5 +20,4 @@ storiesOf('PickupSeriesEdit', module)
         },
       })
     },
-    i18n,
   }))

--- a/src/components/Pickups/PickupUsers.story.js
+++ b/src/components/Pickups/PickupUsers.story.js
@@ -3,9 +3,7 @@ import { action } from '@storybook/addon-actions'
 
 import PickupUsers from './PickupUsers'
 import { joinablePickup, leavablePickup, fullPickup, emptyPickup, currentUserMock } from '>/mockdata'
-import i18n from '@/i18n'
-import router from '@/router'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 
 const store = createStore({
   auth: {
@@ -16,7 +14,7 @@ const store = createStore({
 })
 
 storiesOf('PickupUsers', module)
-  .add('joinable', () => ({
+  .add('joinable', () => defaults({
     render: h => h(PickupUsers, {
       props: {
         pickup: joinablePickup,
@@ -25,11 +23,9 @@ storiesOf('PickupUsers', module)
         join: action('join'),
       },
     }),
-    i18n,
-    router,
     store,
   }))
-  .add('leavable', () => ({
+  .add('leavable', () => defaults({
     render: h => h(PickupUsers, {
       props: {
         pickup: leavablePickup,
@@ -38,21 +34,17 @@ storiesOf('PickupUsers', module)
         leave: action('leave'),
       },
     }),
-    i18n,
-    router,
     store,
   }))
-  .add('full', () => ({
+  .add('full', () => defaults({
     render: h => h(PickupUsers, {
       props: {
         pickup: fullPickup,
       },
     }),
-    i18n,
-    router,
     store,
   }))
-  .add('empty', () => ({
+  .add('empty', () => defaults({
     render: h => h(PickupUsers, {
       props: {
         pickup: emptyPickup,
@@ -61,7 +53,5 @@ storiesOf('PickupUsers', module)
         join: action('join'),
       },
     }),
-    i18n,
-    router,
     store,
   }))

--- a/src/components/ProfilePictures/ProfilePictures.story.js
+++ b/src/components/ProfilePictures/ProfilePictures.story.js
@@ -1,18 +1,15 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 
 import ProfilePicture from './ProfilePicture'
 import { usersMock } from '>/mockdata'
-import i18n from '@/i18n'
-import router from '@/router'
 
 storiesOf('ProfilePicture', module)
-  .add('Profile Pictures', () => ({
+  .add('Profile Pictures', () => defaults({
     render: h => h(ProfilePicture, {
       props: {
         user: usersMock[0],
         size: 100,
       },
     }),
-    i18n,
-    router,
   }))

--- a/src/components/Settings/ProfileEdit.spec.js
+++ b/src/components/Settings/ProfileEdit.spec.js
@@ -32,7 +32,7 @@ describe('ProfileEdit', () => {
     wrapper.vm.edit.displayName = 'a new name'
     expect(wrapper.vm.hasChanged).toBe(true)
     return Vue.nextTick(() => {
-      expect(wrapper.hasClass('changed')).toBe(true)
+      expect(wrapper.classes()).toContain('changed')
     })
   })
 

--- a/src/components/Sidenav/SidenavBox.story.js
+++ b/src/components/Sidenav/SidenavBox.story.js
@@ -5,27 +5,17 @@ import SidenavMapUI from './SidenavMapUI'
 import SidenavGroup from './SidenavGroup'
 import SidenavStoresUI from './SidenavStoresUI'
 import { storesMock as stores, usersMock as users, groupsMock } from '>/mockdata'
-import i18n from '@/i18n'
-import router from '@/router'
-import { createStore } from '>/helpers'
+import { createStore, storybookDefaults as defaults } from '>/helpers'
 
 const store = createStore({
-  groups: {
-    getters: {
-      currentGroupId: () => 1,
-    },
-  },
-  stores: {
-    getters: {
-      all: () => stores,
-    },
-  },
+  currentGroup: { getters: { id: () => 1, roles: () => [] } },
+  stores: { getters: { all: () => stores } },
 })
 
 storiesOf('Sidenav Boxes', module)
   .add('Default', () => SidenavBox)
 
-  .add('Map', () => ({
+  .add('Map', () => defaults({
     render (h) {
       let { showStores, showUsers, toggleUsers, toggleStores } = this
       return h(SidenavMapUI, {
@@ -47,20 +37,15 @@ storiesOf('Sidenav Boxes', module)
         this.showUsers = !this.showUsers
       },
     },
-    i18n,
     store,
   }))
 
-  .add('Group', () => ({
+  .add('Group', () => defaults({
     render: h => h(SidenavGroup),
-    i18n,
-    router,
     store,
   }))
 
-  .add('Stores', () => ({
+  .add('Stores', () => defaults({
     render: h => h(SidenavStoresUI, { props: { stores } }),
-    i18n,
-    router,
     store,
   }))

--- a/src/components/Statistics/AmountViewer.vue
+++ b/src/components/Statistics/AmountViewer.vue
@@ -6,13 +6,12 @@
 </template>
 
 <script>
-import appleImg from '@/assets/feedback/apple.png'
-import appleGuyImg from '@/assets/feedback/appleGuy.png'
-import bagImg from '@/assets/feedback/bag.png'
-// import cartImg from '@/assets/feedback/cart.png'
-import flourImg from '@/assets/feedback/flour.png'
-import flourGuyImg from '@/assets/feedback/flourGuy.png'
-import milkImg from '@/assets/feedback/milk.png'
+import appleImg from 'assets/feedback/apple.png'
+import appleGuyImg from 'assets/feedback/appleGuy.png'
+import bagImg from 'assets/feedback/bag.png'
+import flourImg from 'assets/feedback/flour.png'
+import flourGuyImg from 'assets/feedback/flourGuy.png'
+import milkImg from 'assets/feedback/milk.png'
 
 import AmountBox from './AmountBox'
 
@@ -33,8 +32,6 @@ export default {
     photosArray () {
       let amount = this.amount
       let amountImages = []
-      console.log('selected', this.amount)
-      console.log(amountImages)
       while (amount >= 0.15) {
         if (amount >= 6.0) {
           amountImages.push(bagImg)

--- a/src/components/Statistics/PickupFeedback.vue
+++ b/src/components/Statistics/PickupFeedback.vue
@@ -25,7 +25,7 @@
 <script>
 import { QField, QInput } from 'quasar'
 import AmountPicker from './AmountPicker'
-import cartImg from '@/assets/people/cart.png'
+import cartImg from 'assets/people/cart.png'
 
 export default {
   components: { QField, QInput, AmountPicker },

--- a/src/components/Statistics/Statistics.story.js
+++ b/src/components/Statistics/Statistics.story.js
@@ -1,9 +1,9 @@
+import { storybookDefaults as defaults } from '>/helpers'
 import { storiesOf } from '@storybook/vue'
 
 import AmountPicker from './AmountPicker'
 import AmountBox from './AmountBox'
 import PickupFeedback from './PickupFeedback'
-import i18n from '@/i18n'
 
 const amountPicker = `
 <div style="padding: 2em">
@@ -12,16 +12,15 @@ const amountPicker = `
 `
 
 storiesOf('Statistics', module)
-  .add('AmountPicker', () => ({
+  .add('AmountPicker', () => defaults({
     components: { AmountPicker },
     template: amountPicker,
   }))
-  .add('AmountBox', () => ({
+  .add('AmountBox', () => defaults({
     components: { AmountBox },
     template: '<div style="padding: 2em"><AmountBox :amount="20"/></div>',
   }))
-  .add('PickupFeedback', () => ({
+  .add('PickupFeedback', () => defaults({
     components: { PickupFeedback },
     template: '<div style="padding: 2em"><PickupFeedback/></div>',
-    i18n,
   }))

--- a/src/components/Store/Store.story.js
+++ b/src/components/Store/Store.story.js
@@ -1,23 +1,19 @@
 import { storiesOf } from '@storybook/vue'
 import { storesMock as stores } from '>/mockdata'
-import { statusMocks } from '>/helpers'
+import { statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 import StoreList from './StoreList'
 import StoreEdit from './StoreEdit'
-import i18n from '@/i18n'
-import router from '@/router'
 
 const store = stores[0]
 const otherStores = stores.slice(1)
 
 storiesOf('Stores', module)
-  .add('StoreList', () => ({
+  .add('StoreList', () => defaults({
     render: h => h(StoreList, { props: { stores } }),
-    i18n,
-    router,
   }))
 
-  .add('StoreEdit', () => ({
+  .add('StoreEdit', () => defaults({
     render: h => h(StoreEdit, {
       props: {
         value: store,
@@ -25,11 +21,9 @@ storiesOf('Stores', module)
         status: statusMocks.default(),
       },
     }),
-    i18n,
-    router,
   }))
 
-  .add('StoreEdit (with server error)', () => ({
+  .add('StoreEdit (with server error)', () => defaults({
     render: h => h(StoreEdit, {
       props: {
         value: store,
@@ -37,6 +31,4 @@ storiesOf('Stores', module)
         status: statusMocks.validationError('name', 'a nice server error'),
       },
     }),
-    i18n,
-    router,
   }))

--- a/src/pages/Settings.story.js
+++ b/src/pages/Settings.story.js
@@ -1,12 +1,11 @@
 import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
-import i18n from '@/i18n'
 
 import Settings from '@/pages/Settings'
 import VerificationWarning from '@/components/Settings/VerificationWarning'
 import { currentUserMock } from '>/mockdata'
 
-import { createStore, statusMocks } from '>/helpers'
+import { createStore, statusMocks, storybookDefaults as defaults } from '>/helpers'
 
 const store = createStore({
   auth: {
@@ -34,17 +33,15 @@ const store = createStore({
 })
 
 storiesOf('Settings Page', module)
-  .add('Default', () => ({
+  .add('Default', () => defaults({
     render (h) {
       return h(Settings)
     },
-    i18n,
     store,
   }))
-  .add('verification warning', () => ({
+  .add('verification warning', () => defaults({
     render (h) {
       return h(VerificationWarning)
     },
-    i18n,
     store,
   }))

--- a/src/storyshots.spec.js
+++ b/src/storyshots.spec.js
@@ -1,0 +1,38 @@
+import glob from 'glob'
+import { configure, getStorybook } from '@storybook/vue'
+import { createRenderer } from 'vue-server-renderer'
+import { polyfillRequestAnimationFrame, mountWithDefaults } from '>/helpers'
+polyfillRequestAnimationFrame()
+
+function loadStories () {
+  const files = glob.sync('**/*.story.js', { absolute: true })
+  for (const f of files) {
+    require(f)
+  }
+}
+
+configure(loadStories, module)
+
+const stories = getStorybook()
+
+for (const group of stories) {
+  describe('Storyshots', () => {
+    describe(group.kind, () => {
+      for (const story of group.stories) {
+        it(story.name, async () => {
+          // get the component from storybook
+          const component = story.render()
+
+          // hack: translations don't work if i18n is in component, so delete it
+          delete component.i18n
+
+          const wrapper = mountWithDefaults(component, { clone: false }) // cloning throws errors
+
+          // use server side renderer to get renderered html string
+          const renderer = createRenderer()
+          expect(renderer.renderToString(wrapper.vm)).resolves.toMatchSnapshot()
+        })
+      }
+    })
+  })
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -72,6 +72,14 @@ export function mountWithDefaults (Component, options = {}) {
   return wrapper
 }
 
+export function storybookDefaults (options) {
+  i18n.locale = 'en'
+  return {
+    i18n,
+    ...options,
+  }
+}
+
 export function createValidationError (data) {
   return Object.assign(new Error(), {
     response: {

--- a/test/jestUTC.js
+++ b/test/jestUTC.js
@@ -1,0 +1,10 @@
+/**
+* Runs jest with time zone set to UTC, to have the same environment for all devs and circleci
+*/
+process.env.TZ = 'UTC'
+
+if (process.env.NODE_ENV == null) {
+  process.env.NODE_ENV = 'test'
+}
+
+require('jest').run()

--- a/test/setup/mockRandom.js
+++ b/test/setup/mockRandom.js
@@ -1,0 +1,3 @@
+const mockMath = Object.create(global.Math)
+mockMath.random = () => 0.5
+global.Math = mockMath

--- a/test/setup/setUTC.js
+++ b/test/setup/setUTC.js
@@ -1,1 +1,0 @@
-process.env.TZ = 'UTC'

--- a/test/setup/setUTC.js
+++ b/test/setup/setUTC.js
@@ -1,0 +1,1 @@
+process.env.TZ = 'UTC'

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,12 +241,12 @@
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
 "@types/lodash@^4.14.72":
-  version "4.14.88"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.88.tgz#97eaf2dc668f33ed8e511a5b627035f4ea20b0f5"
+  version "4.14.91"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.91.tgz#794611b28056d16b5436059c6d800b39d573cd3a"
 
 "@types/react@^16.0.18":
-  version "16.0.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.28.tgz#eb0b31272528da8f20477ec27569c4f767315b33"
+  version "16.0.30"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.30.tgz#cca9b180160004df574519c3d7c559fb181d545f"
 
 JSONStream@~1.3.1:
   version "1.3.1"
@@ -654,11 +654,11 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^7.1.6, autoprefixer@^7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.2.tgz#082293b964be00602efacc59aa4aa7df5158bb6e"
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.3.tgz#c2841e38b7940c2d0a9bbffd72c75f33637854f8"
   dependencies:
     browserslist "^2.10.0"
-    caniuse-lite "^1.0.30000780"
+    caniuse-lite "^1.0.30000783"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^6.0.14"
@@ -1695,7 +1695,7 @@ block-stream@*, block-stream@0.0.9:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.1.1, bluebird@^3.4.7, bluebird@^3.5.0, bluebird@~3.5.0:
+bluebird@^3.0.5, bluebird@^3.1.1, bluebird@^3.4.7, bluebird@^3.5.0, bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -2022,12 +2022,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000780"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000780.tgz#8d1977561d00ff0f0ed2b6b66140328ab4504c0a"
+  version "1.0.30000783"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000783.tgz#16b30d47266a4f515cc69ae0316b670c9603cdbe"
 
-caniuse-lite@^1.0.30000780:
-  version "1.0.30000780"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz#1f9095f2efd4940e0ba6c5992ab7a9b64cc35ba4"
+caniuse-lite@^1.0.30000780, caniuse-lite@^1.0.30000783:
+  version "1.0.30000783"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz#9b5499fb1b503d2345d12aa6b8612852f4276ffd"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2311,7 +2311,15 @@ concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-config-chain@~1.1.10, config-chain@~1.1.11:
+condense-newlines@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-whitespace "^0.3.0"
+    kind-of "^3.0.2"
+
+config-chain@~1.1.10, config-chain@~1.1.11, config-chain@~1.1.5:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
   dependencies:
@@ -2405,8 +2413,8 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2944,6 +2952,16 @@ editor@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
 
+editorconfig@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    semver "^5.1.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -3017,10 +3035,10 @@ err-code@^1.0.0:
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
 
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.3, errno@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
   dependencies:
-    prr "~0.0.0"
+    prr "~1.0.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -3247,8 +3265,8 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.12.1:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.1.tgz#5ec1973822b4a066b353770c3c6d69a2a188e880"
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.13.1.tgz#0055e0014464c7eb7878caf549ef2941992b444f"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -3437,6 +3455,12 @@ express@^4.15.2, express@^4.15.4, express@^4.16.2:
     type-is "~1.6.15"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
 
 extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
@@ -3967,8 +3991,8 @@ globals@^10.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
 
 globals@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.0.1.tgz#12a87bb010e5154396acc535e1e43fc753b0e5e8"
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -4553,7 +4577,7 @@ is-es2016-keyword@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz#f6e54e110c5e4f8d265e69d2ed0eaf8cf5f47718"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
@@ -4685,10 +4709,8 @@ is-regex@^1.0.4:
     has "^1.0.1"
 
 is-resolvable@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
-  dependencies:
-    tryit "^1.0.1"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -4715,6 +4737,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
 
 is-windows@^1.0.0:
   version "1.0.1"
@@ -5019,6 +5045,12 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
+jest-serializer-vue@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer-vue/-/jest-serializer-vue-0.3.0.tgz#2128d0c1c83c3bcb2f4fb96104402626bb75506d"
+  dependencies:
+    pretty "2.0.0"
+
 jest-snapshot@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
@@ -5069,6 +5101,15 @@ jest@^21.2.1:
 js-base64@^2.1.9:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.0.tgz#9e566fee624751a1d720c966cd6226d29d4025aa"
+
+js-beautify@^1.6.12:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -5350,6 +5391,10 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
+lodash._reinterpolate@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+
 lodash._root@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
@@ -5417,6 +5462,19 @@ lodash.some@^4.6.0:
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
+lodash.template@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
 
 lodash.union@~4.6.0:
   version "4.6.0"
@@ -5488,6 +5546,12 @@ lru-cache@2.2.x:
 lru-cache@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.3.tgz#51ccd0b4fc0c843587d7a5709ce4d3b7629bedc5"
+
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
 
 lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@~4.1.1:
   version "4.1.1"
@@ -5713,8 +5777,8 @@ moment-duration-format@^1.3.0:
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-1.3.0.tgz#541771b5f87a049cc65540475d3ad966737d6908"
 
 moment@^2.10.3, moment@^2.14.1:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.4.tgz#17e5e2c6ead8819c8ecfad83a0acccb312e94682"
 
 move-concurrently@^1.0.1, move-concurrently@~1.0.1:
   version "1.0.1"
@@ -5871,7 +5935,7 @@ node-version@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
 
-"nopt@2 || 3", nopt@~3.0.6:
+"nopt@2 || 3", nopt@~3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -6897,8 +6961,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -6913,6 +6977,14 @@ pretty-format@^21.2.1:
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
+
+pretty@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
+  dependencies:
+    condense-newlines "^0.2.1"
+    extend-shallow "^2.0.1"
+    js-beautify "^1.6.12"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
@@ -7008,9 +7080,9 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
-prr@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
 ps-node@^0.1.6:
   version "0.1.6"
@@ -7160,8 +7232,8 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 raven-js@^3.20.1:
-  version "3.20.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.20.1.tgz#3170bdb35c05098ddb8548ee5be0687f9d763330"
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.21.0.tgz#609236eb0ec30faf696b552f842a80b426be6258"
 
 raw-body@2.3.2:
   version "2.3.2"
@@ -7219,15 +7291,15 @@ react-icons@^2.2.7:
     react-icon-base "2.1.0"
 
 react-inspector@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.1.tgz#c24f9a0131960b8e63c8392254d34df0717aabdf"
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
 react-modal@^3.1.4:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.7.tgz#21feb937c95cd722bf2d375cada751fdc8189c0e"
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.8.tgz#7d6b1958f44828babd2a1ce826c28fa40d026b0f"
   dependencies:
     exenv "^1.2.0"
     prop-types "^15.5.10"
@@ -7920,6 +7992,10 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+serialize-javascript@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+
 serve-favicon@^2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.4.5.tgz#49d9a46863153a9240691c893d2b0e7d85d6d436"
@@ -8017,6 +8093,10 @@ shvl@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/shvl/-/shvl-1.1.1.tgz#1379655ad2b54f8de1a0d73db4f6ea2f40132352"
 
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -8110,6 +8190,10 @@ source-map@0.1.x, source-map@^0.1.38:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
@@ -8716,10 +8800,6 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tryit@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
-
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -8788,8 +8868,8 @@ uc.micro@^1.0.1, uc.micro@^1.0.3:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
 uglify-js@3.2.x, uglify-js@^3.0.6:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.1.tgz#d6427fd45a25fefc5d196689c0c772a6915e10fe"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.2.tgz#870e4b34ed733d179284f9998efd3293f7fd73f6"
   dependencies:
     commander "~2.12.1"
     source-map "~0.6.1"
@@ -9076,6 +9156,19 @@ vue-router@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.0.1.tgz#d9b05ad9c7420ba0f626d6500d693e60092cc1e9"
 
+vue-server-renderer@^2.5.11:
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.5.11.tgz#82ab4d9a538b252f1a1333862fbbc99595c5f184"
+  dependencies:
+    chalk "^1.1.3"
+    hash-sum "^1.0.2"
+    he "^1.1.0"
+    lodash.template "^4.4.0"
+    lodash.uniq "^4.5.0"
+    resolve "^1.2.0"
+    serialize-javascript "^1.3.0"
+    source-map "0.5.6"
+
 vue-style-loader@^3.0.0, vue-style-loader@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-3.0.3.tgz#623658f81506aef9d121cdc113a4f5c9cac32df7"
@@ -9084,8 +9177,8 @@ vue-style-loader@^3.0.0, vue-style-loader@^3.0.1:
     loader-utils "^1.0.2"
 
 vue-template-compiler@~2.5.9:
-  version "2.5.9"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.9.tgz#7fabc73c8d3d12d32340cd86c5fc33e00e86d686"
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.11.tgz#7dda6905e464ff173c8e70e1dfd1769a7888b7e8"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -9094,9 +9187,9 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue-test-utils@1.0.0-beta.6:
-  version "1.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.6.tgz#65c13dd79ac45a7c4a1709e162bf86fb6a986db0"
+vue-test-utils@1.0.0-beta.8:
+  version "1.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.8.tgz#b4f84ce36f7ae457cdbab9ba21771f4a50d4dabd"
   dependencies:
     lodash "^4.17.4"
 
@@ -9108,8 +9201,8 @@ vue2-leaflet@^0.0.57:
     vue "^2.5.3"
 
 vue@^2.5.3, vue@~2.5.9:
-  version "2.5.9"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.9.tgz#b2380cd040915dca69881dafd121d760952e65f7"
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.11.tgz#80ca2657aa81f03545cd8dd5a2f55454641e6405"
 
 vuelidate@^0.6.0:
   version "0.6.1"
@@ -9172,8 +9265,8 @@ wcwidth@^1.0.0:
     defaults "^1.0.3"
 
 wd@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/wd/-/wd-1.4.1.tgz#6b1ab39aab1728ee276c1a2b6d7321da68b16e8c"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/wd/-/wd-1.5.0.tgz#45c96a16ff9f8c0f9e7ca90f806a8b48bd0034d6"
   dependencies:
     archiver "1.3.0"
     async "2.0.1"


### PR DESCRIPTION
Storyshots are snapshot tests derived from storybook stories: https://github.com/storybooks/storybook/tree/master/addons/storyshots
I adapted the code to our VueJS codebase and it works quite nicely so far!

Some considerations:
- there's only one snapshot file for all stories, it would be nicer to have one file per story
- it would be nicer to have some control over which tests should run, e.g. during debugging
- stories and component tests could share more code, inspiration is https://github.com/mthuret/storybook-addon-specifications
- a Math.random mock was necessary to snapshot AmountPicker reliably, it would be nice to reset it after usage to avoid side effects
- '@/' alias imports for images cause errors in jest, because `moduleNameMapper` does not replace them with the `fileMock` anymore. The `@` alias might be completely unneeded, as webpack already looks in `src/` for imports by default (was disabled in our storybook config before)
- require.context does not work in jest, so I used the `glob` package
- snapshots are not super nice, they contain lots of comments (possibly rendering errors!?)
- [x] fix timezone dependency that breaks down in CircleCI