### PR TITLE
Collapsible SidenavBoxes

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -3677,9 +3677,9 @@ exports[`Storyshots Sidenav Boxes Group 1`] = `
     <div class="q-toolbar row no-wrap items-center relative-position q-toolbar-normal toolbar">
         <i aria-hidden="true" class="q-icon fa fa-fw fa-home"> </i>
         <div class="q-toolbar-title"></div>
-        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-round q-btn-small q-btn-flat">
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat">
             <div class="desktop-only q-focus-helper"></div>
-            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-ellipsis-v"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-fw fa-ellipsis-v"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
             <div class="q-popover animate-scale"
                 style="transform-origin:top left 0px;">
                 <div item-separator="" class="q-list q-list-link">
@@ -3706,8 +3706,11 @@ exports[`Storyshots Sidenav Boxes Group 1`] = `
             <!---->
             </span>
         </button>
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position card-arrow q-btn-rectangle q-btn-standard q-btn-flat">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i class="fa fa-angle-down arrow upsideDown"></i> <!----></span></button>
     </div>
-    <div>
+    <div class="content-div">
         <div>
             <div class="no-padding q-list no-border q-list-highlight">
                 <div class="q-item q-item-division relative-position q-item-link">
@@ -3762,25 +3765,28 @@ exports[`Storyshots Sidenav Boxes Map 1`] = `
         <i aria-hidden="true" class="q-icon fa fa-fw fa-map"> </i>
         <div class="q-toolbar-title"></div>
         <div class="tools">
-            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-round q-btn-small q-btn-flat">
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat" style="padding:0 5px;">
                 <div class="desktop-only q-focus-helper"></div>
-                <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-stack"><i class="fa fa-shopping-cart fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+                <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-fw fa-stack"><i class="fa fa-shopping-cart fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Hide stores
       </span>
                 <!---->
                 </span>
             </button>
-            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-round q-btn-small q-btn-flat">
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat" style="padding:0 5px;">
                 <div class="desktop-only q-focus-helper"></div>
-                <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-stack"><i class="fa fa-user fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+                <!----><span class="q-btn-inner row col flex-center"><!----> <span class="fa-fw fa-stack"><i class="fa fa-user fa-stack-1x"></i> <i class="fa fa-check fa-bot-right fa-stack-1x"></i></span> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Hide users
       </span>
                 <!---->
                 </span>
             </button>
         </div>
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position card-arrow q-btn-rectangle q-btn-standard q-btn-flat">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i class="fa fa-angle-down arrow upsideDown"></i> <!----></span></button>
     </div>
-    <div>
+    <div class="content-div">
         <div class="container map">
             <div class="vue2leaflet-map" style="opacity:1;">
                 <div></div>
@@ -3828,14 +3834,17 @@ exports[`Storyshots Sidenav Boxes Stores 1`] = `
         <div class="q-toolbar-title">
             Stores
         </div>
-        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard q-btn-flat">
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-small q-btn-flat">
             <div class="desktop-only q-focus-helper"></div>
-            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon material-icons">add_circle</i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-fw fa-plus-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;"></span>
             <!---->
             </span>
         </button>
+        <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position card-arrow q-btn-rectangle q-btn-standard q-btn-flat">
+            <div class="desktop-only q-focus-helper"></div>
+            <!----><span class="q-btn-inner row col flex-center"><!----> <i class="fa fa-angle-down arrow upsideDown"></i> <!----></span></button>
     </div>
-    <div>
+    <div class="content-div">
         <div class="no-padding q-list no-border q-list-highlight">
             <div class="q-item q-item-division relative-position q-item-link">
                 <div class="q-item-side q-item-side-left q-item-section text-center">

--- a/src/components/Sidenav/SidenavBox.vue
+++ b/src/components/Sidenav/SidenavBox.vue
@@ -6,17 +6,35 @@
         <slot name="name" />
       </q-toolbar-title>
       <slot name="tools" />
+      <q-btn
+        flat
+        v-if="collapsible"
+        class="card-arrow"
+        @click="collapsed = !collapsed"
+      >
+        <i
+          class="fa fa-angle-down arrow"
+          :class="{ upsideDown: collapsed }"/>
+      </q-btn>
     </q-toolbar>
-    <div>
-      <slot />
-    </div>
+    <transition name="slide-toggle">
+      <div
+        class="content-div"
+        v-show="collapsed">
+        <slot />
+      </div>
+    </transition>
   </q-card>
 </template>
 
 <script>
-import { QCard, QToolbar, QToolbarTitle } from 'quasar'
+import { QSlideTransition, QCard, QToolbar, QToolbarTitle, QBtn } from 'quasar'
 export default {
-  components: { QCard, QToolbar, QToolbarTitle },
+  components: { QSlideTransition, QCard, QToolbar, QToolbarTitle, QBtn },
+  props: {
+    collapsible: { default: true },
+    collapsed: { default: true },
+  },
 }
 </script>
 
@@ -26,4 +44,24 @@ export default {
 .toolbar
   min-height 40px
   height 40px
+.card-arrow
+  margin-left 1em
+  cursor pointer
+  min-width 30px
+  .arrow
+    transition: all .3s ease;
+.upsideDown
+  transform rotate(180deg)
+
+.slide-toggle-enter-active,
+.slide-toggle-leave-active
+  transition max-height .2s
+  overflow hidden
+.slide-toggle-enter-active
+    max-height 1000px
+.slide-toggle-enter,
+.slide-toggle-leave-active
+    max-height 0
+.slide-toggle-leave
+    max-height 1000px
 </style>

--- a/src/components/Sidenav/SidenavBox.vue
+++ b/src/components/Sidenav/SidenavBox.vue
@@ -1,6 +1,9 @@
 <template>
   <q-card class="no-shadow grey-border">
-    <q-toolbar class="toolbar">
+    <q-toolbar
+      class="toolbar"
+      @click.self="$emit('toggleBoxCollapsed')"
+    >
       <slot name="icon" />
       <q-toolbar-title>
         <slot name="name" />

--- a/src/components/Sidenav/SidenavBox.vue
+++ b/src/components/Sidenav/SidenavBox.vue
@@ -10,17 +10,17 @@
         flat
         v-if="collapsible"
         class="card-arrow"
-        @click="collapsed = !collapsed"
+        @click="$emit('toggleBoxCollapsed')"
       >
         <i
           class="fa fa-angle-down arrow"
-          :class="{ upsideDown: collapsed }"/>
+          :class="{ upsideDown: !collapsed }"/>
       </q-btn>
     </q-toolbar>
     <transition name="slide-toggle">
       <div
         class="content-div"
-        v-show="collapsed">
+        v-show="!collapsed">
         <slot />
       </div>
     </transition>
@@ -32,8 +32,8 @@ import { QSlideTransition, QCard, QToolbar, QToolbarTitle, QBtn } from 'quasar'
 export default {
   components: { QSlideTransition, QCard, QToolbar, QToolbarTitle, QBtn },
   props: {
-    collapsible: { default: true },
-    collapsed: { default: true },
+    collapsible: { default: false },
+    collapsed: { default: false },
   },
 }
 </script>

--- a/src/components/Sidenav/SidenavGroup.vue
+++ b/src/components/Sidenav/SidenavGroup.vue
@@ -7,9 +7,8 @@
       <q-btn
         flat
         small
-        round
       >
-        <q-icon name="fa-ellipsis-v" />
+        <q-icon name="fa-fw fa-ellipsis-v" />
         <q-tooltip v-t="'BUTTON.MORE_OPTIONS'" />
         <GroupOptions/>
       </q-btn>

--- a/src/components/Sidenav/SidenavGroup.vue
+++ b/src/components/Sidenav/SidenavGroup.vue
@@ -1,81 +1,13 @@
-<template>
-  <SidenavBox>
-    <template slot="icon">
-      <q-icon name="fa-fw fa-home" />
-    </template>
-    <template slot="tools">
-      <q-btn
-        flat
-        small
-      >
-        <q-icon name="fa-fw fa-ellipsis-v" />
-        <q-tooltip v-t="'BUTTON.MORE_OPTIONS'" />
-        <GroupOptions/>
-      </q-btn>
-    </template>
-
-    <div>
-      <q-list
-        highlight
-        no-border
-        class="no-padding"
-      >
-        <q-item :to="{name: 'group'}">
-          <q-item-side class="text-center">
-            <q-icon name="fa-bullhorn" />
-          </q-item-side>
-          <q-item-main>
-            {{ $t("GROUP.WALL") }}
-          </q-item-main>
-        </q-item>
-        <q-item :to="{name: 'groupPickups'}">
-          <q-item-side class="text-center">
-            <q-icon name="fa-shopping-basket" />
-          </q-item-side>
-          <q-item-main>
-            {{ $t("GROUP.PICKUPS") }}
-          </q-item-main>
-        </q-item>
-        <q-item :to="{name: 'groupDescription'}">
-          <q-item-side class="text-center">
-            <q-icon name="fa-vcard" />
-          </q-item-side>
-          <q-item-main>
-            {{ $t("GROUP.DESCRIPTION") }}
-          </q-item-main>
-        </q-item>
-        <q-item :to="{name: 'groupMembers'}">
-          <q-item-side class="text-center">
-            <q-icon name="fa-users" />
-          </q-item-side>
-          <q-item-main>
-            {{ $t("GROUP.MEMBERS") }}
-          </q-item-main>
-        </q-item>
-        <q-item :to="{name: 'groupHistory'}">
-          <q-item-side class="text-center">
-            <q-icon name="fa-clock-o" />
-          </q-item-side>
-          <q-item-main>
-            {{ $t("GROUP.HISTORY") }}
-          </q-item-main>
-        </q-item>
-      </q-list>
-    </div>
-  </SidenavBox>
-</template>
-
 <script>
-import { QBtn, QList, QItem, QItemSide, QItemMain, QIcon, QTooltip } from 'quasar'
-import SidenavBox from './SidenavBox'
-import GroupOptions from './GroupOptions'
+import { connect } from 'vuex-connect'
+import SidenavGroupUI from './SidenavGroupUI'
 
-export default {
-  components: {
-    SidenavBox, GroupOptions, QBtn, QList, QItem, QItemSide, QItemMain, QIcon, QTooltip,
+export default connect({
+  gettersToProps: {
+    collapsed: 'sidenavBoxes/groupCollapsed',
   },
-}
+  mutationsToEvents: {
+    toggleBoxCollapsed: 'sidenavBoxes/toggleGroupCollapsed',
+  },
+})('SidenavGroup', SidenavGroupUI)
 </script>
-
-<style scoped lang="stylus">
-</style>

--- a/src/components/Sidenav/SidenavGroupUI.vue
+++ b/src/components/Sidenav/SidenavGroupUI.vue
@@ -1,0 +1,88 @@
+<template>
+  <SidenavBox
+    @toggleBoxCollapsed="$emit('toggleBoxCollapsed')"
+    :collapsible="collapsible"
+    :collapsed="collapsed">
+    <template slot="icon">
+      <q-icon name="fa-fw fa-home" />
+    </template>
+    <template slot="tools">
+      <q-btn
+        flat
+        small
+      >
+        <q-icon name="fa-fw fa-ellipsis-v" />
+        <q-tooltip v-t="'BUTTON.MORE_OPTIONS'" />
+        <GroupOptions/>
+      </q-btn>
+    </template>
+
+    <div>
+      <q-list
+        highlight
+        no-border
+        class="no-padding"
+      >
+        <q-item :to="{name: 'group'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-bullhorn" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.WALL") }}
+          </q-item-main>
+        </q-item>
+        <q-item :to="{name: 'groupPickups'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-shopping-basket" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.PICKUPS") }}
+          </q-item-main>
+        </q-item>
+        <q-item :to="{name: 'groupDescription'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-vcard" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.DESCRIPTION") }}
+          </q-item-main>
+        </q-item>
+        <q-item :to="{name: 'groupMembers'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-users" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.MEMBERS") }}
+          </q-item-main>
+        </q-item>
+        <q-item :to="{name: 'groupHistory'}">
+          <q-item-side class="text-center">
+            <q-icon name="fa-clock-o" />
+          </q-item-side>
+          <q-item-main>
+            {{ $t("GROUP.HISTORY") }}
+          </q-item-main>
+        </q-item>
+      </q-list>
+    </div>
+  </SidenavBox>
+</template>
+
+<script>
+import { QBtn, QList, QItem, QItemSide, QItemMain, QIcon, QTooltip } from 'quasar'
+import SidenavBox from './SidenavBox'
+import GroupOptions from './GroupOptions'
+
+export default {
+  components: {
+    SidenavBox, GroupOptions, QBtn, QList, QItem, QItemSide, QItemMain, QIcon, QTooltip,
+  },
+  props: {
+    collapsible: { default: true },
+    collapsed: { required: true },
+  },
+}
+</script>
+
+<style scoped lang="stylus">
+</style>

--- a/src/components/Sidenav/SidenavMap.vue
+++ b/src/components/Sidenav/SidenavMap.vue
@@ -10,10 +10,12 @@ export default connect({
     showUsers: 'map/showUsers',
     selectedStoreId: 'stores/activeStoreId',
     currentGroup: 'currentGroup/value',
+    collapsed: 'sidenavBoxes/mapCollapsed',
   },
   mutationsToEvents: {
     toggleStores: 'map/toggleStores',
     toggleUsers: 'map/toggleUsers',
+    toggleBoxCollapsed: 'sidenavBoxes/toggleMapCollapsed',
   },
 })('SidenavMap', SidenavMapUI)
 </script>

--- a/src/components/Sidenav/SidenavMapAndStores.vue
+++ b/src/components/Sidenav/SidenavMapAndStores.vue
@@ -2,6 +2,7 @@
   <span>
     <SidenavMap/>
     <router-view name="sidenav"/>
+    <router-view name="secondSidenav"/>
     <SidenavStores/>
   </span>
 </template>

--- a/src/components/Sidenav/SidenavMapUI.vue
+++ b/src/components/Sidenav/SidenavMapUI.vue
@@ -10,10 +10,10 @@
       <q-btn
         flat
         small
-        round
         @click="$emit('toggleStores')"
+        style="padding: 0 5px"
       >
-        <span class="fa-stack">
+        <span class="fa-fw fa-stack">
           <i class="fa fa-shopping-cart fa-stack-1x" />
           <i
             v-if="showStores"
@@ -32,10 +32,10 @@
       <q-btn
         flat
         small
-        round
         @click="$emit('toggleUsers')"
+        style="padding: 0 5px"
       >
-        <span class="fa-stack">
+        <span class="fa-fw fa-stack">
           <i class="fa fa-user fa-stack-1x" />
           <i
             v-if="showUsers"

--- a/src/components/Sidenav/SidenavMapUI.vue
+++ b/src/components/Sidenav/SidenavMapUI.vue
@@ -1,5 +1,8 @@
 <template>
-  <SidenavBox>
+  <SidenavBox
+    @toggleBoxCollapsed="$emit('toggleBoxCollapsed')"
+    :collapsible="collapsible"
+    :collapsed="collapsed">
     <template slot="icon">
       <q-icon name="fa-fw fa-map" />
     </template>
@@ -96,6 +99,8 @@ export default {
       required: true,
       type: Object,
     },
+    collapsible: { default: true },
+    collapsed: { required: true },
   },
 }
 </script>

--- a/src/components/Sidenav/SidenavStore.vue
+++ b/src/components/Sidenav/SidenavStore.vue
@@ -5,6 +5,10 @@ import SidenavStoreUI from './SidenavStoreUI'
 export default connect({
   gettersToProps: {
     storeId: 'stores/activeStoreId',
+    collapsed: 'sidenavBoxes/storeCollapsed',
+  },
+  mutationsToEvents: {
+    toggleBoxCollapsed: 'sidenavBoxes/toggleStoreCollapsed',
   },
 })('SidenavStore', SidenavStoreUI)
 </script>

--- a/src/components/Sidenav/SidenavStoreUI.vue
+++ b/src/components/Sidenav/SidenavStoreUI.vue
@@ -7,9 +7,8 @@
       <q-btn
         flat
         small
-        round
       >
-        <q-icon name="fa-ellipsis-v" />
+        <q-icon name="fa-fw fa-ellipsis-v" />
         <q-tooltip v-t="'BUTTON.MORE_OPTIONS'" />
         <StoreOptions/>
       </q-btn>

--- a/src/components/Sidenav/SidenavStoreUI.vue
+++ b/src/components/Sidenav/SidenavStoreUI.vue
@@ -1,5 +1,8 @@
 <template>
-  <SidenavBox>
+  <SidenavBox
+    @toggleBoxCollapsed="$emit('toggleBoxCollapsed')"
+    :collapsible="collapsible"
+    :collapsed="collapsed">
     <template slot="icon">
       <q-icon name="fa-fw fa-shopping-cart" />
     </template>
@@ -48,6 +51,8 @@ import StoreOptions from './StoreOptions'
 export default {
   props: {
     storeId: { required: true },
+    collapsible: { default: true },
+    collapsed: { required: true },
   },
   components: {
     SidenavBox, StoreOptions, QBtn, QList, QItem, QItemSide, QIcon, QItemMain, QTooltip,

--- a/src/components/Sidenav/SidenavStores.vue
+++ b/src/components/Sidenav/SidenavStores.vue
@@ -5,6 +5,10 @@ import SidenavStoresUI from './SidenavStoresUI'
 export default connect({
   gettersToProps: {
     stores: 'stores/byCurrentGroup',
+    collapsed: 'sidenavBoxes/storesCollapsed',
+  },
+  mutationsToEvents: {
+    toggleBoxCollapsed: 'sidenavBoxes/toggleStoresCollapsed',
   },
 })('SidenavStores', SidenavStoresUI)
 </script>

--- a/src/components/Sidenav/SidenavStoresUI.vue
+++ b/src/components/Sidenav/SidenavStoresUI.vue
@@ -10,9 +10,10 @@
       <q-btn
         v-if="hasStores"
         flat
+        small
         @click="$router.push({name: 'storeCreate'})"
       >
-        <q-icon name="add circle" />
+        <q-icon name="fa-fw fa-plus-circle" />
         <q-tooltip v-t="'BUTTON.CREATE'" />
       </q-btn>
     </template>

--- a/src/components/Sidenav/SidenavStoresUI.vue
+++ b/src/components/Sidenav/SidenavStoresUI.vue
@@ -1,5 +1,8 @@
 <template>
-  <SidenavBox>
+  <SidenavBox
+    @toggleBoxCollapsed="$emit('toggleBoxCollapsed')"
+    :collapsible="collapsible"
+    :collapsed="collapsed">
     <template slot="icon">
       <q-icon name="fa-fw fa-shopping-cart" />
     </template>
@@ -31,6 +34,8 @@ import StoreList from '@/components/Store/StoreList'
 export default {
   props: {
     stores: { required: true, type: Array },
+    collapsible: { default: true },
+    collapsed: { required: true },
   },
   components: {
     SidenavBox, QBtn, QList, QItem, QItemMain, QItemSide, QIcon, QTooltip, StoreList, QItemTile,

--- a/src/components/Wall/AvailablePickups.vue
+++ b/src/components/Wall/AvailablePickups.vue
@@ -11,7 +11,7 @@
         class="card-arrow"
         :class="{ upsideDown: showPickups }"
       >
-        <i class="fa fa-arrow-circle-down"/>
+        <i class="fa fa-angle-down"/>
       </div>
     </q-card>
     <transition-group

--- a/src/components/Wall/JoinedPickups.vue
+++ b/src/components/Wall/JoinedPickups.vue
@@ -11,7 +11,7 @@
         class="card-arrow"
         :class="{ upsideDown: showPickups }"
       >
-        <i class="fa fa-arrow-circle-down"/>
+        <i class="fa fa-angle-down"/>
       </div>
     </q-card>
     <transition-group

--- a/src/pages/MainLayout.vue
+++ b/src/pages/MainLayout.vue
@@ -48,7 +48,7 @@
         </template>
         <MainAlerts />
         <div class="mainContent row justify-between no-wrap">
-          <div class="whiteSpace gt-sm" />
+          <div class="whiteSpace gt-lg" />
           <router-view
             v-if="!$q.platform.is.mobile"
             class="sidenav-desktop"
@@ -57,7 +57,8 @@
           <div class="mainContent-page">
             <router-view />
           </div>
-          <div class="whiteSpace gt-sm desktop-only"/>
+          <div class="whiteSpace gt-lg desktop-only"/>
+          <div class="whiteSpace gt-lg desktop-only"/>
         </div>
         <KFooter v-if="$q.platform.is.mobile && !isLoggedIn" />
 
@@ -104,6 +105,7 @@ export default {
 </script>
 
 <style scoped lang="stylus">
+@import '~variables'
 .sidenav-desktop
   margin-right 1em
   width 30%
@@ -116,10 +118,21 @@ body.desktop .mainContent-page
   width 100%
   margin-bottom 4.5em
 .whiteSpace
-  width 5%
+  width 1%
+@media screen and (min-width: 1500px)
+  .whiteSpace
+    width 10%
 
 .background
   background-image url('../assets/repeating_grey.jpg')
   background-size: 600px
   background-attachment:fixed
+</style>
+
+<style lang="stylus">
+@import '~variables'
+
+@media screen and (max-width: $breakpoint-lg)
+  .sidenav-desktop > .q-card
+    margin 5px 0
 </style>

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -241,7 +241,12 @@ export default [
         },
         components: {
           default: StoreLayout,
+          secondSidenav: GroupGroupSidenav,
           sidenav: GroupStoreSidenav,
+        },
+        beforeEnter: (to, from, next) => {
+          console.log('close group sidenav')
+          next()
         },
         children: [
           {

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -241,12 +241,8 @@ export default [
         },
         components: {
           default: StoreLayout,
-          secondSidenav: GroupGroupSidenav,
-          sidenav: GroupStoreSidenav,
-        },
-        beforeEnter: (to, from, next) => {
-          console.log('close group sidenav')
-          next()
+          sidenav: GroupGroupSidenav,
+          secondSidenav: GroupStoreSidenav,
         },
         children: [
           {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,6 +25,7 @@ import pickupSeries from './modules/pickupSeries'
 import route from './modules/route'
 import routeError from './modules/routeError'
 import search from './modules/search'
+import sidenavBoxes from './modules/sidenavBoxes'
 import stores from './modules/stores'
 import timezones from './modules/timezones'
 import users from './modules/users'
@@ -56,6 +57,7 @@ export default new Vuex.Store({
     loadingprogress,
     history,
     search,
+    sidenavBoxes,
     agreements,
     routeError,
     fcm,

--- a/src/store/modules/sidenavBoxes.js
+++ b/src/store/modules/sidenavBoxes.js
@@ -1,5 +1,3 @@
-import { withMeta, createMetaModule } from '@/store/helpers'
-
 function initialState () {
   return {
     mapCollapsed: false,
@@ -11,7 +9,6 @@ function initialState () {
 
 export default {
   namespaced: true,
-  modules: { meta: createMetaModule() },
   state: initialState(),
   getters: {
     mapCollapsed: state => state.mapCollapsed,
@@ -20,16 +17,14 @@ export default {
     groupCollapsed: state => state.groupCollapsed,
   },
   actions: {
-    ...withMeta({
-      hideGroupSidenav ({ commit }) {
-        console.log('test1')
-        commit('hideGroup')
-      },
-      showGroupSidenav ({ commit }) {
-        console.log('test2')
-        commit('showGroup')
-      },
-    }),
+    hideGroupSidenav ({ commit }) {
+      console.log('test1')
+      commit('hideGroup')
+    },
+    showGroupSidenav ({ commit }) {
+      console.log('test2')
+      commit('showGroup')
+    },
   },
   mutations: {
     toggleMapCollapsed (state) { state.mapCollapsed = !state.mapCollapsed },

--- a/src/store/modules/sidenavBoxes.js
+++ b/src/store/modules/sidenavBoxes.js
@@ -1,0 +1,44 @@
+import { withMeta, createMetaModule } from '@/store/helpers'
+
+function initialState () {
+  return {
+    mapCollapsed: false,
+    storeCollapsed: false,
+    storesCollapsed: false,
+    groupCollapsed: false,
+  }
+}
+
+export default {
+  namespaced: true,
+  modules: { meta: createMetaModule() },
+  state: initialState(),
+  getters: {
+    mapCollapsed: state => state.mapCollapsed,
+    storeCollapsed: state => state.storeCollapsed,
+    storesCollapsed: state => state.storesCollapsed,
+    groupCollapsed: state => state.groupCollapsed,
+  },
+  actions: {
+    ...withMeta({
+      hideGroupSidenav ({ commit }) {
+        console.log('test1')
+        commit('hideGroup')
+      },
+      showGroupSidenav ({ commit }) {
+        console.log('test2')
+        commit('showGroup')
+      },
+    }),
+  },
+  mutations: {
+    toggleMapCollapsed (state) { state.mapCollapsed = !state.mapCollapsed },
+    toggleStoreCollapsed (state) { state.storeCollapsed = !state.storeCollapsed },
+    toggleStoresCollapsed (state) { state.storesCollapsed = !state.storesCollapsed },
+    toggleGroupCollapsed (state) { state.groupCollapsed = !state.groupCollapsed },
+    hideGroup (state) { state.groupCollapsed = true },
+    showGroup (state) { state.groupCollapsed = false },
+  },
+}
+
+export const state = initialState()

--- a/src/store/modules/stores.js
+++ b/src/store/modules/stores.js
@@ -62,11 +62,13 @@ export default {
         }
       }
       dispatch('pickups/setStoreFilter', storeId, {root: true})
+      dispatch('sidenavBoxes/hideGroupSidenav', null, {root: true})
       commit('select', storeId)
     },
 
     async clearSelectedStore ({ commit, dispatch }) {
       dispatch('pickups/clearStoreFilter', null, { root: true })
+      dispatch('sidenavBoxes/showGroupSidenav', null, {root: true})
       commit('clearSelected')
     },
 


### PR DESCRIPTION
Enables 'Collapse' functionality for sidenav boxes on desktop.

Makes it possible to display group Sidenav all the time, without it taking to much space.
Group sidenav is folded in on storePages automatically now.

On group pages, the StoreSidenav is hidden.

![screenshot from 2017-12-28 22-28-22](https://user-images.githubusercontent.com/16825880/34423728-7283ef44-ec1e-11e7-8269-7c0c2385ab77.png)
