### PR TITLE
Chrome Pickup Sort Fix

### DIFF
--- a/src/pages/Group/Pickups.vue
+++ b/src/pages/Group/Pickups.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <PickupItem
-      v-for="pickup in pickups"
+      v-for="pickup in sortedPickups"
       :key="pickup.id"
       :pickup="pickup"
       @join="join"
@@ -60,6 +60,14 @@ export default {
     }),
     hasPickups () {
       return this.pickups && this.pickups.length > 0
+    },
+    sortedPickups: function () {
+      function compare (a, b) {
+        if (a.date < b.date) { return -1 }
+        if (a.date > b.date) { return 1 }
+        return 0
+      }
+      return this.pickups.slice(0).sort(compare)
     },
   },
 }

--- a/src/pages/Group/Pickups.vue
+++ b/src/pages/Group/Pickups.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <PickupItem
-      v-for="pickup in sortedPickups"
+      v-for="pickup in pickups"
       :key="pickup.id"
       :pickup="pickup"
       @join="join"
@@ -60,14 +60,6 @@ export default {
     }),
     hasPickups () {
       return this.pickups && this.pickups.length > 0
-    },
-    sortedPickups: function () {
-      function compare (a, b) {
-        if (a.date < b.date) { return -1 }
-        if (a.date > b.date) { return 1 }
-        return 0
-      }
-      return this.pickups.slice(0).sort(compare)
     },
   },
 }

--- a/src/store/modules/pickups.js
+++ b/src/store/modules/pickups.js
@@ -33,7 +33,7 @@ export default {
       }
     },
     all: (state, getters, rootState, rootGetters) => {
-      return state.idList.map(getters.get)
+      return state.idList.map(getters.get).sort(sortByDate)
     },
     filtered: (state, getters) => {
       return getters.all.filter(e => !state.storeIdFilter || (e.store && e.store.id === state.storeIdFilter))

--- a/src/store/modules/pickups.js
+++ b/src/store/modules/pickups.js
@@ -33,7 +33,7 @@ export default {
       }
     },
     all: (state, getters, rootState, rootGetters) => {
-      return state.idList.map(getters.get).sort(sortByDate)
+      return state.idList.map(getters.get)
     },
     filtered: (state, getters) => {
       return getters.all.filter(e => !state.storeIdFilter || (e.store && e.store.id === state.storeIdFilter))
@@ -239,6 +239,8 @@ export function isWithinOneWeek (pickup) {
   return pickup.date < new Date(+new Date() + 6096e5)
 }
 
-export function sortByDate (a, b) {
-  return a.date > b.date
-}
+// export function sortByDate (a, b) {
+//   if (a.date > b.date) { return a }
+//   if (a.date < b.date) { return b }
+//   return 0
+// }

--- a/src/store/modules/pickups.js
+++ b/src/store/modules/pickups.js
@@ -239,8 +239,6 @@ export function isWithinOneWeek (pickup) {
   return pickup.date < new Date(+new Date() + 6096e5)
 }
 
-// export function sortByDate (a, b) {
-//   if (a.date > b.date) { return a }
-//   if (a.date < b.date) { return b }
-//   return 0
-// }
+export function sortByDate (a, b) {
+  return a.date - b.date
+}


### PR DESCRIPTION
Couple things: 
1. I don't know if doing the sort within the component is bad practice/not what you want.
2. For the line  'return this.pickups.slice(0).sort(compare)', I added the slice(0) because the linter would not accept it without me doing that. I don't know a better solution or if if this is even doing anything.

OK, Cheers 👍 

closes #873