### PR TITLE
Group preview animaions

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -658,11 +658,11 @@ exports[`Storyshots GroupGallery signup view 1`] = `
     </div>
     <!---->
     <!---->
-    <h4 class="text-primary">
+    <h4 class="text-primary generic-padding">
         Which group do you want to join?
     </h4>
     <div class="q-card">
-        <div class="q-if row no-wrap items-center relative-position q-input q-search searchbar text-primary">
+        <div class="q-if row no-wrap items-center relative-position q-input q-search searchbar text-primary" style="min-height:0;">
             <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
             <div class="q-if-inner col row no-wrap items-center relative-position">
                 <!---->
@@ -675,206 +675,205 @@ exports[`Storyshots GroupGallery signup view 1`] = `
             </div>
             <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
         </div>
-    </div>
-    <div class="row">
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            05_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
+    </div> <span class="row"><div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch"><div class="q-card groupPreviewCard"><div class="q-card-primary q-card-container row no-wrap ellipsis"><div class="col column"><div class="q-card-title">
+    05_testgroup
+    </div><div class="q-card-subtitle"><span>
       18 Members
     </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>This is the public description
-                                <br> It would make sense if it was markdown</p>
-                            <h1>then this would be a header</h1>
-                            <p>
-                                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+</div>
+<div class="col-auto self-center q-card-title-extra"></div>
+</div>
+<div class="q-card-main q-card-container fixed-height">
+    <div class="smaller-text">
+        <div class="parsed">
+            <p>This is the public description
+                <br> It would make sense if it was markdown</p>
+            <h1>then this would be a header</h1>
+            <p>
+                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+            </p>
+        </div>
+    </div>
+</div>
+<div class="q-card-separator"></div>
+<div class="q-card-actions q-card-actions-horiz row justify-start">
+    <!---->
+    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+        <div class="desktop-only q-focus-helper"></div>
+        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Show public group information
       </span>
-                        <!---->
-                        </span>
-                    </button>
+        <!---->
+        </span>
+    </button>
+</div>
+</div>
+<!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    06_testgroup
                 </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            06_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
+                <div class="q-card-subtitle"><span>
       13 Members
     </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
       (This group has no public description... yet)
     </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Show public group information
       </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            02_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      33 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
-      (This group has no public description... yet)
-    </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            03_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      12 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
-      (This group has no public description... yet)
-    </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            01_testgroup_with_maps_and_password
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      53 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            04_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      18 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>Hi there! This it the public description!</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
+                <!---->
+                </span>
+            </button>
         </div>
     </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    02_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      33 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    03_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      12 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    01_testgroup_with_maps_and_password
+                </div>
+                <div class="q-card-subtitle"><span>
+      53 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height">
+            <div class="smaller-text">
+                <div class="parsed">
+                    <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+                </div>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    04_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height">
+            <div class="smaller-text">
+                <div class="parsed">
+                    <p>Hi there! This it the public description!</p>
+                </div>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+</span>
 </div>
 `;
 
@@ -1018,11 +1017,11 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
             </div>
         </div>
     </div>
-    <h4 class="text-primary">
+    <h4 class="text-primary generic-padding">
         Which group do you want to join?
     </h4>
     <div class="q-card">
-        <div class="q-if row no-wrap items-center relative-position q-input q-search searchbar text-primary">
+        <div class="q-if row no-wrap items-center relative-position q-input q-search searchbar text-primary" style="min-height:0;">
             <i aria-hidden="true" class="q-if-control q-if-control-before q-icon material-icons">search</i>
             <div class="q-if-inner col row no-wrap items-center relative-position">
                 <!---->
@@ -1035,206 +1034,205 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
             </div>
             <i aria-hidden="true" class="q-if-control q-icon material-icons hidden">cancel</i>
         </div>
-    </div>
-    <div class="row">
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            05_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
+    </div> <span class="row"><div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch"><div class="q-card groupPreviewCard"><div class="q-card-primary q-card-container row no-wrap ellipsis"><div class="col column"><div class="q-card-title">
+    05_testgroup
+    </div><div class="q-card-subtitle"><span>
       18 Members
     </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>This is the public description
-                                <br> It would make sense if it was markdown</p>
-                            <h1>then this would be a header</h1>
-                            <p>
-                                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+</div>
+<div class="col-auto self-center q-card-title-extra"></div>
+</div>
+<div class="q-card-main q-card-container fixed-height">
+    <div class="smaller-text">
+        <div class="parsed">
+            <p>This is the public description
+                <br> It would make sense if it was markdown</p>
+            <h1>then this would be a header</h1>
+            <p>
+                <a href="www.google.de" target="_blank" rel="noopener nofollow noreferrer">and this a link</a>
+            </p>
+        </div>
+    </div>
+</div>
+<div class="q-card-separator"></div>
+<div class="q-card-actions q-card-actions-horiz row justify-start">
+    <!---->
+    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+        <div class="desktop-only q-focus-helper"></div>
+        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Show public group information
       </span>
-                        <!---->
-                        </span>
-                    </button>
+        <!---->
+        </span>
+    </button>
+</div>
+</div>
+<!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    06_testgroup
                 </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            06_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
+                <div class="q-card-subtitle"><span>
       13 Members
     </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
       (This group has no public description... yet)
     </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
         Show public group information
       </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            02_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      33 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
-      (This group has no public description... yet)
-    </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            03_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      12 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
-      (This group has no public description... yet)
-    </span></div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            01_testgroup_with_maps_and_password
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      53 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
-            <div class="q-card groupPreviewCard">
-                <div class="q-card-primary q-card-container row no-wrap ellipsis">
-                    <div class="col column">
-                        <div class="q-card-title">
-                            04_testgroup
-                        </div>
-                        <div class="q-card-subtitle"><span>
-      18 Members
-    </span></div>
-                    </div>
-                    <div class="col-auto self-center q-card-title-extra"></div>
-                </div>
-                <div class="q-card-main q-card-container fixed-height">
-                    <div class="smaller-text">
-                        <div class="parsed">
-                            <p>Hi there! This it the public description!</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="q-card-separator"></div>
-                <div class="q-card-actions q-card-actions-horiz row justify-start">
-                    <!---->
-                    <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
-                        <div class="desktop-only q-focus-helper"></div>
-                        <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
-        Show public group information
-      </span>
-                        <!---->
-                        </span>
-                    </button>
-                </div>
-            </div>
+                <!---->
+                </span>
+            </button>
         </div>
     </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    02_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      33 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    03_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      12 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height"><span class="text-italic">
+      (This group has no public description... yet)
+    </span></div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    01_testgroup_with_maps_and_password
+                </div>
+                <div class="q-card-subtitle"><span>
+      53 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height">
+            <div class="smaller-text">
+                <div class="parsed">
+                    <p>To enter this group, type &quot;abc&quot; as password (if nobody changed it!)</p>
+                </div>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+<div class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch">
+    <div class="q-card groupPreviewCard">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+            <div class="col column">
+                <div class="q-card-title">
+                    04_testgroup
+                </div>
+                <div class="q-card-subtitle"><span>
+      18 Members
+    </span></div>
+            </div>
+            <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
+        <div class="q-card-main q-card-container fixed-height">
+            <div class="smaller-text">
+                <div class="parsed">
+                    <p>Hi there! This it the public description!</p>
+                </div>
+            </div>
+        </div>
+        <div class="q-card-separator"></div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start">
+            <!---->
+            <button class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-flat q-btn-rectangle q-btn-standard">
+                <div class="desktop-only q-focus-helper"></div>
+                <!----><span class="q-btn-inner row col flex-center"><!----> <i aria-hidden="true" class="q-icon fa fa-info-circle"> </i> <span class="q-tooltip animate-scale" style="transform-origin:bottom center 0px;">
+        Show public group information
+      </span>
+                <!---->
+                </span>
+            </button>
+        </div>
+    </div>
+    <!---->
+</div>
+</span>
 </div>
 `;
 
@@ -1358,23 +1356,12 @@ exports[`Storyshots GroupGalleryCard without public description 1`] = `
 
 exports[`Storyshots GroupPreviewUI error 1`] = `
 <div>
-    <div class="q-alert-container">
-        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
-            <div class="q-alert-icon row col-auto flex-center">
-                <i aria-hidden="true" class="q-icon material-icons">info</i>
-            </div>
-            <div class="q-alert-content col self-center">
-                By joining this group, your profile data will become visible to other group members.
-                <!---->
-            </div>
-            <!---->
-        </div>
-    </div>
-    <div class="q-card">
+    <div class="q-card shadow-6">
         <div class="q-card-primary q-card-container row no-wrap">
             <div class="col column">
                 <div class="q-card-title">
                     01_testgroup_with_maps_and_password
+                    <!---->
                 </div>
                 <div class="q-card-subtitle"><span>
         53 Members
@@ -1388,7 +1375,9 @@ exports[`Storyshots GroupPreviewUI error 1`] = `
             </div>
         </div>
         <div class="q-card-separator"></div>
-        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span style="width:100%;"><form name="joingroup"><div class="q-alert-container"><div class="q-alert row no-wrap shadow-2 bg-tertiary"><div class="q-alert-icon row col-auto flex-center"><i aria-hidden="true" class="q-icon material-icons">info</i></div> <div class="q-alert-content col self-center">
+            By joining this group, your profile data will become visible to other group members.
+           <!----></div> <!----></div></div> <div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
     </div>
     <div class="q-field-content col-xs-12 col-sm">
         <div class="q-if row no-wrap items-center relative-position q-input text-primary">
@@ -1411,7 +1400,7 @@ exports[`Storyshots GroupPreviewUI error 1`] = `
     </div>
 </div>
 </div>
-<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard">
+<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position float-right generic-margin q-btn-rectangle q-btn-standard bg-secondary text-white">
     <div class="desktop-only q-focus-helper"></div>
     <!----><span class="q-btn-inner row col flex-center"><!----> 
             Join
@@ -1426,12 +1415,12 @@ exports[`Storyshots GroupPreviewUI error 1`] = `
 
 exports[`Storyshots GroupPreviewUI is member 1`] = `
 <div>
-    <!---->
-    <div class="q-card">
+    <div class="q-card shadow-6">
         <div class="q-card-primary q-card-container row no-wrap">
             <div class="col column">
                 <div class="q-card-title">
                     05_testgroup
+                    <!---->
                 </div>
                 <div class="q-card-subtitle"><span>
         18 Members
@@ -1467,23 +1456,12 @@ exports[`Storyshots GroupPreviewUI is member 1`] = `
 
 exports[`Storyshots GroupPreviewUI is not member 1`] = `
 <div>
-    <div class="q-alert-container">
-        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
-            <div class="q-alert-icon row col-auto flex-center">
-                <i aria-hidden="true" class="q-icon material-icons">info</i>
-            </div>
-            <div class="q-alert-content col self-center">
-                By joining this group, your profile data will become visible to other group members.
-                <!---->
-            </div>
-            <!---->
-        </div>
-    </div>
-    <div class="q-card">
+    <div class="q-card shadow-6">
         <div class="q-card-primary q-card-container row no-wrap">
             <div class="col column">
                 <div class="q-card-title">
                     05_testgroup
+                    <!---->
                 </div>
                 <div class="q-card-subtitle"><span>
         18 Members
@@ -1502,7 +1480,9 @@ exports[`Storyshots GroupPreviewUI is not member 1`] = `
             </div>
         </div>
         <div class="q-card-separator"></div>
-        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><!----> <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard"><div class="desktop-only q-focus-helper"></div> <!----> <span class="q-btn-inner row col flex-center"><!----> 
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span style="width:100%;"><form name="joingroup"><div class="q-alert-container"><div class="q-alert row no-wrap shadow-2 bg-tertiary"><div class="q-alert-icon row col-auto flex-center"><i aria-hidden="true" class="q-icon material-icons">info</i></div> <div class="q-alert-content col self-center">
+            By joining this group, your profile data will become visible to other group members.
+           <!----></div> <!----></div></div> <!----> <button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position float-right generic-margin q-btn-rectangle q-btn-standard bg-secondary text-white"><div class="desktop-only q-focus-helper"></div> <!----> <span class="q-btn-inner row col flex-center"><!----> 
             Join
            <!----></span></button>
             </form>
@@ -1515,23 +1495,12 @@ exports[`Storyshots GroupPreviewUI is not member 1`] = `
 
 exports[`Storyshots GroupPreviewUI pending 1`] = `
 <div>
-    <div class="q-alert-container">
-        <div class="q-alert row no-wrap shadow-2 bg-tertiary">
-            <div class="q-alert-icon row col-auto flex-center">
-                <i aria-hidden="true" class="q-icon material-icons">info</i>
-            </div>
-            <div class="q-alert-content col self-center">
-                By joining this group, your profile data will become visible to other group members.
-                <!---->
-            </div>
-            <!---->
-        </div>
-    </div>
-    <div class="q-card">
+    <div class="q-card shadow-6">
         <div class="q-card-primary q-card-container row no-wrap">
             <div class="col column">
                 <div class="q-card-title">
                     01_testgroup_with_maps_and_password
+                    <!---->
                 </div>
                 <div class="q-card-subtitle"><span>
         53 Members
@@ -1545,7 +1514,9 @@ exports[`Storyshots GroupPreviewUI pending 1`] = `
             </div>
         </div>
         <div class="q-card-separator"></div>
-        <div class="q-card-actions q-card-actions-horiz row justify-start"><span><form name="joingroup"><div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
+        <div class="q-card-actions q-card-actions-horiz row justify-start"><span style="width:100%;"><form name="joingroup"><div class="q-alert-container"><div class="q-alert row no-wrap shadow-2 bg-tertiary"><div class="q-alert-icon row col-auto flex-center"><i aria-hidden="true" class="q-icon material-icons">info</i></div> <div class="q-alert-content col self-center">
+            By joining this group, your profile data will become visible to other group members.
+           <!----></div> <!----></div></div> <div class="q-field row no-wrap items-start"><i aria-hidden="true" class="q-field-icon q-field-margin q-icon fa fa-lock"> </i> <div class="row col"><div class="q-field-label col-xs-12 q-field-margin col-sm-5"><div class="q-field-label-inner row items-center"><span>This group requires a password</span>            </div>
     </div>
     <div class="q-field-content col-xs-12 col-sm">
         <div class="q-if row no-wrap items-center relative-position q-input text-primary">
@@ -1568,7 +1539,7 @@ exports[`Storyshots GroupPreviewUI pending 1`] = `
     </div>
 </div>
 </div>
-<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position q-btn-rectangle q-btn-standard">
+<button type="submit" class="q-btn row inline flex-center q-focusable q-hoverable relative-position float-right generic-margin q-btn-rectangle q-btn-standard bg-secondary text-white">
     <div class="desktop-only q-focus-helper"></div>
     <!----><span class="q-btn-inner row col flex-center"><!----> 
             Join
@@ -1583,12 +1554,12 @@ exports[`Storyshots GroupPreviewUI pending 1`] = `
 
 exports[`Storyshots GroupPreviewUI without public description 1`] = `
 <div>
-    <!---->
-    <div class="q-card">
+    <div class="q-card shadow-6">
         <div class="q-card-primary q-card-container row no-wrap">
             <div class="col column">
                 <div class="q-card-title">
                     05_testgroup
+                    <!---->
                 </div>
                 <div class="q-card-subtitle"><span>
         18 Members

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -59,12 +59,21 @@
         v-for="group in filteredGroups"
         :key="group.id"
         class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch"
+        v-if="!previewOpened || group.id === openedGroupId || filteredGroups.length == 1"
+        :class="group.id === openedGroupId || filteredGroups.length == 1 ? 'col-xs-12 col-sm-12 col-md-12' : ''"
       >
         <GroupGalleryCard
           :group="group"
+          v-if="!previewOpened && filteredGroups.length != 1"
           :is-member="false"
-          @preview="$emit('preview', { groupId: group.id })"
+          @preview="showPreview(group)"
         />
+        <GroupPreview
+          v-if="previewOpened || filteredGroups.length == 1"
+          :show-close="filteredGroups.length != 1"
+          @close="hidePreview()"
+          :group="group"
+          :is-logged-in="isLoggedIn"/>
       </div>
     </transition-group>
   </div>
@@ -72,13 +81,30 @@
 
 <script>
 import GroupGalleryCard from './GroupGalleryCard'
+import GroupPreview from './GroupPreview'
 import { QAlert, QSearch, QCard } from 'quasar'
 
 export default {
   data () {
     return {
       search: '',
+      previewOpened: false,
+      openedGroupId: -1,
     }
+  },
+  methods: {
+    showPreview (group) {
+      // $emit('preview', { groupId: group.id })
+      window.history.replaceState({}, null, this.$router.resolve({ name: 'groupPreview', params: { groupPreviewId: group.id } }).href)
+      this.previewOpened = true
+      this.openedGroupId = group.id
+    },
+    hidePreview () {
+      console.log('test')
+      window.history.replaceState({}, null, `#${this.$route.path}`)
+      this.previewOpened = false
+      this.openedGroupId = -1
+    },
   },
   props: {
     myGroups: {
@@ -105,7 +131,7 @@ export default {
       })
     },
   },
-  components: { GroupGalleryCard, QAlert, QSearch, QCard },
+  components: { GroupGalleryCard, QAlert, QSearch, QCard, GroupPreview },
 }
 </script>
 

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -46,10 +46,13 @@
       {{ $t('JOINGROUP.WHICHGROUP') }}
     </h4>
     <q-card>
-      <q-search
-        class="searchbar"
-        v-model="search"
-      />
+      <transition name="slide-toggle">
+        <q-search
+          v-if="!previewOpened"
+          class="searchbar"
+          v-model="search"
+        />
+      </transition>
     </q-card>
     <transition-group
       name="list-complete"
@@ -137,6 +140,7 @@ export default {
 
 <style scoped lang="stylus">
 @import '~variables'
+@import '~slidetoggle'
 body.desktop .alert
   margin 2em 8px 2.5em 8px
 .text-primary
@@ -152,7 +156,7 @@ body.desktop .alert
   text-decoration underline
 
 .list-complete-item
-  transition: all .5s
+  transition: all .7s
   display: inline-block
 
 .list-complete-enter, .list-complete-leave-to

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -40,7 +40,7 @@
       </div>
     </div>
     <h4
-      class="text-primary"
+      class="text-primary generic-padding"
       v-if="otherGroups.length>0"
     >
       {{ $t('JOINGROUP.WHICHGROUP') }}
@@ -51,14 +51,14 @@
         v-model="search"
       />
     </q-card>
-    <div
-      class="row"
+    <transition-group
+      name="list-complete"
       v-if="otherGroups.length>0"
-    >
+      class="row">
       <div
         v-for="group in filteredGroups"
         :key="group.id"
-        class="inline-block col-xs-12 col-sm-6 col-md-4 items-stretch"
+        class="list-complete-item inline-block col-xs-12 col-sm-6 col-md-4 items-stretch"
       >
         <GroupGalleryCard
           :group="group"
@@ -66,7 +66,7 @@
           @preview="$emit('preview', { groupId: group.id })"
         />
       </div>
-    </div>
+    </transition-group>
   </div>
 </template>
 
@@ -112,7 +112,7 @@ export default {
 <style scoped lang="stylus">
 @import '~variables'
 body.desktop .alert
-  margin 2em 0 2.5em 0
+  margin 2em 8px 2.5em 8px
 .text-primary
   margin-left .2em
 .highlight
@@ -122,9 +122,17 @@ body.desktop .alert
   vertical-align middle
   height 45px
   padding 5px
-</style>
-
-<style scoped lang="stylus">
 .underline
   text-decoration underline
+
+.list-complete-item
+  transition: all .5s
+  display: inline-block
+
+.list-complete-enter, .list-complete-leave-to
+  opacity: 0
+  transform: translateY(30px)
+
+.list-complete-leave-active
+  position: absolute
 </style>

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -51,6 +51,7 @@
           v-if="!previewOpened"
           class="searchbar"
           v-model="search"
+          style="min-height: 0"
         />
       </transition>
     </q-card>
@@ -140,7 +141,6 @@ export default {
 
 <style scoped lang="stylus">
 @import '~variables'
-@import '~slidetoggle'
 body.desktop .alert
   margin 2em 8px 2.5em 8px
 .text-primary
@@ -161,8 +161,22 @@ body.desktop .alert
 
 .list-complete-enter, .list-complete-leave-to
   opacity: 0
-  transform: translateY(30px)
+  transform: translateY(2000px)
 
 .list-complete-leave-active
   position: absolute
+
+.slide-toggle-enter-active,
+.slide-toggle-leave-active
+  transition all .2s
+  min-height = 0
+  overflow hidden
+.slide-toggle-enter-to
+    max-height 400px
+.slide-toggle-enter,
+.slide-toggle-leave-active
+    max-height 0
+    opacity 0
+.slide-toggle-leave
+    max-height 400px
 </style>

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -98,16 +98,14 @@ export default {
   },
   methods: {
     showPreview (group) {
-      // $emit('preview', { groupId: group.id })
-      window.history.replaceState({}, null, this.$router.resolve({ name: 'groupPreview', params: { groupPreviewId: group.id } }).href)
       this.previewOpened = true
       this.openedGroupId = group.id
+      window.history.replaceState({}, null, this.$router.resolve({ name: 'groupPreview', params: { groupPreviewId: group.id } }).href)
     },
     hidePreview () {
-      console.log('test')
-      window.history.replaceState({}, null, `#${this.$route.path}`)
       this.previewOpened = false
       this.openedGroupId = -1
+      window.history.replaceState({}, null, `#${this.$route.path}`)
     },
   },
   props: {

--- a/src/components/GroupJoin/GroupPreview.vue
+++ b/src/components/GroupJoin/GroupPreview.vue
@@ -1,0 +1,20 @@
+<script>
+import { connect } from 'vuex-connect'
+import router from '@/router'
+import GroupPreviewUI from '@/components/GroupJoin/GroupPreviewUI'
+
+export default connect({
+  methodsToEvents: {
+    visit: (store, { groupId }) => router.push({ name: 'group', params: { groupId } }),
+    join: ({ dispatch, getters }, { groupId, password }) => {
+      if (getters['auth/isLoggedIn']) {
+        dispatch('groups/join', { id: groupId, password })
+      }
+      else {
+        dispatch('auth/setJoinGroupAfterLogin', { id: groupId, password })
+        router.push({ name: 'signup' })
+      }
+    },
+  },
+})('GroupPreview', GroupPreviewUI)
+</script>

--- a/src/components/GroupJoin/GroupPreviewUI.vue
+++ b/src/components/GroupJoin/GroupPreviewUI.vue
@@ -1,18 +1,25 @@
 <template>
   <div v-if="group">
-    <q-alert
-      v-if="!group.isMember"
-      color="tertiary"
-      icon="info"
-    >
-      {{ $t('JOINGROUP.PROFILE_NOTE' ) }}
-    </q-alert>
     <q-card>
       <q-card-title>
         {{ group.name }}
         <span slot="subtitle">
           {{ group.members.length }} {{ $tc('JOINGROUP.NUM_MEMBERS', group.members.length) }}
         </span>
+        <div
+          v-if="showClose"
+          style="padding: .6em"
+          slot="right">
+          <q-btn
+            @click="$emit('close')"
+            class="q-btn-flat"
+          >
+            <q-icon name="fa-close" />
+            <q-tooltip>
+              {{ $t('BUTTON.CLOSE') }}
+            </q-tooltip>
+          </q-btn>
+        </div>
       </q-card-title>
       <q-card-main>
         <Markdown
@@ -29,11 +36,20 @@
       </q-card-main>
       <q-card-separator />
       <q-card-actions>
-        <span v-if="!group.isMember">
+        <span
+          v-if="!group.isMember"
+          style="width: 100%">
           <form
             name="joingroup"
             @submit.prevent="$emit('join', { groupId: group.id, password })"
           >
+            <q-alert
+              v-if="!group.isMember"
+              color="tertiary"
+              icon="info"
+            >
+              {{ $t('JOINGROUP.PROFILE_NOTE' ) }}
+            </q-alert>
             <q-field
               v-if="group.protected"
               icon="fa-lock"
@@ -49,6 +65,8 @@
             </q-field>
             <q-btn
               type="submit"
+              color="secondary"
+              class="float-right generic-margin"
               loader
               :value="group.joinStatus.pending"
             >
@@ -88,6 +106,10 @@ export default {
       default: false,
       type: Boolean,
     },
+    showClose: {
+      default: false,
+      type: Boolean,
+    },
   },
   components: { QCard, QCardTitle, QCardMain, QCardSeparator, QCardActions, QBtn, QField, QInput, QIcon, QTooltip, QAlert, Markdown },
   computed: {
@@ -105,8 +127,6 @@ export default {
 </script>
 
 <style scoped lang="stylus">
-.q-alert-container
-  margin 8px
 .q-card *
   overflow: hidden
 </style>

--- a/src/components/GroupJoin/GroupPreviewUI.vue
+++ b/src/components/GroupJoin/GroupPreviewUI.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="group">
-    <q-card>
+    <q-card class="shadow-6">
       <q-card-title>
         {{ group.name }}
         <span slot="subtitle">

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -19,6 +19,7 @@
   "BUTTON": {
     "CREATE": "Create",
     "CANCEL": "Cancel",
+    "CLOSE": "Close",
     "DELETE": "Delete",
     "EDIT": "Edit",
     "JOIN": "Join",


### PR DESCRIPTION
Was tinkering with transition groups a bit to improve the groupGallery

- [x] Added animation
- [x] Added groupPreview component on GroupGallery page (like the new historyList) and changed routes accordingly
- [x] Smaller improvements to Layout of GroupPreview