### PR TITLE
Reload data on foreground or online event

### DIFF
--- a/cordova/config/dev/config.xml
+++ b/cordova/config/dev/config.xml
@@ -33,5 +33,6 @@
             <path url="/" />
         </host>
     </universal-links>
+    <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
     <engine name="android" spec="^6.4.0" />
 </widget>

--- a/cordova/package-lock.json
+++ b/cordova/package-lock.json
@@ -247,6 +247,11 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-fcm/-/cordova-plugin-fcm-2.1.2.tgz",
       "integrity": "sha1-Xy98EsFlVtIdMCHn062J4hWCV0c="
     },
+    "cordova-plugin-network-information": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-network-information/-/cordova-plugin-network-information-2.0.1.tgz",
+      "integrity": "sha1-6QQh9DDGq3bUCSI/Jfzvu7zhdpA="
+    },
     "cordova-plugin-whitelist": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.3.tgz",

--- a/cordova/package.json
+++ b/cordova/package.json
@@ -9,12 +9,14 @@
     "plugins": {
       "cordova-plugin-whitelist": {},
       "cordova-plugin-fcm": {},
-      "cordova-universal-links-plugin": {}
+      "cordova-universal-links-plugin": {},
+      "cordova-plugin-network-information": {}
     }
   },
   "dependencies": {
     "cordova-android": "^6.4.0",
     "cordova-plugin-fcm": "^2.1.2",
+    "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-universal-links-plugin": "^1.2.1",
     "fcm": "^1.0.3"

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -1,3 +1,43 @@
+import Vue from 'vue'
+
+import { refresh } from '@/store/storeHelpers'
+
 import './setBaseURL'
 import './setupFCM'
 import './configureUniversalLinks'
+
+const status = new Vue({
+  data () {
+    return {
+      foreground: true,
+      online: null,
+    }
+  },
+  created () {
+    this.online = navigator.connection.type !== 'none'
+    document.addEventListener('deviceready', () => {
+      document.addEventListener('online', () => {
+        this.online = true
+      }, false)
+      document.addEventListener('offline', () => {
+        this.online = false
+      }, false)
+
+      document.addEventListener('resume', () => {
+        this.foreground = true
+      }, false)
+
+      document.addEventListener('pause', () => {
+        this.foreground = false
+      }, false)
+    }, false)
+  },
+})
+
+status.$watch('online', val => {
+  if (val) refresh()
+})
+
+status.$watch('foreground', val => {
+  if (val) refresh()
+})

--- a/src/store/modules/groups.js
+++ b/src/store/modules/groups.js
@@ -112,6 +112,10 @@ export default {
     clearGroupPreview ({ commit }) {
       commit('setActivePreview', null)
     },
+
+    refresh ({ dispatch }) {
+      return dispatch('fetch')
+    },
   },
   mutations: {
     setActivePreview (state, previewId) {

--- a/src/store/modules/history.js
+++ b/src/store/modules/history.js
@@ -109,6 +109,15 @@ export default {
     clear ({ commit }) {
       commit('clear')
     },
+
+    refresh ({ state, dispatch }) {
+      const {type, id} = state.idListScope
+      switch (type) {
+        case 'group': return this.fetchForGroup({ groupId: id })
+        case 'user': return this.fetchForUser({ userId: id })
+        case 'store': return this.fetchForStore({ storeId: id })
+      }
+    },
   },
   mutations: {
     setActive (state, { id }) {

--- a/src/store/modules/invitations.js
+++ b/src/store/modules/invitations.js
@@ -86,6 +86,10 @@ export default {
       commit('delete', id)
     },
 
+    refresh ({ dispatch }) {
+      dispatch('fetch')
+    },
+
   },
   mutations: {
     set (state, list) {

--- a/src/store/modules/pickupSeries.js
+++ b/src/store/modules/pickupSeries.js
@@ -73,6 +73,10 @@ export default {
     clearList ({ commit }) {
       commit('clearList')
     },
+
+    refresh ({ dispatch }) {
+      dispatch('fetchListForActiveStore')
+    },
   },
   mutations: {
     set (state, { list, storeId }) {

--- a/src/store/modules/stores.js
+++ b/src/store/modules/stores.js
@@ -51,6 +51,10 @@ export default {
       },
     }),
 
+    async refresh ({ dispatch }) {
+      dispatch('fetch')
+    },
+
     async selectStore ({ commit, dispatch, getters, rootState }, { storeId }) {
       if (!getters.get(storeId)) {
         try {

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -96,6 +96,9 @@ export default {
       dispatch('meta/clear', ['resetPassword'])
       commit('resetPasswordSuccess', false)
     },
+    refresh ({ dispatch }) {
+      dispatch('fetch')
+    },
   },
   mutations: {
     select (state, userId) {

--- a/src/store/storeHelpers.js
+++ b/src/store/storeHelpers.js
@@ -22,3 +22,13 @@ export function getter (getterName, ...args) {
     }
   }
 }
+
+export function refresh () {
+  store.dispatch('users/refresh')
+  store.dispatch('stores/refresh')
+  store.dispatch('pickups/refresh')
+  store.dispatch('pickupSeries/refresh')
+  store.dispatch('invitations/refresh')
+  store.dispatch('history/refresh')
+  store.dispatch('groups/refresh')
+}


### PR DESCRIPTION
This improves handling of reloading stale data when the app is foregrounded or comes online.

I added `refresh` actions to each store module where it seemed easily possible. Some of them I did not as the actions take filters which are not saved in the state, so would need a bit more reworking (e.g. stores/modules/feedback)

The app still doesn't handle it well if you start it when you are offline, but I do not address that here.