### PR TITLE
Mark inactive users in member list

### DIFF
--- a/src/components/BackToTopBtn.vue
+++ b/src/components/BackToTopBtn.vue
@@ -2,6 +2,7 @@
   <q-btn
     v-back-to-top
     round
+    small
     class="fixed-bottom-right bg-primary btt-btn"
   >
     <q-icon

--- a/src/components/ProfilePictures/UserList.vue
+++ b/src/components/ProfilePictures/UserList.vue
@@ -5,12 +5,11 @@
       no-border
     >
       <q-item
+        v-for="user in activeUsers"
+        :key="user.id"
         link
         :to="{name: 'user', params: { userId: user.id }}"
-        v-for="user in users"
-        :key="user.id"
       >
-
         <q-item-side right>
           <ProfilePicture
             :key="user.id"
@@ -25,21 +24,60 @@
           </q-item-tile>
         </q-item-main>
       </q-item>
+      <q-item-separator />
+      <q-collapsible
+        icon="fa-bed"
+        :label="$t('GROUP.INACTIVE')"
+        :sublabel="inactiveSublabel"
+      >
+        <q-item
+          v-for="user in inactiveUsers"
+          :key="user.id"
+          link
+          :to="{name: 'user', params: { userId: user.id }}"
+          class="inactive"
+        >
+          <q-item-side right>
+            <ProfilePicture
+              :key="user.id"
+              :user="user"
+              :size="30"
+              class="profilePic"
+            />
+          </q-item-side>
+          <q-item-main>
+            <q-item-tile label>
+              {{ user.displayName }}
+            </q-item-tile>
+          </q-item-main>
+        </q-item>
+      </q-collapsible>
     </q-list>
   </div>
 </template>
 
 <script>
 
-import { QList, QListHeader, QItem, QItemMain, QItemTile, QItemSide } from 'quasar'
+import { QList, QItemSeparator, QItem, QItemMain, QItemTile, QItemSide, QCollapsible } from 'quasar'
 import ProfilePicture from './ProfilePicture'
 
 export default {
-  components: { ProfilePicture, QList, QListHeader, QItem, QItemMain, QItemTile, QItemSide },
+  components: { ProfilePicture, QList, QItemSeparator, QItem, QItemMain, QItemTile, QItemSide, QCollapsible },
   props: {
     users: {
       type: Array,
       required: true,
+    },
+  },
+  computed: {
+    inactiveSublabel () {
+      return this.inactiveUsers.length + ' ' + this.$tc('JOINGROUP.NUM_MEMBERS', this.inactiveUsers.length)
+    },
+    activeUsers () {
+      return this.users.filter(u => u.membershipInCurrentGroup.active)
+    },
+    inactiveUsers () {
+      return this.users.filter(u => !u.membershipInCurrentGroup.active)
     },
   },
 }
@@ -47,7 +85,8 @@ export default {
 
 <style scoped lang="stylus">
 .list-wrapper
-  margin .3em
   .profilePic
     margin-right .5em
+.inactive
+  opacity 0.5
 </style>

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -66,6 +66,7 @@
     "PASSWORD": "Enter a password here if you want to make the group private",
     "PICKUPS": "Pickups",
     "MEMBERS": "Members",
+    "INACTIVE": "Inactive",
     "STORES": "Stores",
     "HISTORY": "History",
     "DESCRIPTION": "Description",

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -36,7 +36,15 @@ export default {
     },
     byCurrentGroup: (state, getters, rootState, rootGetters) => {
       const currentGroup = rootGetters['currentGroup/value']
-      return (currentGroup && currentGroup.members) ? currentGroup.members.map(getters.get) : []
+      if (currentGroup && currentGroup.memberships) {
+        return Object.entries(currentGroup.memberships).map(([userId, membership]) => {
+          return {
+            ...getters.get(userId),
+            membershipInCurrentGroup: membership,
+          }
+        })
+      }
+      return []
     },
     activeUser: (state, getters, rootState, rootGetters) => {
       return state.activeUserId && getters.get(state.activeUserId)

--- a/src/store/modules/users.spec.js
+++ b/src/store/modules/users.spec.js
@@ -31,7 +31,7 @@ describe('users', () => {
       history,
       currentGroup: {
         getters: {
-          value: () => ({ members: [1, 2] }),
+          value: () => ({ members: [1, 2], memberships: { 1: {}, 2: {} } }),
         },
       },
     })


### PR DESCRIPTION
Related to #868 

Active users at the top, inactive users at the bottom

![image](https://user-images.githubusercontent.com/4410802/37253252-97e9379a-252f-11e8-84a9-7aa54f3875a8.png)

Also reduces size of the "back-to-top" button to hide less elements. It's still a bit annoying..
