### PR TITLE
PickupListItem: Fixed bug where empty slot was shown for full pickups

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2671,16 +2671,7 @@ exports[`Storyshots PickupItem Full 1`] = `
           </div>
           <!---->
           <!---->
-          <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
-            <div class="hoverHide"></div>
-            <div title="Join" class="hoverShow">
-              <div class="wrapper">
-                <div>
-                  <div text="Current User" seed="5" class="randomArt" style="width:36px;height:36px;"></div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <!---->
           <!---->
         </div>
       </div>
@@ -2944,16 +2935,7 @@ exports[`Storyshots PickupList Default 1`] = `
           </div>
           <!---->
           <!---->
-          <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
-            <div class="hoverHide"></div>
-            <div title="Join" class="hoverShow">
-              <div class="wrapper">
-                <div>
-                  <div text="Current User" seed="5" class="randomArt" style="width:36px;height:36px;"></div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <!---->
           <!---->
         </div>
       </div>
@@ -3388,16 +3370,7 @@ exports[`Storyshots PickupUsers full 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="user-slot-wrapper profilePic active clickable" style="width:36px;height:36px;">
-    <div class="hoverHide"></div>
-    <div title="Join" class="hoverShow">
-      <div class="wrapper">
-        <div>
-          <div text="Current User" seed="5" class="randomArt" style="width:36px;height:36px;"></div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <!---->
   <!---->
 </div>
 `;

--- a/src/components/Pickups/PickupUsers.vue
+++ b/src/components/Pickups/PickupUsers.vue
@@ -43,7 +43,7 @@
       :size="size"
       :hover-user="currentUser"
       :show-join="!pickup.isUserMember"
-      v-if="!(isJoiningOrLeaving(pickup) && !pickup.isUserMember)"
+      v-if="!pickup.isFull && !(isJoiningOrLeaving(pickup) && !pickup.isUserMember)"
       class="profilePic"
       :class="{clickable: !pickup.isUserMember}"
       @join="$emit('join')"


### PR DESCRIPTION
As mentioned by Teddy on slack, full pickups were showing empty slots if the user was not already signed up for the pickup -> fixed. (couldn't find an according issue)