### PR TITLE
Build webpack assets into /assets

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -91,7 +91,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 10000,
-          name: '/assets/images/[name].[hash:7].[ext]',
+          name: (env.prod ? '/' : '') + 'assets/images/[name].[hash:7].[ext]',
         },
       },
       {
@@ -99,7 +99,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 10000,
-          name: '/assets/fonts/[name].[hash:7].[ext]',
+          name: (env.prod ? '/' : '') + 'assets/fonts/[name].[hash:7].[ext]',
         },
       },
       {

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -91,7 +91,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 10000,
-          name: 'img/[name].[hash:7].[ext]',
+          name: '/assets/images/[name].[hash:7].[ext]',
         },
       },
       {
@@ -99,7 +99,7 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 10000,
-          name: 'fonts/[name].[hash:7].[ext]',
+          name: '/assets/fonts/[name].[hash:7].[ext]',
         },
       },
       {
@@ -133,7 +133,7 @@ module.exports = {
     new VueLoaderPlugin(),
     ...(env.prod ? [
       new MiniCssExtractPlugin({
-        filename: '[contenthash].css',
+        filename: 'assets/css/[contenthash].css',
       }),
       new BundleAnalyzerPlugin({
         analyzerMode: 'static',


### PR DESCRIPTION
## What does this PR do?

All webpack built assets with hashes in the path can be cached indefinately, currently we have some stuff in root, some in `/js`, etc... so the nginx config has to have seperate cases for js/img/css/fonts. Putting everything under assets simplifies this.

... but it was a bit fiddly to get rid as things load differently in dev and prod.
