### PR TITLE
exchange info and warning colors

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -419,7 +419,7 @@ exports[`Storyshots GroupGallery signup view 1`] = `
   </div>
   <div class="sidebar expanded">
     <div class="alert">
-      <div class="q-alert row no-wrap shadow-2 bg-info text-white">
+      <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
         <div class="q-alert-side col-auto row flex-center">
           <i aria-hidden="true" class="q-icon material-icons">star</i>
         </div>
@@ -637,7 +637,7 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
   </div>
   <div class="sidebar expanded">
     <div class="alert">
-      <div class="q-alert row no-wrap shadow-2 bg-info text-white">
+      <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
         <div class="q-alert-side col-auto row flex-center">
           <i aria-hidden="true" class="q-icon material-icons">star</i>
         </div>
@@ -1232,7 +1232,7 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email not ver
     <div class="q-card-actions q-card-actions-horiz row justify-start">
       <div style="width:100%;">
         <div>
-          <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
+          <div class="q-alert row no-wrap shadow-2 bg-info text-white">
             <div class="q-alert-side col-auto row flex-center">
               <i aria-hidden="true" class="q-icon material-icons">info</i>
             </div>
@@ -1288,7 +1288,7 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email verifie
     <div class="q-card-actions q-card-actions-horiz row justify-start">
       <div style="width:100%;">
         <div>
-          <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
+          <div class="q-alert row no-wrap shadow-2 bg-info text-white">
             <div class="q-alert-side col-auto row flex-center">
               <i aria-hidden="true" class="q-icon material-icons">info</i>
             </div>
@@ -1344,7 +1344,7 @@ exports[`Storyshots GroupPreviewUI not member, open group 1`] = `
     <div class="q-card-actions q-card-actions-horiz row justify-start">
       <div style="width:100%;">
         <div>
-          <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
+          <div class="q-alert row no-wrap shadow-2 bg-info text-white">
             <div class="q-alert-side col-auto row flex-center">
               <i aria-hidden="true" class="q-icon material-icons">info</i>
             </div>
@@ -1462,7 +1462,7 @@ exports[`Storyshots GroupPreviewUI not member, playground 1`] = `
     <div class="q-card-actions q-card-actions-horiz row justify-start">
       <div style="width:100%;">
         <div>
-          <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
+          <div class="q-alert row no-wrap shadow-2 bg-info text-white">
             <div class="q-alert-side col-auto row flex-center">
               <i aria-hidden="true" class="q-icon material-icons">info</i>
             </div>
@@ -1513,7 +1513,7 @@ exports[`Storyshots GroupPreviewUI pending join 1`] = `
     <div class="q-card-actions q-card-actions-horiz row justify-start">
       <div style="width:100%;">
         <div>
-          <div class="q-alert row no-wrap shadow-2 bg-warning text-white">
+          <div class="q-alert row no-wrap shadow-2 bg-info text-white">
             <div class="q-alert-side col-auto row flex-center">
               <i aria-hidden="true" class="q-icon material-icons">info</i>
             </div>

--- a/src/components/GroupJoin/GroupGalleryUI.vue
+++ b/src/components/GroupJoin/GroupGalleryUI.vue
@@ -15,7 +15,7 @@
     >
       <q-alert
         v-if="!isLoggedIn"
-        color="info"
+        color="warning"
         icon="star"
         class="alert"
       >

--- a/src/components/GroupJoin/GroupPreviewUI.vue
+++ b/src/components/GroupJoin/GroupPreviewUI.vue
@@ -37,7 +37,7 @@
             <template v-if="!group.isMember">
               <q-alert
                 v-if="!group.hasMyApplication"
-                color="warning"
+                color="info"
                 icon="info"
               >
                 {{ $t('JOINGROUP.PROFILE_NOTE' ) }}

--- a/src/components/Layout/LoadingProgress.vue
+++ b/src/components/Layout/LoadingProgress.vue
@@ -3,7 +3,7 @@
     v-if="loading || closing"
     indeterminate
     animate
-    color="warning"
+    color="info"
     class="fixed-top"
     style="height: 2px; z-index: 2500"
   />

--- a/src/components/Settings/VerificationWarning.vue
+++ b/src/components/Settings/VerificationWarning.vue
@@ -2,7 +2,7 @@
   <q-alert
     v-if="!hasEmailVerified"
     icon="fas fa-exclamation-triangle"
-    type="warning"
+    color="warning"
   >
     <p>{{ $t('NOTIFICATIONS.NOT_VERIFIED', { email: user.unverifiedEmail }) }}</p>
     <p>{{ $t('WALL.VERIFY_EMAIL_FOR_NOTIFICATIONS') }}</p>

--- a/src/components/Wall/AvailablePickups.vue
+++ b/src/components/Wall/AvailablePickups.vue
@@ -2,7 +2,7 @@
   <div>
     <q-card
       @click.native="showPickups = !showPickups"
-      color="warning"
+      color="info"
       class="generic-padding notice no-margin-bottom"
     >
       <i class="fas fa-exclamation-triangle on-left"/>

--- a/src/components/Wall/FeedbackNotice.vue
+++ b/src/components/Wall/FeedbackNotice.vue
@@ -2,7 +2,7 @@
   <div>
     <router-link :to="{name: 'pickupFeedback'}">
       <q-card
-        color="warning"
+        color="info"
         class="generic-padding notice"
       >
         <i class="fas fa-balance-scale on-left"/>

--- a/src/pages/Store/Layout.vue
+++ b/src/pages/Store/Layout.vue
@@ -2,7 +2,7 @@
   <div v-if="store && store.status === 'archived'">
     <q-card>
       <k-banner
-        color="warning"
+        color="info"
         icon="fas fa-trash-alt"
         :actions="[{ label: $t('STOREEDIT.RESTORE'), handler: restore }]"
       >

--- a/src/themes/app.variables.styl
+++ b/src/themes/app.variables.styl
@@ -21,8 +21,8 @@ $tertiary  = #c2b140
 
 $positive  = #21BA45
 $negative  = #DB2828
-$info      = #E37619
-$warning   = #F2C037
+$info      = #F2C037
+$warning   = #E37619
 
 $light     = #bdbdbd
 $dark      = #424242


### PR DESCRIPTION
## What does this PR do?

Exchanges info and warning colors without visible changes in the UI and only where it semantically makes sense. (One untreated occurrence is VerificationWarning.vue in which the warning color was already in use - it would have felt wrong to change it to info now...)