### PR TITLE
Fix vertical space layout issue in application chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please document your changes in this format:
 ### Removed
 
 ### Fixed
+- Fix application chat initial questions layout #1097 @nicksellen
 
 
 ## [Release 6.1] - 2018-08-31

--- a/src/components/Conversation/ChatConversation.vue
+++ b/src/components/Conversation/ChatConversation.vue
@@ -6,6 +6,7 @@
       class="absolute-full scroll"
       ref="scroll"
     >
+      <slot name="beforeChatMessages"/>
       <div
         v-if="fetchingPast"
         class="full-width text-center generic-padding"

--- a/src/components/General/DetailUI.vue
+++ b/src/components/General/DetailUI.vue
@@ -120,33 +120,6 @@
           </div>
         </div>
       </div>
-      <q-collapsible
-        opened
-        v-if="application"
-        class="bg-grey-2"
-      >
-        <template slot="header">
-          <b>{{ $t('APPLICATION.INITIAL') }}</b>
-        </template>
-        <div class="q-ma-sm q-pa-sm bg-white">
-          <span class="text-bold text-secondary uppercase">{{ application.group.name }}</span>
-          <span class="message-date">
-            <small class="text-weight-light">
-              <DateAsWords :date="application.createdAt" />
-            </small>
-          </span>
-          <Markdown :source="application.questions" />
-        </div>
-        <div class="q-ma-sm q-pa-sm bg-white">
-          <span class="text-bold text-secondary uppercase">{{ application.user.displayName }}</span>
-          <span class="message-date">
-            <small class="text-weight-light">
-              <DateAsWords :date="application.createdAt" />
-            </small>
-          </span>
-          <Markdown :source="application.answers" />
-        </div>
-      </q-collapsible>
       <ChatConversation
         v-if="conversation"
         :conversation="conversationWithMaybeReversedMessages"
@@ -159,7 +132,36 @@
         @saveMessage="$emit('saveMessage', arguments[0])"
         @fetchPast="$emit('fetchPast', arguments[0])"
         @fetchFuture="$emit('fetchFuture')"
-      />
+      >
+        <q-collapsible
+          slot="beforeChatMessages"
+          opened
+          v-if="application"
+          class="bg-grey-2"
+        >
+          <template slot="header">
+            <b>{{ $t('APPLICATION.INITIAL') }}</b>
+          </template>
+          <div class="q-ma-sm q-pa-sm bg-white">
+            <span class="text-bold text-secondary uppercase">{{ application.group.name }}</span>
+            <span class="message-date">
+              <small class="text-weight-light">
+                <DateAsWords :date="application.createdAt" />
+              </small>
+            </span>
+            <Markdown :source="application.questions" />
+          </div>
+          <div class="q-ma-sm q-pa-sm bg-white">
+            <span class="text-bold text-secondary uppercase">{{ application.user.displayName }}</span>
+            <span class="message-date">
+              <small class="text-weight-light">
+                <DateAsWords :date="application.createdAt" />
+              </small>
+            </span>
+            <Markdown :source="application.answers" />
+          </div>
+        </q-collapsible>
+      </ChatConversation>
     </template>
   </div>
 </template>


### PR DESCRIPTION
Closes #1097 

## What does this PR do?

When the vertical space available was less than the heigh of the initial questions section, the layout would be broken as it would throw it off to the side as it was not part of the scrolling section.

To resolve it I include the initial questions inside the scrolling section by using a slot.

## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible... (well, we don't really test this layout stuff right now)
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
