### PR TITLE
Remove start time from community feed

### DIFF
--- a/src/communityFeed/components/CommunityFeed.vue
+++ b/src/communityFeed/components/CommunityFeed.vue
@@ -93,15 +93,6 @@
               </i18n>
             </q-item-tile>
           </q-item-main>
-          <q-item-side
-            v-if="!$q.platform.is.mobile"
-            right
-            stamp
-          >
-            <DateAsWords
-              :date="topic.createdAt"
-            />
-          </q-item-side>
         </q-item>
       </q-list>
     </component>


### PR DESCRIPTION
## What does this PR do?
The date a topic was started is not displayed in the community feed anymore.
No test needed because it's a tiny change. I guess too tiny even for the changelog..?

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
