### PR TITLE
Fix Selecting many days in recurring pickups breaks layout

### DIFF
--- a/src/pickups/components/PickupSeriesEdit.vue
+++ b/src/pickups/components/PickupSeriesEdit.vue
@@ -45,6 +45,7 @@
             toggle
             v-model="byDay"
             :options="dayOptions"
+            class="ellipsis"
           />
         </q-field>
       </div>


### PR DESCRIPTION
Closes #1133

## What does this PR do?

This pull request fixes the layout break when you select multiple days in a new recurring pickup.

I checked the Quasar Documentation, typed some extra text in the Select component example (as you can see in the image bellow) and could check they don't support yet text truncation in a Select component. So I added the CSS class "ellipsis" [Quasar Documentation Ellipsis](https://quasar-framework.org/components/visibility.html) in the Select component responsible for the text and the issue is fixed.

![Typing a text longer than the container also breaks the layout in Quasar Documentation](https://user-images.githubusercontent.com/41799407/49975869-e2942580-ff26-11e8-9f56-2d26eae38027.png)


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
