### PR TITLE
Display pickups in progress to its collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ Please document your changes in this format:
 - Tapping on push notification showed login page when user is already logged in (second try) @tiltec
 - External link detection was not working in app @tiltec
 - Group links on map didn't work when logged out @tiltec
-- Removed imported but unused components to satisfy eslint rule #1171 @taistadam
-- Convert components' names to template casing to satisfy eslint rule #1163 @taistadam
 
 ## [6.2.9] - 2018-12-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,14 @@ Please document your changes in this format:
 - Replies to wall message via email now go into a thread #1079 @tiltec
 - Wait 5 seconds before triggering refresh in app @tiltec
 - Order of pickup collectors is now kept #1157 @lwm
+- Displaying past pickups (-30min) for users who are members of that pickup #1178 @djahnie @taistadam
 
 ### Fixed
 - Tapping on push notification showed login page when user is already logged in (second try) @tiltec
 - External link detection was not working in app @tiltec
 - Group links on map didn't work when logged out @tiltec
+- Removed imported but unused components to satisfy eslint rule #1171 @taistadam
+- Convert components' names to template casing to satisfy eslint rule #1163 @taistadam
 
 ## [6.2.9] - 2018-12-12
 ### Fixed

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2839,7 +2839,7 @@ exports[`Storyshots PickupItem Full 1`] = `
         <!---->
       </div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">this pickup is already full!
       </div>
       <div class="q-my-xs full-width">
@@ -2882,7 +2882,7 @@ exports[`Storyshots PickupItem Join 1`] = `
         <!---->
       </div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">you can join this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -2932,7 +2932,7 @@ exports[`Storyshots PickupItem Leave 1`] = `
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">you are collector and can leave this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -2950,10 +2950,8 @@ exports[`Storyshots PickupItem Leave 1`] = `
               </a></div>
           </div>
           <!---->
-          <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-            <div class="hoverShow">
-              <!---->
-            </div>
+          <!----> <a appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+            <div class="hoverShow"><i title="Leave" class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
             <div class="hoverHide">
               <div class="wrapper" style="width:36px;height:36px;">
                 <div text="Current User" seed="5" class="randomArt fill"></div>
@@ -2982,7 +2980,7 @@ exports[`Storyshots PickupItem pending 1`] = `
         <!---->
       </div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">you can join this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -3025,7 +3023,7 @@ exports[`Storyshots PickupList Default 1`] = `
   <!---->
 </div>
 <!---->
-<div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+<!---->
 <div class="q-my-xs multiline">you can join this pickup
 </div>
 <div class="q-my-xs full-width">
@@ -3072,7 +3070,7 @@ exports[`Storyshots PickupList Default 1`] = `
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">you are collector and can leave this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -3090,10 +3088,8 @@ exports[`Storyshots PickupList Default 1`] = `
               </a></div>
           </div>
           <!---->
-          <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-            <div class="hoverShow">
-              <!---->
-            </div>
+          <!----> <a appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+            <div class="hoverShow"><i title="Leave" class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
             <div class="hoverHide">
               <div class="wrapper" style="width:36px;height:36px;">
                 <div text="Current User" seed="5" class="randomArt fill"></div>
@@ -3119,7 +3115,7 @@ exports[`Storyshots PickupList Default 1`] = `
         <!---->
       </div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">this pickup is already full!
       </div>
       <div class="q-my-xs full-width">
@@ -3159,7 +3155,7 @@ exports[`Storyshots PickupList Default 1`] = `
         <!---->
       </div>
       <!---->
-      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
+      <!---->
       <div class="q-my-xs multiline">this pickup is fresh and empty
       </div>
       <div class="q-my-xs full-width">
@@ -3579,10 +3575,8 @@ exports[`Storyshots PickupUsers leavable 1`] = `
       </a></div>
   </div>
   <!---->
-  <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-    <div class="hoverShow">
-      <!---->
-    </div>
+  <!----> <a appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+    <div class="hoverShow"><i title="Leave" class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
     <div class="hoverHide">
       <div class="wrapper" style="width:36px;height:36px;">
         <div text="Current User" seed="5" class="randomArt fill"></div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2839,6 +2839,7 @@ exports[`Storyshots PickupItem Full 1`] = `
         <!---->
       </div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">this pickup is already full!
       </div>
       <div class="q-my-xs full-width">
@@ -2881,6 +2882,7 @@ exports[`Storyshots PickupItem Join 1`] = `
         <!---->
       </div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">you can join this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -2930,6 +2932,7 @@ exports[`Storyshots PickupItem Leave 1`] = `
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">you are collector and can leave this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -2947,8 +2950,10 @@ exports[`Storyshots PickupItem Leave 1`] = `
               </a></div>
           </div>
           <!---->
-          <!----> <a title="Leave" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-            <div class="hoverShow"><i class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
+          <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+            <div class="hoverShow">
+              <!---->
+            </div>
             <div class="hoverHide">
               <div class="wrapper" style="width:36px;height:36px;">
                 <div text="Current User" seed="5" class="randomArt fill"></div>
@@ -2977,6 +2982,7 @@ exports[`Storyshots PickupItem pending 1`] = `
         <!---->
       </div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">you can join this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -3019,6 +3025,7 @@ exports[`Storyshots PickupList Default 1`] = `
   <!---->
 </div>
 <!---->
+<div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
 <div class="q-my-xs multiline">you can join this pickup
 </div>
 <div class="q-my-xs full-width">
@@ -3065,6 +3072,7 @@ exports[`Storyshots PickupList Default 1`] = `
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">you are collector and can leave this pickup
       </div>
       <div class="q-my-xs full-width">
@@ -3082,8 +3090,10 @@ exports[`Storyshots PickupList Default 1`] = `
               </a></div>
           </div>
           <!---->
-          <!----> <a title="Leave" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-            <div class="hoverShow"><i class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
+          <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+            <div class="hoverShow">
+              <!---->
+            </div>
             <div class="hoverHide">
               <div class="wrapper" style="width:36px;height:36px;">
                 <div text="Current User" seed="5" class="randomArt fill"></div>
@@ -3109,6 +3119,7 @@ exports[`Storyshots PickupList Default 1`] = `
         <!---->
       </div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">this pickup is already full!
       </div>
       <div class="q-my-xs full-width">
@@ -3148,6 +3159,7 @@ exports[`Storyshots PickupList Default 1`] = `
         <!---->
       </div>
       <!---->
+      <div class="q-my-xs"><b class="text-orange">This pickup is happening right now.</b></div>
       <div class="q-my-xs multiline">this pickup is fresh and empty
       </div>
       <div class="q-my-xs full-width">
@@ -3567,8 +3579,10 @@ exports[`Storyshots PickupUsers leavable 1`] = `
       </a></div>
   </div>
   <!---->
-  <!----> <a title="Leave" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
-    <div class="hoverShow"><i class="fas fa-fw fa-times" style="font-size:27px;"></i></div>
+  <!----> <a pickup="[object Object]" appear="" duration="[object Object]" name="bounce" class="user-slot-wrapper hoverScale" style="width:36px;height:36px;">
+    <div class="hoverShow">
+      <!---->
+    </div>
     <div class="hoverHide">
       <div class="wrapper" style="width:36px;height:36px;">
         <div text="Current User" seed="5" class="randomArt fill"></div>

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -327,7 +327,7 @@
     "NONE_HINT": "You can create a new pickup on the store page.",
     "STORE_NONE_HINT": "You can create a new pickup on the pickup manage page.",
     "PICKUP_DISABLED": "This pickup has been disabled.",
-    "PICKUP_ONGOING": "This pickup is happening right now."
+    "PICKUP_STARTED": "This pickup has already started."
   },
   "FEEDBACKLIST": {
     "SAVED_FOOD": "At least 1 kg was saved here. Thank you! | People gave feedback for {amount} kg of saved food already! Keep up the great work!",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -326,7 +326,8 @@
     "NONE": "No upcoming pickups",
     "NONE_HINT": "You can create a new pickup on the store page.",
     "STORE_NONE_HINT": "You can create a new pickup on the pickup manage page.",
-    "PICKUP_DISABLED": "This pickup has been disabled."
+    "PICKUP_DISABLED": "This pickup has been disabled.",
+    "PICKUP_ONGOING": "This pickup is happening right now."
   },
   "FEEDBACKLIST": {
     "SAVED_FOOD": "At least 1 kg was saved here. Thank you! | People gave feedback for {amount} kg of saved food already! Keep up the great work!",

--- a/src/pickups/api/pickups.js
+++ b/src/pickups/api/pickups.js
@@ -1,5 +1,7 @@
 import axios, { parseCursor } from '@/base/api/axios'
 import { convert as convertConversation } from '@/messages/api/conversations'
+import { pickupRunningTime } from '@/pickups/settings'
+import subMinutes from 'date-fns/sub_minutes'
 
 export default {
 
@@ -12,7 +14,7 @@ export default {
   },
 
   async list (filter) {
-    const params = filter || { 'date_min': new Date() }
+    const params = filter || { 'date_min': subMinutes(new Date(), pickupRunningTime) }
     const response = (await axios.get('/api/pickup-dates/', { params })).data
     return {
       ...response,

--- a/src/pickups/components/CurrentUser.vue
+++ b/src/pickups/components/CurrentUser.vue
@@ -2,13 +2,15 @@
   <a
     @click.stop="$emit('leave')"
     class="user-slot-wrapper"
+    :pickup="pickup"
     :style="{ width: size + 'px', height: size + 'px' }"
-    :title="$t('PICKUPLIST.ITEM.LEAVE')"
   >
     <div class="hoverShow">
       <i
+        v-if="!inProgress(pickup)"
         :style="{fontSize: (size - 9) + 'px'}"
         class="fas fa-fw fa-times"
+        :title="$t('PICKUPLIST.ITEM.LEAVE')"
       />
     </div>
     <div class="hoverHide">
@@ -34,11 +36,19 @@ export default {
       type: Object,
       required: true,
     },
+    pickup: {
+      type: Object,
+      required: true,
+    },
   },
   components: {
     ProfilePicture,
   },
-
+  methods: {
+    inProgress (pickup) {
+      return (pickup.date <= new Date())
+    },
+  },
 }
 </script>
 

--- a/src/pickups/components/CurrentUser.vue
+++ b/src/pickups/components/CurrentUser.vue
@@ -2,12 +2,11 @@
   <a
     @click.stop="$emit('leave')"
     class="user-slot-wrapper"
-    :pickup="pickup"
     :style="{ width: size + 'px', height: size + 'px' }"
   >
     <div class="hoverShow">
       <i
-        v-if="!inProgress(pickup)"
+        v-if="!pickup.hasStarted"
         :style="{fontSize: (size - 9) + 'px'}"
         class="fas fa-fw fa-times"
         :title="$t('PICKUPLIST.ITEM.LEAVE')"
@@ -43,11 +42,6 @@ export default {
   },
   components: {
     ProfilePicture,
-  },
-  methods: {
-    inProgress (pickup) {
-      return (pickup.date <= new Date())
-    },
   },
 }
 </script>

--- a/src/pickups/components/PickupItem.vue
+++ b/src/pickups/components/PickupItem.vue
@@ -33,10 +33,10 @@
           <b class="text-negative">{{ $t('PICKUPLIST.PICKUP_DISABLED') }}</b>
         </div>
         <div
-          v-if="inProgress(pickup)"
+          v-if="pickup.hasStarted"
           class="q-my-xs"
         >
-          <b class="text-orange">{{ $t('PICKUPLIST.PICKUP_ONGOING') }}</b>
+          <b class="text-orange">{{ $t('PICKUPLIST.PICKUP_STARTED') }}</b>
         </div>
         <div
           class="q-my-xs multiline"
@@ -93,7 +93,8 @@ export default {
         .catch(() => {})
     },
     leave () {
-      if (this.pickup.date > new Date()) {
+      console.log(this.pickup.hasStarted)
+      if (!this.pickup.hasStarted) {
         Dialog.create({
           title: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_HEADER'),
           message: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_TEXT'),
@@ -108,9 +109,6 @@ export default {
       if (!this.pickup.isUserMember) return
       if (event.target.closest('a')) return // ignore actual links
       this.$emit('detail', this.pickup)
-    },
-    inProgress (pickup) {
-      return (pickup.date <= new Date())
     },
   },
 }

--- a/src/pickups/components/PickupItem.vue
+++ b/src/pickups/components/PickupItem.vue
@@ -77,6 +77,7 @@ export default {
   },
   methods: {
     join () {
+      if (this.inProgress) return
       Dialog.create({
         title: this.$t('PICKUPLIST.ITEM.JOIN_CONFIRMATION_HEADER'),
         message: this.$t('PICKUPLIST.ITEM.JOIN_CONFIRMATION_TEXT', { date: this.$d(this.pickup.date, 'long') }),
@@ -87,6 +88,7 @@ export default {
         .catch(() => {})
     },
     leave () {
+      if (this.inProgress) return
       Dialog.create({
         title: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_HEADER'),
         message: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_TEXT'),
@@ -100,6 +102,11 @@ export default {
       if (!this.pickup.isUserMember) return
       if (event.target.closest('a')) return // ignore actual links
       this.$emit('detail', this.pickup)
+    },
+  },
+  computed: {
+    inProgress () {
+      return (this.pickup.date <= new Date())
     },
   },
 }

--- a/src/pickups/components/PickupItem.vue
+++ b/src/pickups/components/PickupItem.vue
@@ -33,6 +33,12 @@
           <b class="text-negative">{{ $t('PICKUPLIST.PICKUP_DISABLED') }}</b>
         </div>
         <div
+          v-if="inProgress(pickup)"
+          class="q-my-xs"
+        >
+          <b class="text-orange">{{ $t('PICKUPLIST.PICKUP_ONGOING') }}</b>
+        </div>
+        <div
           class="q-my-xs multiline"
           v-if="pickup.description"
         >{{ pickup.description }}
@@ -102,6 +108,9 @@ export default {
       if (!this.pickup.isUserMember) return
       if (event.target.closest('a')) return // ignore actual links
       this.$emit('detail', this.pickup)
+    },
+    inProgress (pickup) {
+      return (pickup.date <= new Date())
     },
   },
 }

--- a/src/pickups/components/PickupItem.vue
+++ b/src/pickups/components/PickupItem.vue
@@ -93,7 +93,6 @@ export default {
         .catch(() => {})
     },
     leave () {
-      console.log(this.pickup.hasStarted)
       if (!this.pickup.hasStarted) {
         Dialog.create({
           title: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_HEADER'),

--- a/src/pickups/components/PickupItem.vue
+++ b/src/pickups/components/PickupItem.vue
@@ -77,7 +77,6 @@ export default {
   },
   methods: {
     join () {
-      if (this.inProgress) return
       Dialog.create({
         title: this.$t('PICKUPLIST.ITEM.JOIN_CONFIRMATION_HEADER'),
         message: this.$t('PICKUPLIST.ITEM.JOIN_CONFIRMATION_TEXT', { date: this.$d(this.pickup.date, 'long') }),
@@ -88,25 +87,21 @@ export default {
         .catch(() => {})
     },
     leave () {
-      if (this.inProgress) return
-      Dialog.create({
-        title: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_HEADER'),
-        message: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_TEXT'),
-        ok: this.$t('BUTTON.YES'),
-        cancel: this.$t('BUTTON.CANCEL'),
-      })
-        .then(() => this.$emit('leave', this.pickup.id))
-        .catch(() => {})
+      if (this.pickup.date > new Date()) {
+        Dialog.create({
+          title: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_HEADER'),
+          message: this.$t('PICKUPLIST.ITEM.LEAVE_CONFIRMATION_TEXT'),
+          ok: this.$t('BUTTON.YES'),
+          cancel: this.$t('BUTTON.CANCEL'),
+        })
+          .then(() => this.$emit('leave', this.pickup.id))
+          .catch(() => {})
+      }
     },
     detailIfMember (event) {
       if (!this.pickup.isUserMember) return
       if (event.target.closest('a')) return // ignore actual links
       this.$emit('detail', this.pickup)
-    },
-  },
-  computed: {
-    inProgress () {
-      return (this.pickup.date <= new Date())
     },
   },
 }

--- a/src/pickups/components/PickupUsers.vue
+++ b/src/pickups/components/PickupUsers.vue
@@ -43,6 +43,7 @@
         v-if="pickup.isUserMember && !isJoiningOrLeaving(pickup)"
         :size="size"
         :user="currentUser"
+        :pickup="pickup"
         class="hoverScale"
         @leave="$emit('leave')"
       />

--- a/src/pickups/datastore/pickupSeries.js
+++ b/src/pickups/datastore/pickupSeries.js
@@ -20,6 +20,7 @@ export default {
       if (!entry) return
       const pickups = rootGetters['pickups/upcoming']
         .filter(({ series }) => series === entry.id)
+        .filter(p => !p.hasStarted)
         .map(pickup => ({
           ...pickup,
           seriesMeta: {

--- a/src/pickups/datastore/pickupSeries.js
+++ b/src/pickups/datastore/pickupSeries.js
@@ -18,7 +18,7 @@ export default {
     },
     enrich: (state, getters, rootState, rootGetters) => entry => {
       if (!entry) return
-      const pickups = rootGetters['pickups/upcomingAndOngoing']
+      const pickups = rootGetters['pickups/upcomingAndStarted']
         .filter(({ series }) => series === entry.id)
         .filter(p => !p.hasStarted)
         .map(pickup => ({

--- a/src/pickups/datastore/pickupSeries.js
+++ b/src/pickups/datastore/pickupSeries.js
@@ -18,7 +18,7 @@ export default {
     },
     enrich: (state, getters, rootState, rootGetters) => entry => {
       if (!entry) return
-      const pickups = rootGetters['pickups/upcoming']
+      const pickups = rootGetters['pickups/upcomingAndOngoing']
         .filter(({ series }) => series === entry.id)
         .filter(p => !p.hasStarted)
         .map(pickup => ({

--- a/src/pickups/datastore/pickupSeries.spec.js
+++ b/src/pickups/datastore/pickupSeries.spec.js
@@ -12,7 +12,7 @@ describe('pickupSeries module', () => {
     beforeEach(() => {
       datastore = createDatastore({
         pickupSeries: require('./pickupSeries').default,
-        pickups: { getters: { upcoming: () => [] } },
+        pickups: { getters: { upcomingAndOngoing: () => [] } },
         stores: { getters: { get: () => () => null } },
       })
     })

--- a/src/pickups/datastore/pickupSeries.spec.js
+++ b/src/pickups/datastore/pickupSeries.spec.js
@@ -12,7 +12,7 @@ describe('pickupSeries module', () => {
     beforeEach(() => {
       datastore = createDatastore({
         pickupSeries: require('./pickupSeries').default,
-        pickups: { getters: { upcomingAndOngoing: () => [] } },
+        pickups: { getters: { upcomingAndStarted: () => [] } },
         stores: { getters: { get: () => () => null } },
       })
     })

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -60,7 +60,9 @@ export default {
       return getters.byCurrentGroup.filter(({ store }) => store && store.isActiveStore)
     },
     byActiveStoreOneTime: (state, getters) => {
-      return getters.byActiveStore.filter(e => !e.series)
+      return getters.byActiveStore
+        .filter(e => !e.series)
+        .filter(p => !p.hasStarted)
     },
     joined: (state, getters) => getters.byCurrentGroup.filter(e => e.isUserMember),
     available: (state, getters) =>

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -37,7 +37,7 @@ export default {
         ...metaStatusesWithId(getters, ['save', 'join', 'leave'], pickup.id),
       }
     },
-    upcomingAndOngoing: (state, getters) => {
+    upcomingAndStarted: (state, getters) => {
       return Object.values(state.entries)
         .filter(p => p.date >= subMinutes(state.now, pickupRunningTime))
         .map(getters.enrich)
@@ -45,15 +45,10 @@ export default {
         .sort(sortByDate)
     },
     byCurrentGroup: (state, getters) => {
-      return getters.upcomingAndOngoing.filter(({ group }) => group && group.isCurrentGroup)
+      return getters.upcomingAndStarted.filter(({ group }) => group && group.isCurrentGroup)
     },
     byActiveStore: (state, getters) => {
       return getters.byCurrentGroup.filter(({ store }) => store && store.isActiveStore)
-    },
-    byActiveStoreOneTime: (state, getters) => {
-      return getters.byActiveStore
-        .filter(e => !e.series)
-        .filter(p => !p.hasStarted) // only displays upcoming pickups in manage page but not store page
     },
     joined: (state, getters) => getters.byCurrentGroup.filter(e => e.isUserMember),
     available: (state, getters) =>

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -6,16 +6,7 @@ import subMinutes from 'date-fns/sub_minutes'
 function initialState () {
   return {
     now: new Date(), // reactive current time
-    entries: {
-      234: {
-        'id': 234,
-        'date': subMinutes(new Date(), 5),
-        'store': 130,
-        'maxCollectors': 4,
-        'collectorIds': [1, 2, 423],
-        'description': 'you can join this pickup',
-      },
-    },
+    entries: {},
   }
 }
 

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -12,7 +12,7 @@ function initialState () {
         'date': subMinutes(new Date(), 5),
         'store': 130,
         'maxCollectors': 4,
-        'collectorIds': [1, 2, 3],
+        'collectorIds': [1, 2, 423],
         'description': 'you can join this pickup',
       },
     },

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -1,11 +1,21 @@
 import Vue from 'vue'
 import pickups from '@/pickups/api/pickups'
 import { createMetaModule, withMeta, isValidationError, withPrefixedIdMeta, metaStatusesWithId, metaStatuses } from '@/utils/datastore/helpers'
+import subMinutes from 'date-fns/sub_minutes'
 
 function initialState () {
   return {
     now: new Date(), // reactive current time
-    entries: {},
+    entries: {
+      234: {
+        'id': 234,
+        'date': subMinutes(new Date(), 5),
+        'store': 130,
+        'maxCollectors': 4,
+        'collectorIds': [1, 2, 3],
+        'description': 'you can join this pickup',
+      },
+    },
   }
 }
 
@@ -36,7 +46,7 @@ export default {
     },
     upcoming: (state, getters) => {
       return Object.values(state.entries)
-        .filter(p => p.date >= state.now)
+        .filter(p => p.date >= subMinutes(state.now, 30))
         .map(getters.enrich)
         .sort(sortByDate)
     },

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -6,7 +6,16 @@ import subMinutes from 'date-fns/sub_minutes'
 function initialState () {
   return {
     now: new Date(), // reactive current time
-    entries: {},
+    entries: {
+      234: {
+        'id': 234,
+        'date': subMinutes(new Date(), 5),
+        'store': 130,
+        'maxCollectors': 4,
+        'collectorIds': [1, 2, 422],
+        'description': 'you can join this pickup',
+      },
+    },
   }
 }
 
@@ -32,6 +41,7 @@ export default {
         group,
         collectors: pickup.collectorIds.map(rootGetters['users/get']),
         feedbackGivenBy: pickup.feedbackGivenBy ? pickup.feedbackGivenBy.map(rootGetters['users/get']) : [],
+        hasStarted: pickup.date <= new Date(),
         ...metaStatusesWithId(getters, ['save', 'join', 'leave'], pickup.id),
       }
     },

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import pickups from '@/pickups/api/pickups'
 import { createMetaModule, withMeta, isValidationError, withPrefixedIdMeta, metaStatusesWithId, metaStatuses } from '@/utils/datastore/helpers'
+import { pickupRunningTime } from '@/pickups/settings'
 import subMinutes from 'date-fns/sub_minutes'
 
 function initialState () {
@@ -47,7 +48,7 @@ export default {
     },
     upcoming: (state, getters) => {
       return Object.values(state.entries)
-        .filter(p => p.date >= subMinutes(state.now, 30))
+        .filter(p => p.date >= subMinutes(state.now, pickupRunningTime))
         .map(getters.enrich)
         .filter(p => p.date >= state.now || (p.isUserMember && p.date <= state.now))
         .sort(sortByDate)

--- a/src/pickups/datastore/pickups.js
+++ b/src/pickups/datastore/pickups.js
@@ -48,6 +48,7 @@ export default {
       return Object.values(state.entries)
         .filter(p => p.date >= subMinutes(state.now, 30))
         .map(getters.enrich)
+        .filter(p => p.date >= state.now || (p.isUserMember && p.date <= state.now))
         .sort(sortByDate)
     },
     byCurrentGroup: (state, getters) => {

--- a/src/pickups/datastore/pickups.spec.js
+++ b/src/pickups/datastore/pickups.spec.js
@@ -169,7 +169,7 @@ describe('pickups', () => {
       group: makeGroup({ isCurrentGroup: false }),
     })
     const otherGetters = {
-      upcoming: [activePickup, inactivePickup],
+      upcomingAndOngoing: [activePickup, inactivePickup],
     }
     const { getters } = require('./pickups').default
 

--- a/src/pickups/datastore/pickups.spec.js
+++ b/src/pickups/datastore/pickups.spec.js
@@ -29,9 +29,10 @@ describe('pickups', () => {
     beforeEach(() => {
       const now = new Date('2017-01-01T12:00:10Z')
       clock = lolex.install({ now, toFake: ['Date'] })
-      pickup1 = { id: 1, store: 10, date: new Date('2017-01-01T12:01:10Z'), collectorIds: [], group }
-      pickup2 = { id: 2, store: 11, date: new Date(), collectorIds: [userId], maxCollectors: 1, group }
-      pickup3 = { id: 3, store: 12, date: new Date(), collectorIds: [userId], group }
+      const date = new Date('2017-01-01T13:00:10Z')
+      pickup1 = { id: 1, store: 10, date, collectorIds: [], group }
+      pickup2 = { id: 2, store: 11, date, collectorIds: [userId], maxCollectors: 1, group }
+      pickup3 = { id: 3, store: 12, date, collectorIds: [userId], group }
     })
 
     afterEach(() => {
@@ -82,7 +83,7 @@ describe('pickups', () => {
         isFull: true,
         collectors: [{ id: userId, name: `Some Name${userId}` }],
         feedbackGivenBy: [],
-        hasStarted: true,
+        hasStarted: false,
       })
     })
 
@@ -171,7 +172,7 @@ describe('pickups', () => {
       group: makeGroup({ isCurrentGroup: false }),
     })
     const otherGetters = {
-      upcomingAndOngoing: [activePickup, inactivePickup],
+      upcomingAndStarted: [activePickup, inactivePickup],
     }
     const { getters } = require('./pickups').default
 

--- a/src/pickups/datastore/pickups.spec.js
+++ b/src/pickups/datastore/pickups.spec.js
@@ -29,7 +29,7 @@ describe('pickups', () => {
     beforeEach(() => {
       const now = new Date('2017-01-01T12:00:10Z')
       clock = lolex.install({ now, toFake: ['Date'] })
-      pickup1 = { id: 1, store: 10, date: new Date(), collectorIds: [], group }
+      pickup1 = { id: 1, store: 10, date: new Date('2017-01-01T12:01:10Z'), collectorIds: [], group }
       pickup2 = { id: 2, store: 11, date: new Date(), collectorIds: [userId], maxCollectors: 1, group }
       pickup3 = { id: 3, store: 12, date: new Date(), collectorIds: [userId], group }
     })
@@ -82,6 +82,7 @@ describe('pickups', () => {
         isFull: true,
         collectors: [{ id: userId, name: `Some Name${userId}` }],
         feedbackGivenBy: [],
+        hasStarted: true,
       })
     })
 
@@ -109,6 +110,7 @@ describe('pickups', () => {
         isUserMember: false,
         isEmpty: true,
         isFull: false,
+        hasStarted: true,
         ...defaultActionStatusesFor('save', 'join', 'leave'),
         store: {
           id: storeId,

--- a/src/pickups/pages/PickupsManage.vue
+++ b/src/pickups/pages/PickupsManage.vue
@@ -341,10 +341,14 @@ export default {
     ...mapGetters({
       storeId: 'stores/activeStoreId',
       pickupSeries: 'pickupSeries/byActiveStore',
-      oneTimePickups: 'pickups/byActiveStoreOneTime',
+      pickups: 'pickups/byActiveStore',
       pickupCreateStatus: 'pickups/createStatus',
       seriesCreateStatus: 'pickupSeries/createStatus',
     }),
+    oneTimePickups () {
+      // filter out already started pickups
+      return this.pickups.filter(e => !e.series && !p.hasStarted)
+    },
   },
 }
 </script>

--- a/src/pickups/pages/PickupsManage.vue
+++ b/src/pickups/pages/PickupsManage.vue
@@ -347,7 +347,7 @@ export default {
     }),
     oneTimePickups () {
       // filter out already started pickups
-      return this.pickups.filter(e => !e.series && !p.hasStarted)
+      return this.pickups.filter(p => !p.series && !p.hasStarted)
     },
   },
 }

--- a/src/pickups/settings.js
+++ b/src/pickups/settings.js
@@ -1,0 +1,1 @@
+export const pickupRunningTime = 30

--- a/test/enrichedFactories.js
+++ b/test/enrichedFactories.js
@@ -143,6 +143,7 @@ export const makePickup = data => {
     maxCollectors: 10,
     collectorIds: [],
     feedbackGivenBy: [],
+    hasStarted: false,
     description: '',
     isDisabled: false,
     ...data,


### PR DESCRIPTION
Closes #1172 

Displays pickups 30 minutes after their occurring time _for those who are signed up to it_.
The chat is still reachable then.
The member cannot leave the pickup anymore after time of pickup.
Designs of hovering and empty slots not perfect but quite fiddly... probably good enough as it is :)

## Checklist

- [ ] needs more manual testing
- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))