### PR TITLE
Add note about relative user profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please document your changes in this format:
 - Notifications for enabled, disabled and moved pickups #1147 @tiltec
 - Show dialog when editing recurring pickups if pickups diverge from defaults #1147 @tiltec
 - Buttons to reset pickups to defaults #1147 @tiltec
+- Explanatory note about user profiles being relative to groups #1196 @djahnie
 
 ### Changed
 - More details for the pickup series manage page #1147 @tiltec

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -5297,7 +5297,10 @@ exports[`Storyshots User Profile My Trust Button 1`] = `
 exports[`Storyshots User Profile Profile 1`] = `
 <div class="k-profile">
   <!---->
-  <div class="row justify-end" style="margin-bottom:-32px;"><button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable q-btn-rectangle q-focusable q-hoverable bg-primary text-white">
+  <div class="row justify-end" style="margin-bottom:-32px;">
+    <div style="margin-top:7px;margin-right:3px;">
+      User profile relative to group:
+    </div> <button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable q-btn-rectangle q-focusable q-hoverable bg-primary text-white">
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center">
         group 1
@@ -5331,7 +5334,8 @@ exports[`Storyshots User Profile Profile 1`] = `
           </div>
         </div>
       </div>
-    </button></div>
+    </button>
+  </div>
   <div class="photoAndName row no-wrap ellipsis">
     <div duration="510" name="turn-in" appear="" class="photo q-pa-sm q-ma-md bg-white shadow-4">
       <div class="wrapper" style="width:180px;height:180px;">

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -51,7 +51,8 @@
       "TITLE": "What is this carrot button about?",
       "MESSAGE": "It is part of the Karrot trust system. It shows if a group member is newcomer and how much trust is needed until they gain editing permissions.",
       "LINK": "Click here to find out more."
-    }
+    },
+    "RELATIVE_PROFILE": "User profile relative to group:"
   },
   "SWITCHGROUP": {
     "NOT_MEMBER": "{userName} is not member of {groupName}.",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -51,8 +51,7 @@
       "TITLE": "What is this carrot button about?",
       "MESSAGE": "It is part of the Karrot trust system. It shows if a group member is newcomer and how much trust is needed until they gain editing permissions.",
       "LINK": "Click here to find out more."
-    },
-    "RELATIVE_PROFILE": "User profile relative to group:"
+    }
   },
   "SWITCHGROUP": {
     "NOT_MEMBER": "{userName} is not member of {groupName}.",

--- a/src/users/components/ProfileUI.vue
+++ b/src/users/components/ProfileUI.vue
@@ -8,11 +8,8 @@
     </QAlert>
     <div
       class="row justify-end"
-      style="margin-bottom: -32px"
+      style="margin-top: 5px; margin-right: 5px; margin-bottom: -32px"
     >
-      <div style="margin-top: 7px; margin-right: 3px">
-        {{ $t('USERDATA.RELATIVE_PROFILE') }}
-      </div>
       <SwitchGroupButton
         :user="user"
         :groups="user.groups"

--- a/src/users/components/ProfileUI.vue
+++ b/src/users/components/ProfileUI.vue
@@ -10,6 +10,9 @@
       class="row justify-end"
       style="margin-bottom: -32px"
     >
+      <div style="margin-top: 7px; margin-right: 3px">
+        {{ $t('USERDATA.RELATIVE_PROFILE') }}
+      </div>
       <SwitchGroupButton
         :user="user"
         :groups="user.groups"


### PR DESCRIPTION
## What does this PR do?
It adds the line 'User profile relative to group:' in front of the group switch button on a user profile.
(Motivated by @taistadam not seeing the button at all and going for a whole group switch to have the right version of someone's profile. Would be interested if she finds it clearer like this.)

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
