### PR TITLE
Add group logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Added
+- Support for group logos #891 @cstefanj @tiltec
+
 ### Changed
 - Don't send application conversation notification emails to inactive group members @tiltec
 

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -127,6 +127,31 @@ exports[`Storyshots General Components Search 1`] = `
 exports[`Storyshots GroupEdit create 1`] = `
 <div>
   <div class="q-card">
+    <div class="edit-box k-change-photo">
+      <div class="q-field row no-wrap items-start q-field-responsive q-field-no-input"><i aria-hidden="true" class="q-icon q-field-icon q-field-margin fas fa-camera"> </i>
+        <div class="row col">
+          <div class="q-field-label q-field-margin col-xs-12 col-sm-5">
+            <div class="q-field-label-inner row items-center">Group logo</div>
+          </div>
+          <div class="q-field-content col-xs-12 col-sm">
+            <div class="croppa-container       pointer"><input type="file" style="height:1px;width:1px;overflow:hidden;margin-left:-99999px;position:absolute;">
+              <div class="slots" style="width:0;height:0;visibility:hidden;"> <img src="statics/ic_person_black_24px.svg"></div> <canvas></canvas>
+              <!---->
+              <!---->
+            </div>
+            <div class="q-field-bottom row no-wrap">
+              <div class="q-field-helper col">Click to upload your group logo!</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!---->
+      <div class="actionButtons"><button tabindex="0" type="button" disabled="disabled" class="q-btn inline relative-position q-btn-item non-selectable q-btn-rectangle q-focusable q-hoverable bg-primary text-white">
+          <div class="q-focus-helper"></div>
+          <div class="q-btn-inner row col items-center q-popup--skip justify-center"></div>
+          <!---->
+        </button></div>
+    </div>
     <div class="edit-box">
       <form>
         <div class="q-field row no-wrap items-start q-field-responsive q-field-no-input"><i aria-hidden="true" class="q-icon q-field-icon q-field-margin fas fa-fw fa-star"> </i>
@@ -420,16 +445,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  05_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="1" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      05_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -449,16 +479,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  06_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="2" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      06_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          13 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        13 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -471,16 +506,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  02_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="3" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      02_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          33 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        33 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -493,16 +533,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  03_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="4" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      03_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          12 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        12 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -515,16 +560,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  01_testgroup_with_maps_and_password
+            <div class="q-card-media relative-position photo">
+              <div seed="6" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      01_testgroup_with_maps_and_password
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          53 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        53 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -541,16 +591,21 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  04_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="13" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      04_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -627,16 +682,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  05_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="1" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      05_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -674,16 +734,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  06_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="2" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      06_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          13 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        13 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -714,16 +779,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  02_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="3" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      02_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          33 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        33 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -761,16 +831,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  05_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="1" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      05_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -790,16 +865,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  06_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="2" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      06_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          13 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        13 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -812,16 +892,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  02_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="3" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      02_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          33 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        33 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -834,16 +919,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  03_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="4" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      03_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          12 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        12 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -856,16 +946,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  01_testgroup_with_maps_and_password
+            <div class="q-card-media relative-position photo">
+              <div seed="6" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      01_testgroup_with_maps_and_password
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          53 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        53 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -882,16 +977,21 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
           <div class="q-card groupPreviewCard relative-position">
             <!---->
             <!---->
-            <div class="q-card-primary q-card-container row no-wrap ellipsis">
-              <div class="col column">
-                <div class="q-card-title">
-                  04_testgroup
+            <div class="q-card-media relative-position photo">
+              <div seed="13" type="circles" class="full-height"></div>
+              <div class="q-card-media-overlay absolute-bottom">
+                <div class="q-card-primary q-card-container row no-wrap ellipsis">
+                  <div class="col column">
+                    <div class="q-card-title">
+                      04_testgroup
+                    </div>
+                    <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+                  </div>
+                  <div class="col-auto self-center q-card-title-extra"></div>
                 </div>
-                <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
               </div>
-              <div class="col-auto self-center q-card-title-extra"></div>
             </div>
             <div class="q-card-main q-card-container fixed-height smaller-text">
               <div>
@@ -917,16 +1017,21 @@ exports[`Storyshots GroupGalleryCard isMember = false 1`] = `
   <div class="q-card groupPreviewCard relative-position">
     <!---->
     <!---->
-    <div class="q-card-primary q-card-container row no-wrap ellipsis">
-      <div class="col column">
-        <div class="q-card-title">
-          05_testgroup
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+          <div class="col column">
+            <div class="q-card-title">
+              05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
         </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container fixed-height smaller-text">
       <div>
@@ -949,16 +1054,21 @@ exports[`Storyshots GroupGalleryCard isMember = true 1`] = `
   <div class="q-card groupPreviewCard relative-position">
     <!---->
     <!---->
-    <div class="q-card-primary q-card-container row no-wrap ellipsis">
-      <div class="col column">
-        <div class="q-card-title">
-          05_testgroup
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+          <div class="col column">
+            <div class="q-card-title">
+              05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
         </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container fixed-height smaller-text">
       <div>
@@ -999,16 +1109,21 @@ exports[`Storyshots GroupGalleryCard without public description 1`] = `
   <div class="q-card groupPreviewCard relative-position">
     <!---->
     <!---->
-    <div class="q-card-primary q-card-container row no-wrap ellipsis">
-      <div class="col column">
-        <div class="q-card-title">
-          05_testgroup
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap ellipsis">
+          <div class="col column">
+            <div class="q-card-title">
+              05_testgroup
+            </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
         </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container fixed-height smaller-text"><span class="text-italic">
         (This group has no public description... yet)
@@ -1022,16 +1137,21 @@ exports[`Storyshots GroupGalleryCard without public description 1`] = `
 exports[`Storyshots GroupPreviewUI member 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1063,16 +1183,21 @@ exports[`Storyshots GroupPreviewUI member 1`] = `
 exports[`Storyshots GroupPreviewUI not logged in 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1101,16 +1226,21 @@ exports[`Storyshots GroupPreviewUI not logged in 1`] = `
 exports[`Storyshots GroupPreviewUI not member, application needed, email not verified 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1153,16 +1283,21 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email not ver
 exports[`Storyshots GroupPreviewUI not member, application needed, email verified 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1205,16 +1340,21 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email verifie
 exports[`Storyshots GroupPreviewUI not member, open group 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1257,16 +1397,21 @@ exports[`Storyshots GroupPreviewUI not member, open group 1`] = `
 exports[`Storyshots GroupPreviewUI not member, pending application 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1318,16 +1463,21 @@ exports[`Storyshots GroupPreviewUI not member, pending application 1`] = `
 exports[`Storyshots GroupPreviewUI not member, playground 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap text-secondary">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <i aria-hidden="true" class="q-icon fas fa-child text-secondary"> </i></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap text-secondary">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <i aria-hidden="true" class="q-icon fas fa-child text-secondary"> </i></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1370,16 +1520,21 @@ exports[`Storyshots GroupPreviewUI not member, playground 1`] = `
 exports[`Storyshots GroupPreviewUI pending join 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        01_testgroup_with_maps_and_password
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        53 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="6" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          01_testgroup_with_maps_and_password
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          53 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
       <div class="quote">
@@ -1421,16 +1576,21 @@ exports[`Storyshots GroupPreviewUI pending join 1`] = `
 exports[`Storyshots GroupPreviewUI without public description 1`] = `
 <div>
   <div class="q-card shadow-6">
-    <div class="q-card-primary q-card-container row no-wrap">
-      <div class="col column">
-        <div class="q-card-title"><span class="row group items-start">
-        05_testgroup
-        <!----></span> </div>
-        <div class="q-card-subtitle"><span>
-        18 Members
-      </span></div>
+    <div class="q-card-media relative-position photo">
+      <div seed="1" type="circles" class="full-height"></div>
+      <div class="q-card-media-overlay absolute-bottom">
+        <div class="q-card-primary q-card-container row no-wrap">
+          <div class="col column">
+            <div class="q-card-title"><span class="row group items-start">
+          05_testgroup
+          <!----></span> </div>
+            <div class="q-card-subtitle"><span>
+          18 Members
+        </span></div>
+          </div>
+          <div class="col-auto self-center q-card-title-extra"></div>
+        </div>
       </div>
-      <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container"><span class="text-italic">
         (This group has no public description... yet)
@@ -3615,7 +3775,7 @@ exports[`Storyshots Settings Page Default 1`] = `
       <div class="col-auto self-center q-card-title-extra"></div>
     </div>
     <div class="q-card-main q-card-container">
-      <div class="edit-box">
+      <div class="edit-box k-change-photo">
         <div class="q-field row no-wrap items-start q-field-responsive q-field-no-input"><i aria-hidden="true" class="q-icon q-field-icon q-field-margin fas fa-camera"> </i>
           <div class="row col">
             <div class="q-field-label q-field-margin col-xs-12 col-sm-5">

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -135,7 +135,7 @@ exports[`Storyshots GroupEdit create 1`] = `
           </div>
           <div class="q-field-content col-xs-12 col-sm">
             <div class="croppa-container       pointer"><input type="file" style="height:1px;width:1px;overflow:hidden;margin-left:-99999px;position:absolute;">
-              <div class="slots" style="width:0;height:0;visibility:hidden;"> <img src="statics/ic_person_black_24px.svg"></div> <canvas></canvas>
+              <div class="slots" style="width:0;height:0;visibility:hidden;"> <img src="statics/add_a_photo.svg"></div> <canvas></canvas>
               <!---->
               <!---->
             </div>
@@ -3783,7 +3783,7 @@ exports[`Storyshots Settings Page Default 1`] = `
             </div>
             <div class="q-field-content col-xs-12 col-sm">
               <div class="croppa-container       pointer"><input type="file" style="height:1px;width:1px;overflow:hidden;margin-left:-99999px;position:absolute;">
-                <div class="slots" style="width:0;height:0;visibility:hidden;"> <img src="statics/ic_person_black_24px.svg"></div> <canvas></canvas>
+                <div class="slots" style="width:0;height:0;visibility:hidden;"> <img src="statics/add_a_photo.svg"></div> <canvas></canvas>
                 <!---->
                 <!---->
               </div>

--- a/src/authuser/api/authUser.js
+++ b/src/authuser/api/authUser.js
@@ -10,7 +10,12 @@ export default {
   },
 
   async save (obj) {
-    return (await axios.patch('/api/auth/user/', obj)).data
+    let data = obj
+    if (obj.photo) {
+      data = new FormData()
+      data.append('photo', obj.photo, 'photo.jpeg')
+    }
+    return (await axios.patch('/api/auth/user/', data)).data
   },
 
   delete (id) {

--- a/src/authuser/components/Settings/ChangePhoto.spec.js
+++ b/src/authuser/components/Settings/ChangePhoto.spec.js
@@ -26,7 +26,7 @@ describe('ChangePhoto', () => {
     // src contains the full path
     // location is set to 'localhost' by jest, but can be configured
     // https://jestjs.io/docs/en/configuration.html#testurl-string
-    expect(wrapper.find('img').element.src).toBe('http://localhost/statics/ic_person_black_24px.svg')
+    expect(wrapper.find('img').element.src).toBe('http://localhost/statics/add_a_photo.svg')
   })
 
   it('renders image from localhost in development/test', async () => {

--- a/src/authuser/components/Settings/ChangePhoto.spec.js
+++ b/src/authuser/components/Settings/ChangePhoto.spec.js
@@ -19,7 +19,7 @@ describe('ChangePhoto', () => {
   })
 
   it('renders', () => {
-    expect(wrapper.element.className).toBe('edit-box')
+    expect(wrapper.element.className).toBe('edit-box k-change-photo')
   })
 
   it('renders placeholder image', () => {
@@ -42,6 +42,6 @@ describe('ChangePhoto', () => {
 
   it('emits a save event', async () => {
     wrapper.vm.save()
-    expect(wrapper.emitted().save[0][0]).toEqual({ photo: null })
+    expect(wrapper.emitted().save[0][0]).toEqual(null)
   })
 })

--- a/src/authuser/components/Settings/ChangePhoto.vue
+++ b/src/authuser/components/Settings/ChangePhoto.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="edit-box">
+  <div class="edit-box k-change-photo">
     <QField
       icon="fas fa-camera"
-      :label="$t('USERDATA.PHOTO')"
+      :label="label"
       :error="hasError('photo')"
       :error-label="firstError('photo')"
-      :helper="$t('USERDATA.SET_PHOTO')"
+      :helper="helper"
     >
       <Croppa
         ref="croppaPhoto"
@@ -69,6 +69,8 @@ export default {
   props: {
     value: { required: true, type: Object },
     mimeType: { type: String, default: 'image/png' },
+    label: { type: String, default: '' },
+    helper: { type: String, default: '' },
   },
   data () {
     return {
@@ -112,14 +114,11 @@ export default {
 
 <style scoped lang="stylus">
 @import '~editbox'
-</style>
-
-<style lang="stylus">
-.croppa-container canvas
-  width 100% !important
-  height 100% !important
-  max-width 300px
-  max-height 300px
-.croppa-container.pointer canvas
-  cursor pointer
+.k-change-photo
+  >>> .croppa-container
+    canvas
+      width 100% !important
+      height 100% !important
+      max-width 300px
+      max-height 300px
 </style>

--- a/src/authuser/components/Settings/ChangePhoto.vue
+++ b/src/authuser/components/Settings/ChangePhoto.vue
@@ -26,7 +26,7 @@
         >
         <img
           slot="placeholder"
-          src="statics/ic_person_black_24px.svg"
+          src="statics/add_a_photo.svg"
         >
       </Croppa>
     </QField>
@@ -121,4 +121,5 @@ export default {
       height 100% !important
       max-width 300px
       max-height 300px
+      cursor pointer
 </style>

--- a/src/authuser/components/Settings/ChangePhoto.vue
+++ b/src/authuser/components/Settings/ChangePhoto.vue
@@ -12,7 +12,6 @@
         :width="300"
         :height="300"
         placeholder=""
-        canvas-color="#fff"
         :prevent-white-space="true"
         :show-loading="true"
         @file-choose="saveDisabled = false"
@@ -69,6 +68,7 @@ export default {
   mixins: [statusMixin],
   props: {
     value: { required: true, type: Object },
+    mimeType: { type: String, default: 'image/png' },
   },
   data () {
     return {
@@ -98,13 +98,11 @@ export default {
   methods: {
     async save () {
       if (this.$refs.croppaPhoto.hasImage()) {
-        const photoBlob = await this.$refs.croppaPhoto.promisedBlob('image/jpeg', 0.9)
-        const data = new FormData()
-        data.append('photo', photoBlob, 'photo.jpeg')
-        this.$emit('save', data)
+        const photoBlob = await this.$refs.croppaPhoto.promisedBlob(this.mimeType, 0.9)
+        this.$emit('save', photoBlob)
       }
       else {
-        this.$emit('save', { photo: null })
+        this.$emit('save', null)
       }
       this.saveDisabled = true
     },

--- a/src/authuser/pages/Settings.vue
+++ b/src/authuser/pages/Settings.vue
@@ -6,7 +6,8 @@
         <ChangePhoto
           :value="user"
           :status="profileEditStatus"
-          @save="saveUser"
+          mime-type="image/jpeg"
+          @save="saveUser({ photo: arguments[0] })"
         />
         <QCardSeparator />
         <ProfileEdit

--- a/src/authuser/pages/Settings.vue
+++ b/src/authuser/pages/Settings.vue
@@ -6,6 +6,8 @@
         <ChangePhoto
           :value="user"
           :status="profileEditStatus"
+          :label="$t('USERDATA.PHOTO')"
+          :helper="$t('USERDATA.SET_PHOTO')"
           mime-type="image/jpeg"
           @save="saveUser({ photo: arguments[0] })"
         />

--- a/src/group/api/groups.js
+++ b/src/group/api/groups.js
@@ -33,8 +33,14 @@ export default {
   },
 
   async save (group) {
-    let groupId = group.id
-    return convert((await axios.patch(`/api/groups/${groupId}/`, group)).data)
+    let data = group
+    if (group.photo) {
+      data = new FormData()
+      data.append('photo', group.photo, 'photo.png')
+    }
+
+    const groupId = group.id
+    return convert((await axios.patch(`/api/groups/${groupId}/`, data)).data)
   },
 
   async join (groupId) {

--- a/src/group/components/GroupEdit.vue
+++ b/src/group/components/GroupEdit.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
     <QCard>
+      <ChangePhoto
+        :value="value"
+        :status="status"
+        @save="$emit('save', { id: value.id, photo: arguments[0] })"
+      />
       <div
         class="edit-box"
         :class="{ changed: hasChanged }"

--- a/src/group/components/GroupEdit.vue
+++ b/src/group/components/GroupEdit.vue
@@ -4,6 +4,8 @@
       <ChangePhoto
         :value="value"
         :status="status"
+        :label="$t('GROUP.LOGO')"
+        :helper="$t('GROUP.SET_LOGO')"
         @save="$emit('save', { id: value.id, photo: arguments[0] })"
       />
       <div
@@ -156,6 +158,7 @@ import { validationMixin } from 'vuelidate'
 import { required, minLength, maxLength } from 'vuelidate/lib/validators'
 import editMixin from '@/utils/mixins/editMixin'
 import statusMixin from '@/utils/mixins/statusMixin'
+import ChangePhoto from '@/authuser/components/Settings/ChangePhoto'
 
 export default {
   name: 'GroupEdit',
@@ -192,6 +195,7 @@ export default {
     QAutocomplete,
     AddressPicker,
     MarkdownInput,
+    ChangePhoto,
   },
   computed: {
     canSave () {

--- a/src/group/datastore/currentGroup.js
+++ b/src/group/datastore/currentGroup.js
@@ -20,6 +20,7 @@ export default {
       return {
         ...group,
         isPlayground,
+        hasPhoto: group.photoUrls && group.photoUrls.fullSize,
         membership: getters.membership,
         memberships: getters.memberships,
         activeAgreement: getters.activeAgreement,

--- a/src/groupInfo/components/GroupGalleryCard.vue
+++ b/src/groupInfo/components/GroupGalleryCard.vue
@@ -20,12 +20,28 @@
       <QTooltip v-if="hasMyApplication">
         {{ $t('APPLICATION.GALLERY_TOOLTIP') }}
       </QTooltip>
-      <QCardTitle class="ellipsis">
-        {{ group.name }}
-        <span slot="subtitle">
-          {{ group.members.length }} {{ $tc('JOINGROUP.NUM_MEMBERS', group.members.length) }}
-        </span>
-      </QCardTitle>
+      <QCardMedia
+        class="photo"
+      >
+        <img
+          v-if="group.hasPhoto"
+          :src="group.photoUrls.fullSize">
+        <RandomArt
+          v-else
+          :seed="group.id"
+          type="circles"
+          class="full-height"
+        />
+        <QCardTitle
+          slot="overlay"
+          class="ellipsis"
+        >
+          {{ group.name }}
+          <span slot="subtitle">
+            {{ group.members.length }} {{ $tc('JOINGROUP.NUM_MEMBERS', group.members.length) }}
+          </span>
+        </QCardTitle>
+      </QCardMedia>
       <QCardMain class="fixed-height smaller-text">
         <div
           v-if="group.publicDescription"
@@ -66,11 +82,36 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { QCard, QCardTitle, QCardMain, QCardSeparator, QCardActions, QBtn, QTooltip, QIcon, QChip } from 'quasar'
+import {
+  QCard,
+  QCardTitle,
+  QCardMain,
+  QCardSeparator,
+  QCardActions,
+  QCardMedia,
+  QBtn,
+  QTooltip,
+  QIcon,
+  QChip,
+} from 'quasar'
 import Markdown from '@/utils/components/Markdown'
+import RandomArt from '@/utils/components/RandomArt'
 
 export default {
-  components: { Markdown, QCard, QCardTitle, QCardMain, QCardSeparator, QCardActions, QBtn, QTooltip, QIcon, QChip },
+  components: {
+    Markdown,
+    RandomArt,
+    QCard,
+    QCardTitle,
+    QCardMain,
+    QCardSeparator,
+    QCardActions,
+    QCardMedia,
+    QBtn,
+    QTooltip,
+    QIcon,
+    QChip,
+  },
   props: {
     group: {
       type: Object,
@@ -121,4 +162,11 @@ export default {
     max-height 60px
   .smaller-text >>> *
     font-size 1em
+  .photo
+    height 160px
+    img
+      max-height 100%
+      max-width 100%
+      width auto
+      margin 0 auto
 </style>

--- a/src/groupInfo/components/GroupPreviewUI.vue
+++ b/src/groupInfo/components/GroupPreviewUI.vue
@@ -1,21 +1,37 @@
 <template>
   <div v-if="group">
     <QCard class="shadow-6">
-      <QCardTitle
-        :class="group.isPlayground ? 'text-secondary' : ''"
+      <QCardMedia
+        class="photo"
+        :class="{ hasPhoto: group.hasPhoto }"
       >
-        <span class="row group items-start">
-          {{ group.name }}
-          <QIcon
-            v-if="group.isPlayground"
-            name="fas fa-child"
-            color="secondary"
-          />
-        </span>
-        <span slot="subtitle">
-          {{ group.members.length }} {{ $tc('JOINGROUP.NUM_MEMBERS', group.members.length) }}
-        </span>
-      </QCardTitle>
+        <img
+          v-if="group.hasPhoto"
+          :src="group.photoUrls.fullSize"
+        >
+        <RandomArt
+          v-else
+          :seed="group.id"
+          type="circles"
+          class="full-height"
+        />
+        <QCardTitle
+          :class="group.isPlayground ? 'text-secondary' : ''"
+          slot="overlay"
+        >
+          <span class="row group items-start">
+            {{ group.name }}
+            <QIcon
+              v-if="group.isPlayground"
+              name="fas fa-child"
+              color="secondary"
+            />
+          </span>
+          <span slot="subtitle">
+            {{ group.members.length }} {{ $tc('JOINGROUP.NUM_MEMBERS', group.members.length) }}
+          </span>
+        </QCardTitle>
+      </QCardMedia>
       <QCardMain>
         <div
           v-if="group.publicDescription"
@@ -119,12 +135,14 @@ import {
   QCardMain,
   QCardSeparator,
   QCardActions,
+  QCardMedia,
   QBtn,
   QIcon,
   QAlert,
 } from 'quasar'
 import Markdown from '@/utils/components/Markdown'
 import statusMixin from '@/utils/mixins/statusMixin'
+import RandomArt from '@/utils/components/RandomArt'
 
 export default {
   props: {
@@ -151,11 +169,13 @@ export default {
     QCardMain,
     QCardSeparator,
     QCardActions,
+    QCardMedia,
     QBtn,
     QIcon,
     QTooltip,
     QAlert,
     Markdown,
+    RandomArt,
   },
   computed: {
     status () {
@@ -181,4 +201,14 @@ export default {
 <style scoped lang="stylus">
 .q-card *
   overflow: hidden
+.photo
+  &.hasPhoto
+    height 200px
+  &:not(.hasPhoto)
+    height 140px
+  img
+    max-height 100%
+    max-width 100%
+    width auto
+    margin 0 auto
 </style>

--- a/src/groupInfo/datastore/groups.js
+++ b/src/groupInfo/datastore/groups.js
@@ -32,6 +32,7 @@ export default {
         isCurrentGroup,
         isPlayground,
         isInactive,
+        hasPhoto: group.photoUrls && group.photoUrls.fullSize,
         ...metaStatusesWithId(getters, ['save', 'join', 'leave'], group.id),
       }
     },

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -115,6 +115,8 @@
     "PRIVATE_DESCRIPTION_TITLE": "Private group description",
     "DESCRIPTION_VERBOSE": "Group description, visible for members",
     "PUBLIC_DESCRIPTION": "Text you see before joining the group",
+    "LOGO": "Group logo",
+    "SET_LOGO": "Click to upload your group logo!",
     "APPLICATIONS": "Applications",
     "APPLICATION_QUESTIONS": "Questions for people who want to join this group",
     "PICKUPS": "Pickups",

--- a/src/statics/add_a_photo.svg
+++ b/src/statics/add_a_photo.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="add_a_photo.svg"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1023"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="0.50847458"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10" />
+  <defs
+     id="defs3">
+    <path
+       id="a"
+       d="M24 24H0V0h24v24z" />
+  </defs>
+  <clipPath
+     id="b">
+    <use
+       xlink:href="#a"
+       overflow="visible"
+       id="use5" />
+  </clipPath>
+  <path
+     clip-path="url(#b)"
+     d="M 3,4 V 1 H 5 V 4 H 8 V 6 H 5 V 9 H 3 V 6 H 0 V 4 Z m 3,6 V 7 H 9 V 4 h 7 l 1.83,2 H 21 c 1.1,0 2,0.9 2,2 v 12 c 0,1.1 -0.9,2 -2,2 H 5 C 3.9,22 3,21.1 3,20 V 10 Z m 7,9 c 2.76,0 5,-2.24 5,-5 0,-2.76 -2.24,-5 -5,-5 -2.76,0 -5,2.24 -5,5 0,2.76 2.24,5 5,5 z M 9.8,14 c 0,1.77 1.43,3.2 3.2,3.2 1.77,0 3.2,-1.43 3.2,-3.2 0,-1.77 -1.43,-3.2 -3.2,-3.2 -1.77,0 -3.2,1.43 -3.2,3.2 z"
+     id="path8"
+     style="fill:#808080"
+     inkscape:connector-curvature="0"
+     transform="matrix(0.55784819,0,0,0.55784819,5.0847458,5.0847458)" />
+</svg>

--- a/src/statics/ic_person_black_24px.svg
+++ b/src/statics/ic_person_black_24px.svg
@@ -1,4 +1,0 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
-</svg>

--- a/src/topbar/components/KTopbar.vue
+++ b/src/topbar/components/KTopbar.vue
@@ -4,6 +4,7 @@ import KTopbarUI from './KTopbarUI'
 
 export default connect({
   gettersToProps: {
+    currentGroup: 'currentGroup/value',
     breadcrumbs: 'breadcrumbs/all',
     user: 'auth/user',
     searchOpen: 'search/open',

--- a/src/topbar/components/KTopbarUI.vue
+++ b/src/topbar/components/KTopbarUI.vue
@@ -6,7 +6,12 @@
       v-if="!$q.platform.is.mobile"
       class="logo"
     >
-      <KarrotLogo/>
+      <img
+        v-if="currentGroup && currentGroup.hasPhoto"
+        :src="currentGroup.photoUrls.thumbnail"
+        style="height: 95%"
+      >
+      <KarrotLogo v-else />
     </RouterLink>
     <QToolbarTitle>
       <div class="row justify-between no-wrap">
@@ -168,6 +173,10 @@ export default {
     NotificationButton,
   },
   props: {
+    currentGroup: {
+      default: null,
+      type: Object,
+    },
     breadcrumbs: {
       type: Array,
       required: false,

--- a/src/topbar/components/Layout.story.js
+++ b/src/topbar/components/Layout.story.js
@@ -12,6 +12,7 @@ const datastore = createDatastore({
   users: { getters: { all: () => usersMock } },
   search: require('@/topbar/datastore/search').default,
   breadcrumbs: { getters: { all: () => [] } },
+  currentGroup: { getters: { value: () => ({}) } },
   auth: { getters: { user: () => currentUserMock } },
   i18n: { getters: { locale: () => 'en' } },
   presence: require('@/utils/datastore/presence').default,


### PR DESCRIPTION
Closes #891

## What does this PR do?

Adds group logo support, using https://github.com/yunity/karrot-backend/pull/621
Uses circle-style RandomArt if no logo has been uploaded

![screenshot_2019-01-14_23-16-42](https://user-images.githubusercontent.com/4410802/51144852-80468180-1852-11e9-8731-94a8dab3da0b.png)


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
