### PR TITLE
Support new backend API with pickup dates as range

### DIFF
--- a/src/pickups/api/pickups.js
+++ b/src/pickups/api/pickups.js
@@ -62,22 +62,28 @@ export function convert (val) {
     return val.map(convert)
   }
   else {
-    return {
-      ...val,
-      feedbackDue: new Date(val.feedbackDue),
-      ...(val.date ? {
-        date: new Date(val.date[0]),
-        dateEnd: new Date(val.date[1]),
-      } : {}),
+    const result = { ...val }
+
+    if (val.feedbackDue) {
+      result.feedbackDue = new Date(val.feedbackDue)
     }
+
+    if (val.date) {
+      result.date = new Date(val.date[0])
+      result.dateEnd = new Date(val.date[1])
+    }
+
+    return result
   }
 }
 
-function convertDateToRange (pickup) {
-  return {
-    ...pickup,
-    ...(pickup.date ? {
-      date: [pickup.date],
-    } : {}),
+export function convertDateToRange (pickup) {
+  const result = { ...pickup }
+  if (pickup.date) {
+    result.date = [pickup.date]
+    if (pickup.dateEnd) {
+      result.date.push(pickup.dateEnd)
+    }
   }
+  return result
 }

--- a/src/pickups/api/pickups.js
+++ b/src/pickups/api/pickups.js
@@ -6,7 +6,7 @@ import subMinutes from 'date-fns/sub_minutes'
 export default {
 
   async create (pickup) {
-    return convert((await axios.post('/api/pickup-dates/', pickup)).data)
+    return convert((await axios.post('/api/pickup-dates/', convertDateToRange(pickup))).data)
   },
 
   async get (pickupId) {
@@ -40,7 +40,7 @@ export default {
   },
 
   async save (pickup) {
-    return convert((await axios.patch(`/api/pickup-dates/${pickup.id}/`, pickup)).data)
+    return convert((await axios.patch(`/api/pickup-dates/${pickup.id}/`, convertDateToRange(pickup))).data)
   },
 
   async join (pickupId) {
@@ -64,8 +64,20 @@ export function convert (val) {
   else {
     return {
       ...val,
-      date: new Date(val.date),
       feedbackDue: new Date(val.feedbackDue),
+      ...(val.date ? {
+        date: new Date(val.date[0]),
+        dateEnd: new Date(val.date[1]),
+      } : {}),
     }
+  }
+}
+
+function convertDateToRange (pickup) {
+  return {
+    ...pickup,
+    ...(pickup.date ? {
+      date: [pickup.date],
+    } : {}),
   }
 }

--- a/src/pickups/api/pickups.spec.js
+++ b/src/pickups/api/pickups.spec.js
@@ -1,0 +1,22 @@
+describe('pickups/api/pickups', () => {
+  beforeEach(() => jest.resetModules())
+
+  it('converts date range into date and dateEnd', () => {
+    const { convert } = require('./pickups')
+    const date = new Date()
+    const dateEnd = new Date()
+    expect(convert({
+      date: [date, dateEnd],
+    })).toEqual({ date, dateEnd })
+  })
+
+  it('converts date into date range', () => {
+    const { convertDateToRange } = require('./pickups')
+    const date = new Date()
+    expect(convertDateToRange({
+      date,
+    })).toEqual({
+      date: [date],
+    })
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Just the minimal needed to work with the backend in https://github.com/yunity/karrot-backend/pull/622

No actually support for setting pickups with end dates, but will at least work as before :)

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
