### PR TITLE
Wrapper for images does not overflow images to stop content…

### DIFF
--- a/src/feedback/components/AmountPicker.vue
+++ b/src/feedback/components/AmountPicker.vue
@@ -18,7 +18,6 @@
           :amount="value"
         />
         <div
-          style="margin-left: .6em"
           class="col"
         >
           <div
@@ -55,7 +54,7 @@
         <!-- don't use type="number" here because browsers might enforce different decimal setting
         depending on browser locale-->
         <QInput
-          style="width: 5em; margin: 0 5px 0 2em; text-align: right"
+          style="width: 3em; margin: 0 5px 0 2em; text-align: right"
           v-model="valueToNumber"
           align="right"
         />
@@ -100,6 +99,8 @@ export default {
 </script>
 
 <style scoped lang="stylus">
+.amount
+  margin-right: 0.6em
 .wrapper
   position relative
 .showOverlay .content

--- a/src/feedback/components/AmountViewer.vue
+++ b/src/feedback/components/AmountViewer.vue
@@ -1,11 +1,15 @@
 <template>
-  <div class="wrapper row">
+  <TransitionGroup
+    name="imageTransition"
+    tag="div"
+    class="wrapper col"
+  >
     <img
       v-for="(photoSrc, idx) in photosArray"
       :src="photoSrc"
       :key="idx"
     >
-  </div>
+  </TransitionGroup>
 </template>
 
 <script>
@@ -77,8 +81,22 @@ export default {
 <style scoped lang="stylus">
 @import '~variables'
 .wrapper
-  .amount
-    margin-right .6em
+  display flex
+  flex 1
+  min-height 60px
+  overflow-x hidden
   img
+    margin-right: -10px
     height 60px
+
+.imageTransition-enter-active
+  transition: all 1s 1s
+.imageTransition-leave-active
+  transition: all 1s
+.imageTransition-leave-to
+  opacity: 0;
+  transform: translateY(30px)
+.imageTransition-enter
+  opacity: 0;
+  transform: translateX(60px)
 </style>


### PR DESCRIPTION
Wrapper for images does not overflow images to stop content below it from jumping around. Also added a transition to the images.

## What does this PR do?

As mentioned in #1111, using the slider on a screen that's not so wide makes the content jump around because the images keep getting added and removed. This is a small ui improvement to counter this jarring effect.

## Links to related issues

https://github.com/yunity/karrot-frontend/issues/1111

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
