### PR TITLE
Mark conversations as seen when opening the latestMessages menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Added
+
+### Changed
+- Mark latest messages as seen when visiting the menu, without the need to mark all messages as read @tiltec
+- Dim topbar buttons and make them brighter when there's something interesting in them @tiltec
 
 ## [6.4.0] - 2019-01-18
 ### Added

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2209,7 +2209,7 @@ exports[`Storyshots Layout KTopbar 1`] = `
       <div></div>
     </div>
   </div>
-  <!----> <button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
+  <!----> <button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable k-search-button q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-fw fa-search"> </i>
       <div class="q-tooltip animate-popup">
@@ -2224,7 +2224,7 @@ exports[`Storyshots Layout KTopbar 1`] = `
     </div>
   </button> <button tabindex="0" type="button" title="Messages" class="q-btn inline relative-position q-btn-item non-selectable q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
     <div class="q-focus-helper"></div>
-    <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-comments"> </i>
+    <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-comments hasUnread"> </i>
       <div class="q-chip row no-wrap inline items-center q-chip-floating q-chip-dense q-chip-square bg-secondary text-white">
         <div class="q-chip-main ellipsis q-popup--skip">
           1
@@ -2234,7 +2234,7 @@ exports[`Storyshots Layout KTopbar 1`] = `
     </div>
   </button> <button tabindex="0" type="button" title="Notifications" class="q-btn inline relative-position q-btn-item non-selectable q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
     <div class="q-focus-helper"></div>
-    <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-bell"> </i>
+    <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-bell hasUnseen"> </i>
       <div class="q-chip row no-wrap inline items-center q-chip-floating q-chip-dense q-chip-square bg-secondary text-white">
         <div class="q-chip-main ellipsis q-popup--skip">
           1
@@ -2242,7 +2242,7 @@ exports[`Storyshots Layout KTopbar 1`] = `
       </div>
       <div tabindex="-1" class="q-popover scroll k-notifications-popover"></div>
     </div>
-  </button> <button tabindex="0" type="button" title="Switch language" class="q-btn inline relative-position q-btn-item non-selectable q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
+  </button> <button tabindex="0" type="button" title="Switch language" class="q-btn inline relative-position q-btn-item non-selectable k-locale-select q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-globe fa-fw"> </i>
       <div tabindex="-1" minimized="" class="q-popover scroll"></div>
@@ -2256,7 +2256,7 @@ exports[`Storyshots Layout KTopbar 1`] = `
           <div></div>
         </div>
       </div>
-    </button></a> <button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
+    </button></a> <button tabindex="0" type="button" class="q-btn inline relative-position q-btn-item non-selectable k-more-options q-btn-round q-btn-flat q-focusable q-hoverable q-btn-dense">
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><i aria-hidden="true" class="q-icon fas fa-ellipsis-v"> </i>
       <div tabindex="-1" class="q-popover scroll">

--- a/src/base/datastore/routerPlugin.js
+++ b/src/base/datastore/routerPlugin.js
@@ -74,14 +74,14 @@ export default datastore => {
 
   datastore.watch((state, getters) => [
     getters['breadcrumbs/allNames'],
-    getters['latestMessages/unreadCount'],
-  ], ([breadcrumbNames, unreadCount]) => {
+    getters['latestMessages/unseenCount'],
+  ], ([breadcrumbNames, unseenCount]) => {
     let names = breadcrumbNames.slice().reverse()
     names.push('Karrot')
     let title = names.join(' · ')
 
-    if (unreadCount > 0) {
-      title = `(${unreadCount}) ${title}`
+    if (unseenCount > 0) {
+      title = `(${unseenCount}) ${title}`
     }
 
     document.title = title

--- a/src/base/pages/MainLayout.vue
+++ b/src/base/pages/MainLayout.vue
@@ -182,7 +182,7 @@ export default {
       routeError: 'routeError/status',
       showRightDrawer: 'detail/isActive',
       disableDesktopSidenav: 'route/disableDesktopSidenav',
-      messagesUnreadCount: 'latestMessages/unreadCount',
+      messagesUnseenCount: 'latestMessages/unseenCount',
       messagesAllUnreadMuted: 'latestMessages/allUnreadMuted',
       notificationsUnseenCount: 'notifications/unseenCount',
       currentGroup: 'currentGroup/value',
@@ -212,7 +212,7 @@ export default {
       return Boolean(this.routerComponents.sidenav)
     },
     hasNotification () {
-      return this.messagesUnreadCount > 0 || this.notificationsUnseenCount > 0
+      return this.messagesUnseenCount > 0 || this.notificationsUnseenCount > 0
     },
     hasImportantNotification () {
       return !this.messagesAllUnreadMuted || this.notificationsUnseenCount > 0

--- a/src/base/socket.js
+++ b/src/base/socket.js
@@ -8,7 +8,7 @@ import auth from '@/authuser/api/auth'
 import { camelizeKeys } from '@/utils/utils'
 import { convert as convertApplication } from '@/applications/api/groupApplications'
 import { convert as convertMessage } from '@/messages/api/messages'
-import { convert as convertConversation } from '@/messages/api/conversations'
+import { convert as convertConversation, convertMeta as convertConversationMeta } from '@/messages/api/conversations'
 import { convert as convertPickup } from '@/pickups/api/pickups'
 import { convert as convertSeries } from '@/pickups/api/pickupSeries'
 import { convert as convertFeedback } from '@/feedback/api/feedback'
@@ -174,6 +174,9 @@ function receiveMessage ({ topic, payload }) {
     const conversation = convertConversation(camelizeKeys(payload))
     datastore.dispatch('conversations/updateConversation', conversation)
     datastore.dispatch('latestMessages/updateConversationsAndRelated', { conversations: [conversation] })
+  }
+  else if (topic === 'conversations:meta') {
+    datastore.commit('latestMessages/setEntryMeta', convertConversationMeta(camelizeKeys(payload)))
   }
   else if (topic === 'conversations:leave') {
     datastore.commit('conversations/clearConversation', payload.id)

--- a/src/base/style/app.variables.styl
+++ b/src/base/style/app.variables.styl
@@ -41,3 +41,4 @@ $accentFont = 'Cabin Sketch'
 
 $groupNavOverlay = 0  // TODO seems not needed, remove?
 
+$topbar-opacity-low = .6

--- a/src/communityFeed/components/CommunityFeed.vue
+++ b/src/communityFeed/components/CommunityFeed.vue
@@ -1,12 +1,15 @@
 <template>
   <QBtn
-    icon="fab fa-discourse fa-fw"
     :title="$t('COMMUNITY_FEED.HEADER', { community: $t('COMMUNITY_FEED.HEADER_LINK') })"
     flat
     dense
     round
     @click="showing = !showing"
   >
+    <QIcon
+      name="fab fa-discourse fa-fw"
+      :class="{ hasUnread: unreadCount > 0 }"
+    />
     <QChip
       v-if="unreadCount > 0"
       floating
@@ -160,5 +163,8 @@ export default {
   background linear-gradient(to right, $lightGreen, $lighterGreen)
 body.desktop .k-community-feed
   max-width 700px
-
+.q-icon:not(.hasUnread)
+  opacity $topbar-opacity-low
+.q-btn:hover .q-icon
+  opacity 1
 </style>

--- a/src/messages/api/conversations.js
+++ b/src/messages/api/conversations.js
@@ -38,6 +38,10 @@ export default {
       muted,
     })).data)
   },
+
+  async markAllSeen () {
+    return (await axios.post(`/api/conversations/mark_all_seen/`)).data
+  },
 }
 
 function convertListResults (results) {
@@ -47,6 +51,7 @@ function convertListResults (results) {
     pickups: convertPickup(results.pickups),
     applications: convertApplication(results.applications),
     usersInfo: results.usersInfo,
+    meta: convertMeta(results.meta),
   }
 }
 
@@ -59,5 +64,12 @@ export function convert (val) {
       ...val,
       updatedAt: new Date(val.updatedAt),
     }
+  }
+}
+
+export function convertMeta (val) {
+  return {
+    ...val,
+    markedAt: new Date(val.markedAt),
   }
 }

--- a/src/messages/components/LatestMessageButton.vue
+++ b/src/messages/components/LatestMessageButton.vue
@@ -9,13 +9,14 @@
   >
     <QIcon
       name="fas fa-comments"
+      :class="{ hasUnread: unreadCount > 0 }"
     />
     <QChip
-      v-if="unreadCount > 0"
+      v-if="unseenCount > 0"
       floating
       :color="allUnreadMuted ? 'grey' : 'secondary'"
     >
-      {{ unreadCount > 9 ? '9+' : unreadCount }}
+      {{ unseenCount > 9 ? '9+' : unseenCount }}
     </QChip>
     <QPopover
       v-if="!$q.platform.is.mobile"
@@ -51,6 +52,7 @@ export default {
   },
   computed: {
     ...mapGetters({
+      unseenCount: 'latestMessages/unseenCount',
       unreadCount: 'latestMessages/unreadCount',
       allUnreadMuted: 'latestMessages/allUnreadMuted',
     }),
@@ -72,6 +74,11 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
+@import '~variables'
 .k-latest-messages-popover
   width 400px
+.q-icon:not(.hasUnread)
+  opacity $topbar-opacity-low
+.q-btn:hover .q-icon
+  opacity 1
 </style>

--- a/src/messages/components/LatestMessages.vue
+++ b/src/messages/components/LatestMessages.vue
@@ -146,6 +146,7 @@ export default {
       fetchPastConversations: 'latestMessages/fetchPastConversations',
       fetchPastThreads: 'latestMessages/fetchPastThreads',
       fetchInitial: 'latestMessages/fetchInitial',
+      markAllSeen: 'latestMessages/markAllSeen',
     }),
     open (conv) {
       const { type, target } = conv
@@ -164,6 +165,7 @@ export default {
   },
   mounted () {
     this.fetchInitial()
+    this.markAllSeen()
   },
 }
 </script>

--- a/src/notifications/components/NotificationButton.vue
+++ b/src/notifications/components/NotificationButton.vue
@@ -9,6 +9,7 @@
   >
     <QIcon
       name="fas fa-bell"
+      :class="{ hasUnseen: unseenCount > 0 }"
     />
     <QChip
       v-if="unseenCount > 0"
@@ -75,6 +76,11 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
+@import '~variables'
 .k-notifications-popover
   width 400px
+.q-icon:not(.hasUnseen)
+  opacity $topbar-opacity-low
+.q-btn:hover .q-icon
+  opacity 1
 </style>

--- a/src/topbar/components/KTopbarUI.vue
+++ b/src/topbar/components/KTopbarUI.vue
@@ -35,6 +35,7 @@
       dense
       round
       @click="$emit('showSearch')"
+      class="k-search-button"
     >
       <QIcon name="fas fa-fw fa-search" />
       <QTooltip v-t="'BUTTON.SEARCH'" />
@@ -85,6 +86,7 @@
         flat
         dense
         round
+        class="k-more-options"
       >
         <QIcon name="fas fa-ellipsis-v" />
         <QPopover
@@ -237,6 +239,11 @@ export default {
   background-color lightgrey
   min-width 251px
   max-width 251px
+.k-search-button, .k-more-options
+  opacity $topbar-opacity-low
+  &:hover
+    opacity 1
+
 .presence-indicator
   margin-right .3em
   font-size 100%

--- a/src/topbar/components/Layout.story.js
+++ b/src/topbar/components/Layout.story.js
@@ -26,6 +26,7 @@ const datastore = createDatastore({
   latestMessages: {
     getters: {
       unreadCount: () => 1,
+      unseenCount: () => 1,
       allUnreadMuted: () => false,
     },
   },

--- a/src/utils/components/LocaleSelect.vue
+++ b/src/utils/components/LocaleSelect.vue
@@ -5,6 +5,7 @@
     round
     @click="open = !open"
     :title="$t('LANGUAGECHOOSER.SWITCH')"
+    class="k-locale-select"
   >
     <QIcon
       name="fas fa-globe fa-fw"
@@ -58,3 +59,12 @@ export default {
   },
 }
 </script>
+
+<style lang="stylus" scoped>
+@import '~variables'
+.k-locale-select
+  .q-icon
+    opacity $topbar-opacity-low
+  &:hover .q-icon
+    opacity 1
+</style>


### PR DESCRIPTION
## What does this PR do?

It helps if users don't read all of their conversations to still get updates about new messages.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
