### PR TITLE
Emoji picker search bar

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -115,12 +115,16 @@ exports[`Storyshots ChatConversation closed 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -135,7 +139,11 @@ exports[`Storyshots ChatConversation closed 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -149,12 +157,16 @@ exports[`Storyshots ChatConversation closed 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -169,7 +181,11 @@ exports[`Storyshots ChatConversation closed 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -183,12 +199,16 @@ exports[`Storyshots ChatConversation closed 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -203,7 +223,11 @@ exports[`Storyshots ChatConversation closed 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -217,12 +241,16 @@ exports[`Storyshots ChatConversation closed 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -237,7 +265,11 @@ exports[`Storyshots ChatConversation closed 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button>
     <!----></span>
@@ -286,12 +318,16 @@ exports[`Storyshots ChatConversation default 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -306,7 +342,11 @@ exports[`Storyshots ChatConversation default 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -320,12 +360,16 @@ exports[`Storyshots ChatConversation default 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -340,7 +384,11 @@ exports[`Storyshots ChatConversation default 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -354,12 +402,16 @@ exports[`Storyshots ChatConversation default 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -374,7 +426,11 @@ exports[`Storyshots ChatConversation default 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -388,12 +444,16 @@ exports[`Storyshots ChatConversation default 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -408,7 +468,11 @@ exports[`Storyshots ChatConversation default 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button>
     <!----></span>
@@ -450,12 +514,16 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -470,7 +538,11 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -484,12 +556,16 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -504,7 +580,11 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -518,12 +598,16 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -538,7 +622,11 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -552,12 +640,16 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -572,7 +664,11 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button>
     <!----></span>
@@ -614,12 +710,16 @@ exports[`Storyshots ChatConversation not participant 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -634,7 +734,11 @@ exports[`Storyshots ChatConversation not participant 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -648,12 +752,16 @@ exports[`Storyshots ChatConversation not participant 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -668,7 +776,11 @@ exports[`Storyshots ChatConversation not participant 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -682,12 +794,16 @@ exports[`Storyshots ChatConversation not participant 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -702,7 +818,11 @@ exports[`Storyshots ChatConversation not participant 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -716,12 +836,16 @@ exports[`Storyshots ChatConversation not participant 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -736,7 +860,11 @@ exports[`Storyshots ChatConversation not participant 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button>
     <!----></span>
@@ -778,12 +906,16 @@ exports[`Storyshots ChatConversation thread 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 11</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 11</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -798,7 +930,11 @@ exports[`Storyshots ChatConversation thread 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -812,12 +948,16 @@ exports[`Storyshots ChatConversation thread 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 13</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 13</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -832,7 +972,11 @@ exports[`Storyshots ChatConversation thread 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -846,12 +990,16 @@ exports[`Storyshots ChatConversation thread 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 15</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 15</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -866,7 +1014,11 @@ exports[`Storyshots ChatConversation thread 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -944,14 +1096,14 @@ exports[`Storyshots Detail application 1`] = `
         </div>
         <div>
           <div class="q-collapsible-sub-item relative-position">
-            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">Group 0</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">Group 0</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <div class="markdown">
                 <p>What are your motivations for joining slköaslkfjasdfasfd?</p>
               </div>
             </div>
-            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">User 29</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">User 29</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <div class="markdown">
@@ -986,12 +1138,16 @@ exports[`Storyshots Detail application 1`] = `
                 <div class="q-focus-helper"></div>
                 <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                  <div tabindex="-1" class="q-popover scroll"></div>
+                  <div tabindex="-1" class="q-popover scroll">
+                    <div style="width:195px;">
+                      <!---->
+                    </div>
+                  </div>
                 </div>
               </button></div>
             <!---->
             <div class="q-item-main q-item-section">
-              <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 27</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+              <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 27</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
                 <!---->
@@ -1006,7 +1162,11 @@ exports[`Storyshots Detail application 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button>
             <!----></span>
@@ -1020,12 +1180,16 @@ exports[`Storyshots Detail application 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 25</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 25</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -1040,7 +1204,11 @@ exports[`Storyshots Detail application 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -1054,12 +1222,16 @@ exports[`Storyshots Detail application 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 23</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 23</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -1074,7 +1246,11 @@ exports[`Storyshots Detail application 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -1088,12 +1264,16 @@ exports[`Storyshots Detail application 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 21</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 21</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -1108,7 +1288,11 @@ exports[`Storyshots Detail application 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -2858,13 +3042,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 9:15 AM">
+            <div title="Oct 2, 2017, 5:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 9:15 AM">
+          <div title="Oct 2, 2017, 5:15 AM">
             3 months ago
           </div>
         </div>
@@ -2885,13 +3069,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 9:15 AM">
+            <div title="Oct 2, 2017, 5:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 9:15 AM">
+          <div title="Oct 2, 2017, 5:15 AM">
             3 months ago
           </div>
         </div>
@@ -2912,13 +3096,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 9:15 AM">
+            <div title="Oct 2, 2017, 5:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 9:15 AM">
+          <div title="Oct 2, 2017, 5:15 AM">
             3 months ago
           </div>
         </div>
@@ -2939,13 +3123,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 9:12 AM">
+            <div title="Oct 2, 2017, 5:12 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 9:12 AM">
+          <div title="Oct 2, 2017, 5:12 AM">
             3 months ago
           </div>
         </div>
@@ -2966,13 +3150,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 9:12 AM">
+            <div title="Oct 2, 2017, 5:12 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 9:12 AM">
+          <div title="Oct 2, 2017, 5:12 AM">
             3 months ago
           </div>
         </div>
@@ -2991,13 +3175,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 8:00 AM">
+            <div title="Oct 2, 2017, 4:00 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 8:00 AM">
+          <div title="Oct 2, 2017, 4:00 AM">
             3 months ago
           </div>
         </div>
@@ -3018,13 +3202,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 4:28 PM">
+            <div title="Oct 1, 2017, 12:28 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 4:28 PM">
+          <div title="Oct 1, 2017, 12:28 PM">
             3 months ago
           </div>
         </div>
@@ -3045,13 +3229,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 4:28 PM">
+            <div title="Oct 1, 2017, 12:28 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 4:28 PM">
+          <div title="Oct 1, 2017, 12:28 PM">
             3 months ago
           </div>
         </div>
@@ -3072,13 +3256,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 4:27 PM">
+            <div title="Oct 1, 2017, 12:27 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 4:27 PM">
+          <div title="Oct 1, 2017, 12:27 PM">
             3 months ago
           </div>
         </div>
@@ -3099,7 +3283,7 @@ exports[`Storyshots Issues history item 1`] = `
           Your group voted to keep discussing
         </div>
         <div class="text-weight-light q-item-stamp">
-          <div title="Dec 30, 2017, 6:00 PM">
+          <div title="Dec 30, 2017, 1:00 PM">
             less than a minute ago
           </div>
         </div>
@@ -3111,7 +3295,7 @@ exports[`Storyshots Issues history item 1`] = `
         <div class="q-list">
           <div class="q-item q-item-division relative-position">
             <div class="q-item-main q-item-section">
-              <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 6:00 PM</div>
+              <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 1:00 PM</div>
               <div class="q-item-sublabel" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">6 members participated in the voting.</div>
             </div>
           </div>
@@ -3158,7 +3342,7 @@ exports[`Storyshots Issues results - expelled 1`] = `
 <div class="q-list">
   <div class="q-item q-item-division relative-position">
     <div class="q-item-main q-item-section">
-      <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 6:00 PM</div>
+      <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 1:00 PM</div>
       <div class="q-item-sublabel" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">6 members participated in the voting.</div>
     </div>
   </div>
@@ -3209,7 +3393,7 @@ exports[`Storyshots Issues vote - furtherDiscussion 1`] = `
   <div class="q-pb-lg">
     <div class="q-caption q-caption-opacity row inline">
       <div>Time left to vote</div>:
-      <div title="Dec 30, 2017, 6:00 PM" class="q-pl-xs">
+      <div title="Dec 30, 2017, 1:00 PM" class="q-pl-xs">
         6 days
       </div>
     </div>
@@ -3323,7 +3507,7 @@ exports[`Storyshots Latest Messages flag: closed 1`] = `
           Mira Bellenbaum
         </div>
         <!----> <i aria-hidden="true" title="This conversation has been closed automatically." class="q-icon q-ml-xs fas fa-fw fa-lock text-grey" style="font-size:12px;"> </i>
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3355,7 +3539,7 @@ exports[`Storyshots Latest Messages flag: closed+muted 1`] = `
         <div class="ellipsis">
           Mira Bellenbaum
         </div> <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i> <i aria-hidden="true" title="This conversation has been closed automatically." class="q-icon q-ml-xs fas fa-fw fa-lock text-grey" style="font-size:12px;"> </i>
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3387,7 +3571,7 @@ exports[`Storyshots Latest Messages flag: muted 1`] = `
         Mira Bellenbaum
         <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i>
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3417,7 +3601,7 @@ exports[`Storyshots Latest Messages flag: unread 1`] = `
         Mira Bellenbaum
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3451,7 +3635,7 @@ exports[`Storyshots Latest Messages flag: unread+muted 1`] = `
         Mira Bellenbaum
         <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i>
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3487,7 +3671,7 @@ exports[`Storyshots Latest Messages type: application chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3517,7 +3701,7 @@ exports[`Storyshots Latest Messages type: group wall 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3547,7 +3731,7 @@ exports[`Storyshots Latest Messages type: issue chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3581,7 +3765,7 @@ exports[`Storyshots Latest Messages type: my application chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3606,10 +3790,10 @@ exports[`Storyshots Latest Messages type: pickup chat 1`] = `
   <div class="q-item-main q-item-section">
     <div class="row no-wrap justify-between items-baseline q-item-label">
       <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" class="q-icon q-mr-sm fas fa-fw fa-shopping-basket"> </i>
-        Saturday 8:00 AM
+        Saturday 4:00 AM
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3642,7 +3826,7 @@ exports[`Storyshots Latest Messages type: place wall 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3674,7 +3858,7 @@ exports[`Storyshots Latest Messages type: private chat 1`] = `
         Mira Bellenbaum
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3702,7 +3886,7 @@ exports[`Storyshots Latest Messages type: thread 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -4083,7 +4267,7 @@ exports[`Storyshots Notifications application_accepted 1`] = `
       Your application was accepted!
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4101,7 +4285,7 @@ exports[`Storyshots Notifications application_declined 1`] = `
       Your application was declined
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4119,7 +4303,7 @@ exports[`Storyshots Notifications conflict_resolution_continued 1`] = `
       The conflict resolution process with continues
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4137,7 +4321,7 @@ exports[`Storyshots Notifications conflict_resolution_continued_about_you 1`] = 
       The conflict resolution process with you continues
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4155,7 +4339,7 @@ exports[`Storyshots Notifications conflict_resolution_created 1`] = `
       Join the discussion about a conflict with
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4173,7 +4357,7 @@ exports[`Storyshots Notifications conflict_resolution_created_about_you 1`] = `
       A conflict resolution process was started with you
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4191,7 +4375,7 @@ exports[`Storyshots Notifications conflict_resolution_decided 1`] = `
       The conflict resolution process with was decided
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4209,7 +4393,7 @@ exports[`Storyshots Notifications conflict_resolution_decided_about_you 1`] = `
       The conflict resolution process with you was decided
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4227,7 +4411,7 @@ exports[`Storyshots Notifications conflict_resolution_you_were_removed 1`] = `
       You were removed from the group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4242,10 +4426,10 @@ exports[`Storyshots Notifications feedback_possible 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-balance-scale"> </i>
-      You can give feedback for the pickup you did on Sunday 12:00 PM
+      You can give feedback for the pickup you did on Sunday 7:00 AM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4268,7 +4452,7 @@ exports[`Storyshots Notifications invitation_accepted 1`] = `
       User 38 accepted your invitation
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4290,7 +4474,7 @@ exports[`Storyshots Notifications new_applicant 1`] = `
       User 33 applied to join your group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4312,7 +4496,7 @@ exports[`Storyshots Notifications new_member 1`] = `
       User 37 joined your group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4330,7 +4514,7 @@ exports[`Storyshots Notifications new_place 1`] = `
       Place 0 has been created
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4345,10 +4529,10 @@ exports[`Storyshots Notifications pickup_disabled 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-times"> </i>
-      Pickup at Sunday, December 24, 12:00 PM was disabled
+      Pickup at Sunday, December 24, 7:00 AM was disabled
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4364,10 +4548,10 @@ exports[`Storyshots Notifications pickup_enabled 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-check"> </i>
-      Pickup at Sunday, December 24, 12:00 PM was enabled again
+      Pickup at Sunday, December 24, 7:00 AM was enabled again
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4383,10 +4567,10 @@ exports[`Storyshots Notifications pickup_moved 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline far fa-clock"> </i>
-      Pickup was moved to Sunday, December 24, 12:00 PM
+      Pickup was moved to Sunday, December 24, 7:00 AM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4402,10 +4586,10 @@ exports[`Storyshots Notifications pickup_upcoming 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-calendar-alt"> </i>
-      Reminder: You have a pickup at 12:00 PM
+      Reminder: You have a pickup at 7:00 AM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 2:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 9:00 AM" style="display:inline;">
         in about 2 hours
       </div>
       · Group 1
@@ -4428,7 +4612,7 @@ exports[`Storyshots Notifications user_became_editor 1`] = `
       User 31 gained editing permissions
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4446,7 +4630,7 @@ exports[`Storyshots Notifications voting_ends_soon 1`] = `
       Voting ends soon, don't forget to participate!
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 2:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 9:00 AM" style="display:inline;">
         in about 2 hours
       </div>
       · Group 1
@@ -4464,7 +4648,7 @@ exports[`Storyshots Notifications you_became_editor 1`] = `
       You gained editing permissions
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
+      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4663,7 +4847,7 @@ exports[`Storyshots PickupItem Full 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
         Monday, August 14, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4713,7 +4897,7 @@ exports[`Storyshots PickupItem Join 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
         Saturday, August 12, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4764,7 +4948,7 @@ exports[`Storyshots PickupItem Leave 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content isUserMember">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4811,7 +4995,7 @@ exports[`Storyshots PickupItem pending 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
         Saturday, August 12, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4873,7 +5057,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
           Saturday, August 12, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4921,7 +5105,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content isUserMember">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
           Sunday, August 13, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4965,7 +5149,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
           Monday, August 14, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5012,7 +5196,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content isEmpty">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          8:00 AM
+          4:00 AM
           <!----></span>
           Tuesday, August 15, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5086,7 +5270,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                 <div class="q-if-baseline">|</div>
                 <div class="q-if-inner col column q-popup--skip">
                   <div class="row no-wrap relative-position">
-                    <div class="col q-input-target ellipsis justify-start">8:00 AM</div>
+                    <div class="col q-input-target ellipsis justify-start">4:00 AM</div>
                   </div>
                 </div>
                 <div tabindex="-1" class="q-popover scroll">
@@ -5094,7 +5278,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                     <div class="q-datetime-header column no-wrap items-center">
                       <div class="col"></div>
                       <div class="q-datetime-time row scroll flex-center">
-                        <div class="q-datetime-clockstring col row justify-center items-start"><span class="col-auto" style="text-align:right;"><span tabindex="0" class="q-datetime-link active" style="text-align:right;"><span tabindex="-1">8</span></span></span><span style="opacity:0.6;">:</span><span class="col-auto row no-wrap items-center" style="text-align:left;"><span tabindex="0" class="q-datetime-link" style="text-align:left;"><span tabindex="-1">00</span></span><span tabindex="0" class="q-datetime-ampm column"><span class="q-datetime-link active"><span tabindex="-1">AM</span></span><span class="q-datetime-link"><span tabindex="-1">PM</span></span></span></span></div>
+                        <div class="q-datetime-clockstring col row justify-center items-start"><span class="col-auto" style="text-align:right;"><span tabindex="0" class="q-datetime-link active" style="text-align:right;"><span tabindex="-1">4</span></span></span><span style="opacity:0.6;">:</span><span class="col-auto row no-wrap items-center" style="text-align:left;"><span tabindex="0" class="q-datetime-link" style="text-align:left;"><span tabindex="-1">00</span></span><span tabindex="0" class="q-datetime-ampm column"><span class="q-datetime-link active"><span tabindex="-1">AM</span></span><span class="q-datetime-link"><span tabindex="-1">PM</span></span></span></span></div>
                       </div>
                       <div class="col"></div>
                     </div>
@@ -5105,15 +5289,15 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                           <div class="q-datetime-clock cursor-pointer">
                             <div class="q-datetime-clock-circle full-width full-height">
                               <div class="q-datetime-clock-center"></div>
-                              <div class="q-datetime-clock-pointer" style="transform:rotate(60deg);"><span></span></div>
+                              <div class="q-datetime-clock-pointer" style="transform:rotate(-60deg);"><span></span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-1"><span>1</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-2"><span>2</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-3"><span>3</span></div>
-                              <div class="q-datetime-clock-position q-datetime-clock-pos-4"><span>4</span></div>
+                              <div class="q-datetime-clock-position q-datetime-clock-pos-4 active"><span>4</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-5"><span>5</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-6"><span>6</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-7"><span>7</span></div>
-                              <div class="q-datetime-clock-position q-datetime-clock-pos-8 active"><span>8</span></div>
+                              <div class="q-datetime-clock-position q-datetime-clock-pos-8"><span>8</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-9"><span>9</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-10"><span>10</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-11"><span>11</span></div>
@@ -6853,14 +7037,14 @@ exports[`Storyshots Statistics FeedbackItem 1`] = `
     <div class="row no-wrap">
       <div class="content full-width">
         <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 8:00 AM
+            Aug 12, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
             Griesheimer Markt
           </a>
           <!---->
         </div> <small class="text-weight-light"><a>
             Mira Bellenbaum
-          </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
+          </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
   4 months ago
 </div></span></small>
         <div>
@@ -6911,14 +7095,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 8:00 AM
+            Aug 12, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Mira Bellenbaum
-                </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
+                </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
   4 months ago
 </div></span></small>
               <div>
@@ -6948,14 +7132,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 8:00 AM
+            Aug 13, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Mira Bellenbaum
-                </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 3:40 PM">
+                </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 11:40 AM">
   3 months ago
 </div></span></small>
               <div>
@@ -6981,14 +7165,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 8:00 AM
+            Aug 13, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Max Mustermann
-                </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 12:12 PM">
+                </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 8:12 AM">
   3 months ago
 </div></span></small>
               <div>
@@ -7034,29 +7218,29 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
                     <div class="q-if-baseline">|</div>
                     <div class="q-if-inner col column q-popup--skip">
                       <div class="row no-wrap relative-position">
-                        <div class="col q-input-target ellipsis justify-start">Aug 12, 2017, 8:00 AM (Griesheimer Markt)</div>
+                        <div class="col q-input-target ellipsis justify-start">Aug 12, 2017, 4:00 AM (Griesheimer Markt)</div>
                       </div>
                     </div>
                     <div tabindex="-1" class="q-popover scroll column no-wrap">
                       <div class="q-list no-border scroll">
                         <div class="q-item q-item-division relative-position cursor-pointer q-select-highlight cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 12, 2017, 8:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 12, 2017, 4:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 13, 2017, 8:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 13, 2017, 4:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 14, 2017, 8:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 14, 2017, 4:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 15, 2017, 8:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 15, 2017, 4:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                       </div>
@@ -7198,14 +7382,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 8:00 AM
+            Aug 12, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Mira Bellenbaum
-                    </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
+                    </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
   4 months ago
 </div></span></small>
                   <div>
@@ -7235,14 +7419,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 8:00 AM
+            Aug 13, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Mira Bellenbaum
-                    </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 3:40 PM">
+                    </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 11:40 AM">
   3 months ago
 </div></span></small>
                   <div>
@@ -7268,14 +7452,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 8:00 AM
+            Aug 13, 2017, 4:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Max Mustermann
-                    </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 12:12 PM">
+                    </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 8:12 AM">
   3 months ago
 </div></span></small>
                   <div>
@@ -7892,7 +8076,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
               <div class="q-focus-helper"></div>
               <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-                <div tabindex="-1" class="q-popover scroll"></div>
+                <div tabindex="-1" class="q-popover scroll">
+                  <div style="width:195px;">
+                    <!---->
+                  </div>
+                </div>
               </div>
             </button></div>
           <div class="q-item-side q-item-section q-item-side-left">
@@ -7901,7 +8089,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
               </a></div>
           </div>
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mira Bellenbaum</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:43 PM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mira Bellenbaum</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:43 AM">
   4 months ago
 </div></small></span>
               <!---->
@@ -7916,7 +8104,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button>
           <!----></span>
@@ -7936,7 +8128,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
             <div class="q-focus-helper"></div>
             <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-              <div tabindex="-1" class="q-popover scroll"></div>
+              <div tabindex="-1" class="q-popover scroll">
+                <div style="width:195px;">
+                  <!---->
+                </div>
+              </div>
             </div>
           </button></div>
         <div class="q-item-side q-item-section q-item-side-left">
@@ -7945,7 +8141,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
             </a></div>
         </div>
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:47 PM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:47 AM">
   4 months ago
 </div></small></span>
             <!---->
@@ -7960,7 +8156,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button>
         <!----></span>
@@ -7980,7 +8180,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
           <div class="q-focus-helper"></div>
           <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-            <div tabindex="-1" class="q-popover scroll"></div>
+            <div tabindex="-1" class="q-popover scroll">
+              <div style="width:195px;">
+                <!---->
+              </div>
+            </div>
           </div>
         </button></div>
       <div class="q-item-side q-item-section q-item-side-left">
@@ -7989,7 +8193,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
           </a></div>
       </div>
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:47 PM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:47 AM">
   4 months ago
 </div></small></span>
           <!---->
@@ -8004,7 +8208,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button>
       <!----></span>
@@ -8024,7 +8232,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
         <div class="q-focus-helper"></div>
         <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-          <div tabindex="-1" class="q-popover scroll"></div>
+          <div tabindex="-1" class="q-popover scroll">
+            <div style="width:195px;">
+              <!---->
+            </div>
+          </div>
         </div>
       </button></div>
     <div class="q-item-side q-item-section q-item-side-left">
@@ -8033,7 +8245,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
         </a></div>
     </div>
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:49 PM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:49 AM">
   4 months ago
 </div></small></span>
         <!---->
@@ -8048,7 +8260,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button>
     <!----></span>
@@ -8068,7 +8284,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button></div>
   <div class="q-item-side q-item-section q-item-side-left">
@@ -8077,7 +8297,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Karl Karlson</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:51 PM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Karl Karlson</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:51 AM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8092,7 +8312,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-      <div tabindex="-1" class="q-popover scroll"></div>
+      <div tabindex="-1" class="q-popover scroll">
+        <div style="width:195px;">
+          <!---->
+        </div>
+      </div>
     </div>
   </button>
   <!----></span>
@@ -8112,7 +8336,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button></div>
   <div class="q-item-side q-item-section q-item-side-left">
@@ -8121,7 +8349,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8136,7 +8364,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-      <div tabindex="-1" class="q-popover scroll"></div>
+      <div tabindex="-1" class="q-popover scroll">
+        <div style="width:195px;">
+          <!---->
+        </div>
+      </div>
     </div>
   </button>
   <!----></span>
@@ -8156,7 +8388,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button></div>
   <div class="q-item-side q-item-section q-item-side-left">
@@ -8165,7 +8401,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8180,7 +8416,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-      <div tabindex="-1" class="q-popover scroll"></div>
+      <div tabindex="-1" class="q-popover scroll">
+        <div style="width:195px;">
+          <!---->
+        </div>
+      </div>
     </div>
   </button>
   <!----></span>
@@ -8200,7 +8440,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button></div>
   <div class="q-item-side q-item-section q-item-side-left">
@@ -8209,7 +8453,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8224,7 +8468,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-      <div tabindex="-1" class="q-popover scroll"></div>
+      <div tabindex="-1" class="q-popover scroll">
+        <div style="width:195px;">
+          <!---->
+        </div>
+      </div>
     </div>
   </button>
   <!----></span>
@@ -8244,7 +8492,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       <div class="q-focus-helper"></div>
       <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:1;"><i class="far fa-smile"></i> +
   </span>
-        <div tabindex="-1" class="q-popover scroll"></div>
+        <div tabindex="-1" class="q-popover scroll">
+          <div style="width:195px;">
+            <!---->
+          </div>
+        </div>
       </div>
     </button></div>
   <div class="q-item-side q-item-section q-item-side-left">
@@ -8253,7 +8505,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8268,7 +8520,11 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
     <div class="q-focus-helper"></div>
     <div class="q-btn-inner row col items-center q-popup--skip justify-center"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
   </span>
-      <div tabindex="-1" class="q-popover scroll"></div>
+      <div tabindex="-1" class="q-popover scroll">
+        <div style="width:195px;">
+          <!---->
+        </div>
+      </div>
     </div>
   </button>
   <!----></span>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -124,7 +124,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -166,7 +166,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -208,7 +208,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -250,7 +250,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -327,7 +327,7 @@ exports[`Storyshots ChatConversation default 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -369,7 +369,7 @@ exports[`Storyshots ChatConversation default 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -411,7 +411,7 @@ exports[`Storyshots ChatConversation default 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -453,7 +453,7 @@ exports[`Storyshots ChatConversation default 1`] = `
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -523,7 +523,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -565,7 +565,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -607,7 +607,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -649,7 +649,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -719,7 +719,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 1</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -761,7 +761,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 3</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -803,7 +803,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 5</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -845,7 +845,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
       </button></div>
     <!---->
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 7</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
         <!---->
@@ -915,7 +915,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 11</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 11</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -957,7 +957,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 13</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 13</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -999,7 +999,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 15</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 15</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -1096,14 +1096,14 @@ exports[`Storyshots Detail application 1`] = `
         </div>
         <div>
           <div class="q-collapsible-sub-item relative-position">
-            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">Group 0</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">Group 0</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <div class="markdown">
                 <p>What are your motivations for joining slköaslkfjasdfasfd?</p>
               </div>
             </div>
-            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">User 29</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="q-ma-sm q-pa-sm bg-white"><span class="text-bold text-secondary uppercase">User 29</span> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <div class="markdown">
@@ -1147,7 +1147,7 @@ exports[`Storyshots Detail application 1`] = `
               </button></div>
             <!---->
             <div class="q-item-main q-item-section">
-              <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 27</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+              <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 27</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
                 <!---->
@@ -1189,7 +1189,7 @@ exports[`Storyshots Detail application 1`] = `
             </button></div>
           <!---->
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 25</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 25</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
               <!---->
@@ -1231,7 +1231,7 @@ exports[`Storyshots Detail application 1`] = `
           </button></div>
         <!---->
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 23</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 23</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
             <!---->
@@ -1273,7 +1273,7 @@ exports[`Storyshots Detail application 1`] = `
         </button></div>
       <!---->
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 21</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 7:00 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">User 21</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
 </div></small></span>
           <!---->
@@ -3042,13 +3042,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 5:15 AM">
+            <div title="Oct 2, 2017, 9:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 5:15 AM">
+          <div title="Oct 2, 2017, 9:15 AM">
             3 months ago
           </div>
         </div>
@@ -3069,13 +3069,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 5:15 AM">
+            <div title="Oct 2, 2017, 9:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 5:15 AM">
+          <div title="Oct 2, 2017, 9:15 AM">
             3 months ago
           </div>
         </div>
@@ -3096,13 +3096,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 5:15 AM">
+            <div title="Oct 2, 2017, 9:15 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 5:15 AM">
+          <div title="Oct 2, 2017, 9:15 AM">
             3 months ago
           </div>
         </div>
@@ -3123,13 +3123,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 5:12 AM">
+            <div title="Oct 2, 2017, 9:12 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 5:12 AM">
+          <div title="Oct 2, 2017, 9:12 AM">
             3 months ago
           </div>
         </div>
@@ -3150,13 +3150,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 5:12 AM">
+            <div title="Oct 2, 2017, 9:12 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 5:12 AM">
+          <div title="Oct 2, 2017, 9:12 AM">
             3 months ago
           </div>
         </div>
@@ -3175,13 +3175,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 2, 2017, 4:00 AM">
+            <div title="Oct 2, 2017, 8:00 AM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 2, 2017, 4:00 AM">
+          <div title="Oct 2, 2017, 8:00 AM">
             3 months ago
           </div>
         </div>
@@ -3202,13 +3202,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 12:28 PM">
+            <div title="Oct 1, 2017, 4:28 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 12:28 PM">
+          <div title="Oct 1, 2017, 4:28 PM">
             3 months ago
           </div>
         </div>
@@ -3229,13 +3229,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 12:28 PM">
+            <div title="Oct 1, 2017, 4:28 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 12:28 PM">
+          <div title="Oct 1, 2017, 4:28 PM">
             3 months ago
           </div>
         </div>
@@ -3256,13 +3256,13 @@ exports[`Storyshots History List Default 1`] = `
           did something
         </span></div>
           <div class="mobile-only text-weight-light q-item-stamp">
-            <div title="Oct 1, 2017, 12:27 PM">
+            <div title="Oct 1, 2017, 4:27 PM">
               3 months ago
             </div>
           </div>
         </div>
         <div class="q-item-side q-item-section desktop-only q-item-side-right">
-          <div title="Oct 1, 2017, 12:27 PM">
+          <div title="Oct 1, 2017, 4:27 PM">
             3 months ago
           </div>
         </div>
@@ -3283,7 +3283,7 @@ exports[`Storyshots Issues history item 1`] = `
           Your group voted to keep discussing
         </div>
         <div class="text-weight-light q-item-stamp">
-          <div title="Dec 30, 2017, 1:00 PM">
+          <div title="Dec 30, 2017, 6:00 PM">
             less than a minute ago
           </div>
         </div>
@@ -3295,7 +3295,7 @@ exports[`Storyshots Issues history item 1`] = `
         <div class="q-list">
           <div class="q-item q-item-division relative-position">
             <div class="q-item-main q-item-section">
-              <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 1:00 PM</div>
+              <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 6:00 PM</div>
               <div class="q-item-sublabel" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">6 members participated in the voting.</div>
             </div>
           </div>
@@ -3342,7 +3342,7 @@ exports[`Storyshots Issues results - expelled 1`] = `
 <div class="q-list">
   <div class="q-item q-item-division relative-position">
     <div class="q-item-main q-item-section">
-      <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 1:00 PM</div>
+      <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">This voting round ended on Dec 30, 2017, 6:00 PM</div>
       <div class="q-item-sublabel" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">6 members participated in the voting.</div>
     </div>
   </div>
@@ -3393,7 +3393,7 @@ exports[`Storyshots Issues vote - furtherDiscussion 1`] = `
   <div class="q-pb-lg">
     <div class="q-caption q-caption-opacity row inline">
       <div>Time left to vote</div>:
-      <div title="Dec 30, 2017, 1:00 PM" class="q-pl-xs">
+      <div title="Dec 30, 2017, 6:00 PM" class="q-pl-xs">
         6 days
       </div>
     </div>
@@ -3507,7 +3507,7 @@ exports[`Storyshots Latest Messages flag: closed 1`] = `
           Mira Bellenbaum
         </div>
         <!----> <i aria-hidden="true" title="This conversation has been closed automatically." class="q-icon q-ml-xs fas fa-fw fa-lock text-grey" style="font-size:12px;"> </i>
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3539,7 +3539,7 @@ exports[`Storyshots Latest Messages flag: closed+muted 1`] = `
         <div class="ellipsis">
           Mira Bellenbaum
         </div> <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i> <i aria-hidden="true" title="This conversation has been closed automatically." class="q-icon q-ml-xs fas fa-fw fa-lock text-grey" style="font-size:12px;"> </i>
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3571,7 +3571,7 @@ exports[`Storyshots Latest Messages flag: muted 1`] = `
         Mira Bellenbaum
         <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i>
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3601,7 +3601,7 @@ exports[`Storyshots Latest Messages flag: unread 1`] = `
         Mira Bellenbaum
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3635,7 +3635,7 @@ exports[`Storyshots Latest Messages flag: unread+muted 1`] = `
         Mira Bellenbaum
         <i aria-hidden="true" title="Notifications are disabled" class="q-icon q-ml-xs fas fa-fw fa-bell-slash text-grey" style="font-size:12px;"> </i>
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3671,7 +3671,7 @@ exports[`Storyshots Latest Messages type: application chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3701,7 +3701,7 @@ exports[`Storyshots Latest Messages type: group wall 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3731,7 +3731,7 @@ exports[`Storyshots Latest Messages type: issue chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3765,7 +3765,7 @@ exports[`Storyshots Latest Messages type: my application chat 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3790,10 +3790,10 @@ exports[`Storyshots Latest Messages type: pickup chat 1`] = `
   <div class="q-item-main q-item-section">
     <div class="row no-wrap justify-between items-baseline q-item-label">
       <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" class="q-icon q-mr-sm fas fa-fw fa-shopping-basket"> </i>
-        Saturday 4:00 AM
+        Saturday 8:00 AM
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3826,7 +3826,7 @@ exports[`Storyshots Latest Messages type: place wall 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3858,7 +3858,7 @@ exports[`Storyshots Latest Messages type: private chat 1`] = `
         Mira Bellenbaum
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -3886,7 +3886,7 @@ exports[`Storyshots Latest Messages type: thread 1`] = `
         </div>
         <!---->
         <!---->
-      </div> <span><small><div title="Aug 11, 2017, 11:43 AM" class="q-pl-xs" style="white-space:nowrap;">
+      </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
     </div>
@@ -4267,7 +4267,7 @@ exports[`Storyshots Notifications application_accepted 1`] = `
       Your application was accepted!
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4285,7 +4285,7 @@ exports[`Storyshots Notifications application_declined 1`] = `
       Your application was declined
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4303,7 +4303,7 @@ exports[`Storyshots Notifications conflict_resolution_continued 1`] = `
       The conflict resolution process with continues
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4321,7 +4321,7 @@ exports[`Storyshots Notifications conflict_resolution_continued_about_you 1`] = 
       The conflict resolution process with you continues
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4339,7 +4339,7 @@ exports[`Storyshots Notifications conflict_resolution_created 1`] = `
       Join the discussion about a conflict with
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4357,7 +4357,7 @@ exports[`Storyshots Notifications conflict_resolution_created_about_you 1`] = `
       A conflict resolution process was started with you
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4375,7 +4375,7 @@ exports[`Storyshots Notifications conflict_resolution_decided 1`] = `
       The conflict resolution process with was decided
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4393,7 +4393,7 @@ exports[`Storyshots Notifications conflict_resolution_decided_about_you 1`] = `
       The conflict resolution process with you was decided
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4411,7 +4411,7 @@ exports[`Storyshots Notifications conflict_resolution_you_were_removed 1`] = `
       You were removed from the group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4426,10 +4426,10 @@ exports[`Storyshots Notifications feedback_possible 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-balance-scale"> </i>
-      You can give feedback for the pickup you did on Sunday 7:00 AM
+      You can give feedback for the pickup you did on Sunday 12:00 PM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4452,7 +4452,7 @@ exports[`Storyshots Notifications invitation_accepted 1`] = `
       User 38 accepted your invitation
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4474,7 +4474,7 @@ exports[`Storyshots Notifications new_applicant 1`] = `
       User 33 applied to join your group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4496,7 +4496,7 @@ exports[`Storyshots Notifications new_member 1`] = `
       User 37 joined your group
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4514,7 +4514,7 @@ exports[`Storyshots Notifications new_place 1`] = `
       Place 0 has been created
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4529,10 +4529,10 @@ exports[`Storyshots Notifications pickup_disabled 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-times"> </i>
-      Pickup at Sunday, December 24, 7:00 AM was disabled
+      Pickup at Sunday, December 24, 12:00 PM was disabled
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4548,10 +4548,10 @@ exports[`Storyshots Notifications pickup_enabled 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-check"> </i>
-      Pickup at Sunday, December 24, 7:00 AM was enabled again
+      Pickup at Sunday, December 24, 12:00 PM was enabled again
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4567,10 +4567,10 @@ exports[`Storyshots Notifications pickup_moved 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline far fa-clock"> </i>
-      Pickup was moved to Sunday, December 24, 7:00 AM
+      Pickup was moved to Sunday, December 24, 12:00 PM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4586,10 +4586,10 @@ exports[`Storyshots Notifications pickup_upcoming 1`] = `
   <!---->
   <div class="q-item-main q-item-section">
     <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" class="q-icon q-mr-xs vertical-baseline fas fa-calendar-alt"> </i>
-      Reminder: You have a pickup at 7:00 AM
+      Reminder: You have a pickup at 12:00 PM
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 9:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 2:00 PM" style="display:inline;">
         in about 2 hours
       </div>
       · Group 1
@@ -4612,7 +4612,7 @@ exports[`Storyshots Notifications user_became_editor 1`] = `
       User 31 gained editing permissions
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4630,7 +4630,7 @@ exports[`Storyshots Notifications voting_ends_soon 1`] = `
       Voting ends soon, don't forget to participate!
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 9:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 2:00 PM" style="display:inline;">
         in about 2 hours
       </div>
       · Group 1
@@ -4648,7 +4648,7 @@ exports[`Storyshots Notifications you_became_editor 1`] = `
       You gained editing permissions
     </div>
     <div class="q-item-sublabel">
-      <div title="Dec 24, 2017, 7:00 AM" style="display:inline;">
+      <div title="Dec 24, 2017, 12:00 PM" style="display:inline;">
         less than a minute ago
       </div>
       · Group 1
@@ -4847,7 +4847,7 @@ exports[`Storyshots PickupItem Full 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
         Monday, August 14, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4897,7 +4897,7 @@ exports[`Storyshots PickupItem Join 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
         Saturday, August 12, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4948,7 +4948,7 @@ exports[`Storyshots PickupItem Leave 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content isUserMember">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
         Sunday, August 13, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -4995,7 +4995,7 @@ exports[`Storyshots PickupItem pending 1`] = `
   <div class="q-card-main q-card-container row no-padding justify-between content">
     <div class="column q-pa-sm full-width">
       <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
         Saturday, August 12, 2017
         <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5057,7 +5057,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
           Saturday, August 12, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5105,7 +5105,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content isUserMember">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
           Sunday, August 13, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5149,7 +5149,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
           Monday, August 14, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5196,7 +5196,7 @@ exports[`Storyshots PickupList Default 1`] = `
     <div class="q-card-main q-card-container row no-padding justify-between content isEmpty">
       <div class="column q-pa-sm full-width">
         <div><span class="featured-text">
-          4:00 AM
+          8:00 AM
           <!----></span>
           Tuesday, August 15, 2017
           <span><strong>Open Chat <i aria-hidden="true" class="q-icon material-icons">chat</i></strong></span></div>
@@ -5270,7 +5270,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                 <div class="q-if-baseline">|</div>
                 <div class="q-if-inner col column q-popup--skip">
                   <div class="row no-wrap relative-position">
-                    <div class="col q-input-target ellipsis justify-start">4:00 AM</div>
+                    <div class="col q-input-target ellipsis justify-start">8:00 AM</div>
                   </div>
                 </div>
                 <div tabindex="-1" class="q-popover scroll">
@@ -5278,7 +5278,7 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                     <div class="q-datetime-header column no-wrap items-center">
                       <div class="col"></div>
                       <div class="q-datetime-time row scroll flex-center">
-                        <div class="q-datetime-clockstring col row justify-center items-start"><span class="col-auto" style="text-align:right;"><span tabindex="0" class="q-datetime-link active" style="text-align:right;"><span tabindex="-1">4</span></span></span><span style="opacity:0.6;">:</span><span class="col-auto row no-wrap items-center" style="text-align:left;"><span tabindex="0" class="q-datetime-link" style="text-align:left;"><span tabindex="-1">00</span></span><span tabindex="0" class="q-datetime-ampm column"><span class="q-datetime-link active"><span tabindex="-1">AM</span></span><span class="q-datetime-link"><span tabindex="-1">PM</span></span></span></span></div>
+                        <div class="q-datetime-clockstring col row justify-center items-start"><span class="col-auto" style="text-align:right;"><span tabindex="0" class="q-datetime-link active" style="text-align:right;"><span tabindex="-1">8</span></span></span><span style="opacity:0.6;">:</span><span class="col-auto row no-wrap items-center" style="text-align:left;"><span tabindex="0" class="q-datetime-link" style="text-align:left;"><span tabindex="-1">00</span></span><span tabindex="0" class="q-datetime-ampm column"><span class="q-datetime-link active"><span tabindex="-1">AM</span></span><span class="q-datetime-link"><span tabindex="-1">PM</span></span></span></span></div>
                       </div>
                       <div class="col"></div>
                     </div>
@@ -5289,15 +5289,15 @@ exports[`Storyshots PickupSeriesEdit Default 1`] = `
                           <div class="q-datetime-clock cursor-pointer">
                             <div class="q-datetime-clock-circle full-width full-height">
                               <div class="q-datetime-clock-center"></div>
-                              <div class="q-datetime-clock-pointer" style="transform:rotate(-60deg);"><span></span></div>
+                              <div class="q-datetime-clock-pointer" style="transform:rotate(60deg);"><span></span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-1"><span>1</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-2"><span>2</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-3"><span>3</span></div>
-                              <div class="q-datetime-clock-position q-datetime-clock-pos-4 active"><span>4</span></div>
+                              <div class="q-datetime-clock-position q-datetime-clock-pos-4"><span>4</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-5"><span>5</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-6"><span>6</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-7"><span>7</span></div>
-                              <div class="q-datetime-clock-position q-datetime-clock-pos-8"><span>8</span></div>
+                              <div class="q-datetime-clock-position q-datetime-clock-pos-8 active"><span>8</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-9"><span>9</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-10"><span>10</span></div>
                               <div class="q-datetime-clock-position q-datetime-clock-pos-11"><span>11</span></div>
@@ -7037,14 +7037,14 @@ exports[`Storyshots Statistics FeedbackItem 1`] = `
     <div class="row no-wrap">
       <div class="content full-width">
         <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 4:00 AM
+            Aug 12, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
             Griesheimer Markt
           </a>
           <!---->
         </div> <small class="text-weight-light"><a>
             Mira Bellenbaum
-          </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
+          </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
   4 months ago
 </div></span></small>
         <div>
@@ -7095,14 +7095,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 4:00 AM
+            Aug 12, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Mira Bellenbaum
-                </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
+                </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
   4 months ago
 </div></span></small>
               <div>
@@ -7132,14 +7132,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 4:00 AM
+            Aug 13, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Mira Bellenbaum
-                </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 11:40 AM">
+                </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 3:40 PM">
   3 months ago
 </div></span></small>
               <div>
@@ -7165,14 +7165,14 @@ exports[`Storyshots Statistics FeedbackList 1`] = `
           <div class="row no-wrap">
             <div class="content full-width">
               <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 4:00 AM
+            Aug 13, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                   Griesheimer Markt
                 </a>
                 <!---->
               </div> <small class="text-weight-light"><a>
                   Max Mustermann
-                </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 8:12 AM">
+                </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 12:12 PM">
   3 months ago
 </div></span></small>
               <div>
@@ -7218,29 +7218,29 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
                     <div class="q-if-baseline">|</div>
                     <div class="q-if-inner col column q-popup--skip">
                       <div class="row no-wrap relative-position">
-                        <div class="col q-input-target ellipsis justify-start">Aug 12, 2017, 4:00 AM (Griesheimer Markt)</div>
+                        <div class="col q-input-target ellipsis justify-start">Aug 12, 2017, 8:00 AM (Griesheimer Markt)</div>
                       </div>
                     </div>
                     <div tabindex="-1" class="q-popover scroll column no-wrap">
                       <div class="q-list no-border scroll">
                         <div class="q-item q-item-division relative-position cursor-pointer q-select-highlight cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 12, 2017, 4:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 12, 2017, 8:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 13, 2017, 4:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 13, 2017, 8:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 14, 2017, 4:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 14, 2017, 8:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                         <div class="q-item q-item-division relative-position cursor-pointer cursor-pointer">
                           <div class="q-item-main q-item-section">
-                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 15, 2017, 4:00 AM (Griesheimer Markt)</div>
+                            <div class="q-item-label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:NaN;">Aug 15, 2017, 8:00 AM (Griesheimer Markt)</div>
                           </div>
                         </div>
                       </div>
@@ -7382,14 +7382,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 12, 2017, 4:00 AM
+            Aug 12, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Mira Bellenbaum
-                    </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 11:43 AM">
+                    </a> <span place="date" class="message-date"><div title="Aug 11, 2017, 3:43 PM">
   4 months ago
 </div></span></small>
                   <div>
@@ -7419,14 +7419,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 4:00 AM
+            Aug 13, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Mira Bellenbaum
-                    </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 11:40 AM">
+                    </a> <span place="date" class="message-date"><div title="Sep 11, 2017, 3:40 PM">
   3 months ago
 </div></span></small>
                   <div>
@@ -7452,14 +7452,14 @@ exports[`Storyshots Statistics PickupFeedback 1`] = `
               <div class="row no-wrap">
                 <div class="content full-width">
                   <div class="row no-wrap items-baseline"><strong class="q-mr-sm" style="white-space:nowrap;">
-            Aug 13, 2017, 4:00 AM
+            Aug 13, 2017, 8:00 AM
           </strong> <a class="ellipsis text-secondary">
                       Griesheimer Markt
                     </a>
                     <!---->
                   </div> <small class="text-weight-light"><a>
                       Max Mustermann
-                    </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 8:12 AM">
+                    </a> <span place="date" class="message-date"><div title="Sep 18, 2017, 12:12 PM">
   3 months ago
 </div></span></small>
                   <div>
@@ -8089,7 +8089,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
               </a></div>
           </div>
           <div class="q-item-main q-item-section">
-            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mira Bellenbaum</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:43 AM">
+            <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mira Bellenbaum</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:43 PM">
   4 months ago
 </div></small></span>
               <!---->
@@ -8141,7 +8141,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
             </a></div>
         </div>
         <div class="q-item-main q-item-section">
-          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:47 AM">
+          <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:47 PM">
   4 months ago
 </div></small></span>
             <!---->
@@ -8193,7 +8193,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
           </a></div>
       </div>
       <div class="q-item-main q-item-section">
-        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:47 AM">
+        <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:47 PM">
   4 months ago
 </div></small></span>
           <!---->
@@ -8245,7 +8245,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
         </a></div>
     </div>
     <div class="q-item-main q-item-section">
-      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:49 AM">
+      <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:49 PM">
   4 months ago
 </div></small></span>
         <!---->
@@ -8297,7 +8297,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Karl Karlson</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:51 AM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Karl Karlson</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:51 PM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8349,7 +8349,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8401,7 +8401,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8453,7 +8453,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
   4 months ago
 </div></small></span>
       <!---->
@@ -8505,7 +8505,7 @@ exports[`Storyshots WallConversation WallConversation 1`] = `
       </a></div>
   </div>
   <div class="q-item-main q-item-section">
-    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 11:52 AM">
+    <div class="no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Aug 11, 2017, 3:52 PM">
   4 months ago
 </div></small></span>
       <!---->

--- a/src/messages/components/ConversationAddReaction.spec.js
+++ b/src/messages/components/ConversationAddReaction.spec.js
@@ -24,17 +24,17 @@ describe('Conversation message reactions', () => {
   it('changing search changes emoji displayed', () => {
     wrapper.setData({ search: 'pizza' })
 
-    expect(wrapper.vm.whitelist).toContain('pizza')
-    expect(wrapper.vm.whitelist).not.toContain('laughing')
+    expect(wrapper.vm.results).toContain('pizza')
+    expect(wrapper.vm.results).not.toContain('laughing')
   })
 
   it('searches with many results get truncated', () => {
     wrapper.setData({ search: 'man' })
 
-    expect(wrapper.vm.whitelist.length).toBe(20)
+    expect(wrapper.vm.results.length).toBe(20)
   })
 
   it('emoji is not present when already reacted', () => {
-    expect(wrapper.vm.whitelist).not.toContain('thumbsup')
+    expect(wrapper.vm.results).not.toContain('thumbsup')
   })
 })

--- a/src/messages/components/ConversationAddReaction.spec.js
+++ b/src/messages/components/ConversationAddReaction.spec.js
@@ -21,6 +21,19 @@ describe('Conversation message reactions', () => {
     expect(wrapper.emitted().toggle).toEqual([['laughing']])
   })
 
+  it('changing search changes emoji displayed', () => {
+    wrapper.setData({ search: 'pizza' })
+
+    expect(wrapper.vm.whitelist).toContain('pizza')
+    expect(wrapper.vm.whitelist).not.toContain('laughing')
+  })
+
+  it('searches with many results get truncated', () => {
+    wrapper.setData({ search: 'man' })
+
+    expect(wrapper.vm.whitelist.length).toBe(20)
+  })
+
   it('emoji is not present when already reacted', () => {
     expect(wrapper.vm.whitelist).not.toContain('thumbsup')
   })

--- a/src/messages/components/ConversationAddReaction.vue
+++ b/src/messages/components/ConversationAddReaction.vue
@@ -9,11 +9,13 @@
       @show="open = true"
       @hide="open = false"
     >
-      <ConversationAddReactionInner
-        v-if="open"
-        :reacted="reacted"
-        @toggle="$emit('toggle', arguments[0])"
-      />
+      <div style="width: 195px">
+        <ConversationAddReactionInner
+          v-if="open"
+          :reacted="reacted"
+          @toggle="$emit('toggle', arguments[0])"
+        />
+      </div>
     </QPopover>
   </QBtn>
 </template>

--- a/src/messages/components/ConversationAddReaction.vue
+++ b/src/messages/components/ConversationAddReaction.vue
@@ -7,15 +7,11 @@
       anchor="top left"
       self="top left"
       @show="open = true"
-      @hide="open = false, search = ''"
+      @hide="open = false"
     >
-      <QSearch
-        v-model="search"
-      />
       <ConversationAddReactionInner
         v-if="open"
         :reacted="reacted"
-        :search="search"
         @toggle="$emit('toggle', arguments[0])"
       />
     </QPopover>
@@ -23,12 +19,12 @@
 </template>
 
 <script>
-import { QBtn, QPopover, QSearch } from 'quasar'
+import { QBtn, QPopover } from 'quasar'
 
 const ConversationAddReactionInner = () => import('./ConversationAddReactionInner')
 
 export default {
-  components: { QBtn, QPopover, QSearch, ConversationAddReactionInner },
+  components: { QBtn, QPopover, ConversationAddReactionInner },
   props: {
     opacity: {
       type: Number,
@@ -42,7 +38,6 @@ export default {
   data () {
     return {
       open: false,
-      search: '',
     }
   },
 }

--- a/src/messages/components/ConversationAddReaction.vue
+++ b/src/messages/components/ConversationAddReaction.vue
@@ -9,10 +9,14 @@
       @show="open = true"
       @hide="open = false"
     >
-      <QSearch v-model="search" />
+      <p>{{ search }}</p>
+      <QSearch
+        v-model="search"
+      />
       <ConversationAddReactionInner
         v-if="open"
         :reacted="reacted"
+        :search="search"
         @toggle="$emit('toggle', arguments[0])"
       />
     </QPopover>
@@ -39,6 +43,7 @@ export default {
   data () {
     return {
       open: false,
+      search: '',
     }
   },
 }

--- a/src/messages/components/ConversationAddReaction.vue
+++ b/src/messages/components/ConversationAddReaction.vue
@@ -9,6 +9,7 @@
       @show="open = true"
       @hide="open = false"
     >
+      <QSearch v-model="search" />
       <ConversationAddReactionInner
         v-if="open"
         :reacted="reacted"
@@ -19,12 +20,12 @@
 </template>
 
 <script>
-import { QBtn, QPopover } from 'quasar'
+import { QBtn, QPopover, QSearch } from 'quasar'
 
 const ConversationAddReactionInner = () => import('./ConversationAddReactionInner')
 
 export default {
-  components: { QBtn, QPopover, ConversationAddReactionInner },
+  components: { QBtn, QPopover, QSearch, ConversationAddReactionInner },
   props: {
     opacity: {
       type: Number,

--- a/src/messages/components/ConversationAddReaction.vue
+++ b/src/messages/components/ConversationAddReaction.vue
@@ -7,9 +7,8 @@
       anchor="top left"
       self="top left"
       @show="open = true"
-      @hide="open = false"
+      @hide="open = false, search = ''"
     >
-      <p>{{ search }}</p>
       <QSearch
         v-model="search"
       />

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="row"
-    style="margin: 2px 4px; width: 185px"
   >
     <QSearch
       v-model="search"
@@ -92,4 +91,8 @@ export default {
 <style scoped lang="stylus">
 .big
   font-size 1.6em
+  max-width 8px
+.row
+  margin 2px 4px
+  max-width 225px
 </style>

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -90,7 +90,6 @@ export default {
 
 <style scoped lang="stylus">
 .k-add-reaction
-  width 185px
   margin 2px 4px
 .big
   font-size 1.6em

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -36,14 +36,10 @@ function searchEmoji (search) {
     matchingEmojiNames.push(cleanedSearch)
   }
 
-  // Checks the length because we don't want to have too many results
+  // Checking input length because we don't want to have too many results
   if (cleanedSearch.length > 2) {
-    for (var index in Object.keys(emojiList)) {
-      // This regular expression does a substring search of emoji names to
-      // find more interesting results
-      const regexp = '.*' + cleanedSearch + '.*'
-      const emojiShortcode = Object.keys(emojiList)[index]
-      if (emojiShortcode.match(regexp) &&
+    for (const emojiShortcode in emojiList) {
+      if (emojiShortcode.includes(cleanedSearch) &&
           emojiShortcode !== cleanedSearch &&
           !matchingEmojiUnicodes.has(emojiList[emojiShortcode])) {
         matchingEmojiUnicodes.add(emojiList[emojiShortcode])

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -17,6 +17,19 @@
 
 <script>
 import EmojiButton from './EmojiButton'
+import emojiList from 'markdown-it-emoji/lib/data/full.json'
+
+function searchEmoji (search) {
+  // clean search by removing colons and setting lowercase
+  let cleanedSearch = search.replace(/:/g, '').toLowerCase()
+  // only considers exact match searches
+  if (Object.keys(emojiList).includes(cleanedSearch)) {
+    return [cleanedSearch]
+  }
+  else {
+    return []
+  }
+}
 
 export default {
   components: { EmojiButton },
@@ -33,9 +46,8 @@ export default {
   computed: {
     whitelist () {
       // sorted alphabetically
-      console.log('search: ' + this.search)
       if (this.search !== '') {
-        return [this.search].filter(e => !this.reacted.includes(e))
+        return searchEmoji(this.search).filter(e => !this.reacted.includes(e))
       }
       return [
         'carrot',

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="row"
+    class="k-add-reaction"
   >
     <QSearch
       v-model="search"
@@ -89,10 +89,9 @@ export default {
 </script>
 
 <style scoped lang="stylus">
+.k-add-reaction
+  width 185px
+  margin 2px 4px
 .big
   font-size 1.6em
-  max-width 8px
-.row
-  margin 2px 4px
-  max-width 225px
 </style>

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -55,6 +55,11 @@ export default {
         'ok_hand',
         'thumbsup',
         'thumbsdown',
+        'rage',
+        'cry',
+        'heart',
+        'muscle',
+        'raised_hands',
       ].filter(e => !this.reacted.includes(e))
     },
   },

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -27,12 +27,26 @@ function searchEmoji (search) {
   // clean search by removing colons and setting lowercase
   let cleanedSearch = search.replace(/:/g, '').toLowerCase()
   // only considers exact match searches
+  let match = []
   if (Object.keys(emojiList).includes(cleanedSearch)) {
-    return [cleanedSearch]
+    match.push(cleanedSearch)
   }
-  else {
-    return []
+  // Don't search if user hasn't input more than 2 characters
+  if (cleanedSearch.length > 2) {
+    for (var key in Object.keys(emojiList)) {
+      // Regexp matching characters
+      let regexp = cleanedSearch.split('').join('.*')
+      regexp = regexp + '.*'
+      if (Object.keys(emojiList)[key].match(regexp) &&
+          Object.keys(emojiList)[key] !== cleanedSearch) {
+        match.push(Object.keys(emojiList)[key])
+      }
+      if (match.length >= 20) {
+        return match
+      }
+    }
   }
+  return match
 }
 
 export default {

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -6,7 +6,7 @@
       v-model="search"
     />
     <EmojiButton
-      v-for="name in whitelist"
+      v-for="name in results"
       :key="name"
       v-close-overlay
       :name="name"
@@ -66,7 +66,7 @@ export default {
     }
   },
   computed: {
-    whitelist () {
+    results () {
       // sorted alphabetically
       if (this.search !== '') {
         return searchEmoji(this.search).filter(e => !this.reacted.includes(e))

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -25,10 +25,18 @@ export default {
       type: Array,
       default: () => [],
     },
+    search: {
+      type: String,
+      default: () => '',
+    },
   },
   computed: {
     whitelist () {
       // sorted alphabetically
+      console.log('search: ' + this.search)
+      if (this.search !== '') {
+        return [this.search].filter(e => !this.reacted.includes(e))
+      }
       return [
         'carrot',
         'laughing',

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -24,29 +24,37 @@ import emojiList from 'markdown-it-emoji/lib/data/full.json'
 import { QSearch } from 'quasar'
 
 function searchEmoji (search) {
-  // clean search by removing colons and setting lowercase
+  // Remove colons and set to lowercase to normalize search
   let cleanedSearch = search.replace(/:/g, '').toLowerCase()
-  // only considers exact match searches
-  let match = []
+  let matchingEmojiNames = []
+  // The set is used to remove duplicate emoji that may have different names
+  let matchingEmojiUnicodes = new Set()
+  // First add the exact search in case there is an emoji shortcode with less
+  // than three characters
   if (Object.keys(emojiList).includes(cleanedSearch)) {
-    match.push(cleanedSearch)
+    matchingEmojiUnicodes.add(emojiList[cleanedSearch])
+    matchingEmojiNames.push(cleanedSearch)
   }
-  // Don't search if user hasn't input more than 2 characters
+
+  // Checks the length because we don't want to have too many results
   if (cleanedSearch.length > 2) {
-    for (var key in Object.keys(emojiList)) {
-      // Regexp matching characters
-      let regexp = cleanedSearch.split('').join('.*')
-      regexp = regexp + '.*'
-      if (Object.keys(emojiList)[key].match(regexp) &&
-          Object.keys(emojiList)[key] !== cleanedSearch) {
-        match.push(Object.keys(emojiList)[key])
+    for (var index in Object.keys(emojiList)) {
+      // This regular expression does a substring search of emoji names to
+      // find more interesting results
+      let regexp = '.*' + cleanedSearch + '.*'
+      let emojiShortcode = Object.keys(emojiList)[index]
+      if (emojiShortcode.match(regexp) &&
+          emojiShortcode !== cleanedSearch &&
+          !matchingEmojiUnicodes.has(emojiList[emojiShortcode])) {
+        matchingEmojiUnicodes.add(emojiList[emojiShortcode])
+        matchingEmojiNames.push(emojiShortcode)
       }
-      if (match.length >= 20) {
-        return match
+      if (matchingEmojiNames.length >= 20) {
+        return matchingEmojiNames
       }
     }
   }
-  return match
+  return matchingEmojiNames
 }
 
 export default {

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -1,8 +1,11 @@
 <template>
   <div
     class="row"
-    style="margin: 2px 4px"
+    style="margin: 2px 4px; width: 185px"
   >
+    <QSearch
+      v-model="search"
+    />
     <EmojiButton
       v-for="name in whitelist"
       :key="name"
@@ -18,6 +21,7 @@
 <script>
 import EmojiButton from './EmojiButton'
 import emojiList from 'markdown-it-emoji/lib/data/full.json'
+import { QSearch } from 'quasar'
 
 function searchEmoji (search) {
   // clean search by removing colons and setting lowercase
@@ -32,16 +36,17 @@ function searchEmoji (search) {
 }
 
 export default {
-  components: { EmojiButton },
+  components: { EmojiButton, QSearch },
   props: {
     reacted: {
       type: Array,
       default: () => [],
     },
-    search: {
-      type: String,
-      default: () => '',
-    },
+  },
+  data () {
+    return {
+      search: '',
+    }
   },
   computed: {
     whitelist () {

--- a/src/messages/components/ConversationAddReactionInner.vue
+++ b/src/messages/components/ConversationAddReactionInner.vue
@@ -25,10 +25,10 @@ import { QSearch } from 'quasar'
 
 function searchEmoji (search) {
   // Remove colons and set to lowercase to normalize search
-  let cleanedSearch = search.replace(/:/g, '').toLowerCase()
-  let matchingEmojiNames = []
+  const cleanedSearch = search.replace(/:/g, '').toLowerCase()
+  const matchingEmojiNames = []
   // The set is used to remove duplicate emoji that may have different names
-  let matchingEmojiUnicodes = new Set()
+  const matchingEmojiUnicodes = new Set()
   // First add the exact search in case there is an emoji shortcode with less
   // than three characters
   if (Object.keys(emojiList).includes(cleanedSearch)) {
@@ -41,8 +41,8 @@ function searchEmoji (search) {
     for (var index in Object.keys(emojiList)) {
       // This regular expression does a substring search of emoji names to
       // find more interesting results
-      let regexp = '.*' + cleanedSearch + '.*'
-      let emojiShortcode = Object.keys(emojiList)[index]
+      const regexp = '.*' + cleanedSearch + '.*'
+      const emojiShortcode = Object.keys(emojiList)[index]
       if (emojiShortcode.match(regexp) &&
           emojiShortcode !== cleanedSearch &&
           !matchingEmojiUnicodes.has(emojiList[emojiShortcode])) {

--- a/src/messages/components/EmojiButton.vue
+++ b/src/messages/components/EmojiButton.vue
@@ -22,13 +22,7 @@ function getEmojiElement (name) {
   const cached = EMOJI_CACHE[name]
   if (cached) return EMOJI_CACHE[name].cloneNode(true)
   const container = document.createElement('div')
-  if (Object.keys(emojiList).includes(name)) {
-    container.innerHTML = twemoji.parse(emojiList[name])
-  }
-  // On error, we display the 'carrot' emoji
-  else {
-    container.innerHTML = twemoji.parse(emojiList['carrot'])
-  }
+  container.innerHTML = twemoji.parse(emojiList['carrot'])
   const el = container.firstChild
   EMOJI_CACHE[name] = el
   return el

--- a/src/messages/components/EmojiButton.vue
+++ b/src/messages/components/EmojiButton.vue
@@ -22,7 +22,7 @@ function getEmojiElement (name) {
   const cached = EMOJI_CACHE[name]
   if (cached) return EMOJI_CACHE[name].cloneNode(true)
   const container = document.createElement('div')
-  container.innerHTML = twemoji.parse(emojiList['carrot'])
+  container.innerHTML = twemoji.parse(emojiList[name])
   const el = container.firstChild
   EMOJI_CACHE[name] = el
   return el

--- a/src/messages/components/EmojiButton.vue
+++ b/src/messages/components/EmojiButton.vue
@@ -22,7 +22,13 @@ function getEmojiElement (name) {
   const cached = EMOJI_CACHE[name]
   if (cached) return EMOJI_CACHE[name].cloneNode(true)
   const container = document.createElement('div')
-  container.innerHTML = twemoji.parse(emojiList[name])
+  if (Object.keys(emojiList).includes(name)) {
+    container.innerHTML = twemoji.parse(emojiList[name])
+  }
+  // On error, we display the 'carrot' emoji
+  else {
+    container.innerHTML = twemoji.parse(emojiList['carrot'])
+  }
   const el = container.firstChild
   EMOJI_CACHE[name] = el
   return el


### PR DESCRIPTION
Closes #1072 

## What does this PR do?

Adds a search bar to the emoji picker so users can choose a wider range of emoji. 5 additional emoji were hardcoded on the default options. 

The emoji names are looked up in the following [library](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/full.json) and later parsed with [twemoji](https://twitter.github.io/twemoji/) to get the image. If the emoji exists in the library, but twemoji can't parse it, the carrot emoji is shown.

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
