### PR TITLE
Adjust space under blockquote elements

### DIFF
--- a/src/utils/components/Markdown.vue
+++ b/src/utils/components/Markdown.vue
@@ -84,6 +84,10 @@ export default {
     overflow-x auto
     overflow-wrap normal
     display block
+  blockquote
+    margin-bottom 0.5rem
+    p:last-child
+      margin-bottom 0rem
   img:not(.emoji)
     max-height 150px
     max-width 300px


### PR DESCRIPTION
## What does this PR do?
Adds a 0.5rem bottom margin to blockquote elements. Removes the standard 0.5rem bottom margin p elements have, if it's the last one inside a blockquote. 

## Links to related issues
None.

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
