### PR TITLE
Separate conversations and threads in message notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Please document your changes in this format:
 - Rename stores to places in UI and change shopping-cart to dot-circle #1398 @tiltec @djahnie
 - Separate conversations and threads in message notifications @tiltec @djahnie
 
+### Fixed
+- Permission checks in main routes had a typo and were not active @djahnie @tiltec
+
 ## [7.3.0] - 2019-04-29
 ### Added
 - Show people who marked a place as favorite @tiltec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Changed
 - Rename stores to places in UI and change shopping-cart to dot-circle #1398 @tiltec @djahnie
+- Separate conversations and threads in message notifications @tiltec @djahnie
 
 ## [7.3.0] - 2019-04-29
 ### Added

--- a/src/base/routes/main.js
+++ b/src/base/routes/main.js
@@ -4,6 +4,8 @@ const GroupWall = () => import('@/group/pages/Wall')
 const GroupPickups = () => import('@/pickups/pages/GroupPickups')
 const GroupFeedback = () => import('@/feedback/pages/GroupFeedback')
 const Messages = () => import('@/messages/pages/Messages')
+const LatestConversations = () => import('@/messages/components/LatestConversations')
+const LatestThreads = () => import('@/messages/components/LatestThreads')
 const Notifications = () => import('@/notifications/pages/Notifications')
 const GroupMap = () => import('@/maps/pages/Map')
 const GroupSettings = () => import('@/group/pages/Settings')
@@ -131,7 +133,7 @@ export default [
         name: 'issueList',
         path: 'issues',
         meta: {
-          requiredLoggedIn: true,
+          requireLoggedIn: true,
           breadcrumbs: [
             { translation: 'ISSUE.TITLE', route: { name: 'issueList' } },
           ],
@@ -154,7 +156,7 @@ export default [
               footer: { render: h => Platform.is.mobile ? h('router-view', { props: { name: 'issueFooter' } }) : null },
             },
             meta: {
-              requiredLoggedIn: true,
+              requireLoggedIn: true,
               breadcrumbs: [
                 { type: 'activeIssue' },
               ],
@@ -303,7 +305,7 @@ export default [
         name: 'messageReplies',
         path: 'message/:messageId/replies',
         meta: {
-          requiredLoggedIn: true,
+          requireLoggedIn: true,
           breadcrumbs: [
             { type: 'currentGroup' },
           ],
@@ -412,7 +414,7 @@ export default [
         name: 'pickupDetail',
         path: 'place/:placeId/pickups/:pickupId/detail',
         meta: {
-          requiredLoggedIn: true,
+          requireLoggedIn: true,
           breadcrumbs: [
             { translation: 'GROUP.PICKUP' },
           ],
@@ -455,7 +457,7 @@ export default [
     name: 'applicationDetail',
     path: '/group/:groupId/applications/:applicationId',
     meta: {
-      requiredLoggedIn: true,
+      requireLoggedIn: true,
       breadcrumbs: [
         { translation: 'APPLICATION.APPLICATION', route: { name: 'applicationDetail' } },
       ],
@@ -503,7 +505,7 @@ export default [
     name: 'userDetail',
     path: '/user/:userId/detail',
     meta: {
-      requiredLoggedIn: true,
+      requireLoggedIn: true,
       breadcrumbs: [
         { type: 'currentGroup' },
         { type: 'activeUser' },
@@ -521,8 +523,9 @@ export default [
   {
     name: 'messages',
     path: 'messages',
+    redirect: { name: 'latestConversations' },
     meta: {
-      requiredLoggedIn: true,
+      requireLoggedIn: true,
       breadcrumbs: [
         { translation: 'GROUP.MESSAGES', route: { name: 'messages' } },
       ],
@@ -532,12 +535,24 @@ export default [
       default: Messages,
       sidenav: Sidenav,
     },
+    children: [
+      {
+        name: 'latestConversations',
+        path: 'conversations',
+        component: LatestConversations,
+      },
+      {
+        name: 'latestThreads',
+        path: 'threads',
+        component: LatestThreads,
+      },
+    ],
   },
   {
     name: 'notifications',
     path: 'notifications',
     meta: {
-      requiredLoggedIn: true,
+      requireLoggedIn: true,
       breadcrumbs: [
         { translation: 'NOTIFICATION_BELLS_LIST.TITLE', route: { name: 'notifications' } },
       ],

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -526,6 +526,7 @@
     "RECEIVED_VIA_EMAIL": "This message was sent via e-mail"
   },
   "CONVERSATION": {
+    "CONVERSATIONS": "Conversations",
     "OPEN": "Open Chat",
     "REPLY_TO_MESSAGE": "Reply to message...",
     "REPLIES": "Replies",

--- a/src/messages/api/conversations.js
+++ b/src/messages/api/conversations.js
@@ -32,8 +32,12 @@ export default {
     return convert((await axios.patch(`/api/conversations/${id}/`, data)).data)
   },
 
-  async markAllSeen () {
-    return (await axios.post(`/api/conversations/mark_all_seen/`)).data
+  async markConversationsSeen () {
+    return (await axios.post(`/api/conversations/mark_conversations_seen/`)).data
+  },
+
+  async markThreadsSeen () {
+    return (await axios.post(`/api/conversations/mark_threads_seen/`)).data
   },
 }
 
@@ -64,6 +68,7 @@ export function convert (val) {
 export function convertMeta (val) {
   return {
     ...val,
-    markedAt: new Date(val.markedAt),
+    conversationsMarkedAt: new Date(val.conversationsMarkedAt),
+    threadsMarkedAt: new Date(val.threadsMarkedAt),
   }
 }

--- a/src/messages/components/LatestConversations.vue
+++ b/src/messages/components/LatestConversations.vue
@@ -12,7 +12,7 @@
         </QItem>
         <LatestMessageItem
           v-for="conv in conversations"
-          :key="'conv' + conv.id"
+          :key="conv.id"
           v-close-overlay
           :group="conv.type === 'group' ? conv.target : null"
           :user="conv.type === 'private' ? conv.target : null"

--- a/src/messages/components/LatestConversations.vue
+++ b/src/messages/components/LatestConversations.vue
@@ -1,0 +1,127 @@
+<template>
+  <div
+    class="bg-white relative-position"
+  >
+    <KSpinner v-show="fetchInitialPending" />
+    <template v-if="!fetchInitialPending">
+      <QList no-border>
+        <QItem
+          v-if="conversations.length === 0"
+        >
+          {{ $t('CONVERSATION.NO_CONVERSATIONS') }}
+        </QItem>
+        <LatestMessageItem
+          v-for="conv in conversations"
+          :key="'conv' + conv.id"
+          v-close-overlay
+          :group="conv.type === 'group' ? conv.target : null"
+          :user="conv.type === 'private' ? conv.target : null"
+          :pickup="conv.type === 'pickup' ? conv.target : null"
+          :place="conv.type === 'place' ? conv.target : null"
+          :application="conv.type === 'application' ? conv.target : null"
+          :issue="conv.type === 'issue' ? conv.target : null"
+          :message="conv.latestMessage"
+          :unread-count="conv.unreadMessageCount"
+          :muted="conv.muted"
+          :closed="conv.isClosed"
+          :selected="isSelected(conv)"
+          @open="open(conv)"
+        />
+        <QItem
+          v-if="!asPopover && canFetchPastConversations"
+          class="row justify-center"
+        >
+          <QBtn
+            size="sm"
+            :loading="fetchingPastConversations"
+            @click="fetchPastConversations"
+          >
+            {{ $t('BUTTON.SHOW_MORE') }}
+          </QBtn>
+        </QItem>
+        <div
+          v-if="asPopover"
+          class="row justify-end q-mt-sm q-mr-sm"
+        >
+          <QBtn
+            v-close-overlay
+            size="sm"
+            color="secondary"
+            :to="{ name: 'latestConversations' }"
+          >
+            {{ $t('BUTTON.SHOW_MORE') }}
+          </QBtn>
+        </div>
+      </QList>
+    </template>
+  </div>
+</template>
+
+<script>
+import {
+  QList,
+  QItem,
+  QBtn,
+} from 'quasar'
+import { mapGetters, mapActions } from 'vuex'
+import LatestMessageItem from './LatestMessageItem'
+import KSpinner from '@/utils/components/KSpinner'
+
+export default {
+  components: {
+    QList,
+    QItem,
+    QBtn,
+    LatestMessageItem,
+    KSpinner,
+  },
+  props: {
+    asPopover: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    ...mapGetters({
+      conversations: 'latestMessages/conversations',
+      canFetchPastConversations: 'latestMessages/canFetchPastConversations',
+      fetchingPastConversations: 'latestMessages/fetchingPastConversations',
+      fetchInitialPending: 'latestMessages/fetchInitialPending',
+      selectedConversation: 'detail/conversation',
+    }),
+  },
+  mounted () {
+    this.fetchInitial()
+    setTimeout(() => this.markConversationsSeen(), 3 * 1000)
+  },
+  destroyed () {
+    this.markConversationsSeen()
+  },
+  methods: {
+    ...mapActions({
+      openForPickup: 'detail/openForPickup',
+      openForUser: 'detail/openForUser',
+      openForApplication: 'detail/openForApplication',
+      fetchPastConversations: 'latestMessages/fetchPastConversations',
+      fetchInitial: 'latestMessages/fetchInitial',
+      markConversationsSeen: 'latestMessages/markConversationsSeen',
+    }),
+    open (conv) {
+      const { type, target } = conv
+      switch (type) {
+        case 'group': return this.$router.push({ name: 'group', params: { groupId: target.id } })
+        case 'place': return this.$router.push({ name: 'placeWall', params: { groupId: target.group.id, placeId: target.id } })
+        case 'pickup': return this.openForPickup(target)
+        case 'private': return this.openForUser(target)
+        case 'application': return this.openForApplication(target)
+        case 'issue': return this.$router.push({ name: 'issueChat', params: { groupId: target.group.id, issueId: target.id } })
+      }
+    },
+    isSelected (conv) {
+      if (!this.selectedConversation) return false
+      if (Boolean(conv.thread) !== Boolean(this.selectedConversation.thread)) return false
+      return conv.id === this.selectedConversation.id
+    },
+  },
+}
+</script>

--- a/src/messages/components/LatestMessageButton.vue
+++ b/src/messages/components/LatestMessageButton.vue
@@ -25,7 +25,6 @@
     >
       <LatestMessages
         v-if="showing"
-        as-popover
       />
     </QPopover>
   </QBtn>

--- a/src/messages/components/LatestMessages.vue
+++ b/src/messages/components/LatestMessages.vue
@@ -1,171 +1,95 @@
 <template>
-  <Component
-    :is="asPage ? 'QCard' : 'div'"
-    class="bg-white relative-position"
-  >
-    <KSpinner v-show="fetchInitialPending" />
-    <template v-if="!fetchInitialPending">
-      <QList no-border>
-        <QItem
-          v-if="conversations.length === 0"
-        >
-          {{ $t('CONVERSATION.NO_CONVERSATIONS') }}
-        </QItem>
-        <LatestMessageItem
-          v-for="conv in conversations"
-          :key="'conv' + conv.id"
-          v-close-overlay
-          :group="conv.type === 'group' ? conv.target : null"
-          :user="conv.type === 'private' ? conv.target : null"
-          :pickup="conv.type === 'pickup' ? conv.target : null"
-          :place="conv.type === 'place' ? conv.target : null"
-          :application="conv.type === 'application' ? conv.target : null"
-          :issue="conv.type === 'issue' ? conv.target : null"
-          :message="conv.latestMessage"
-          :unread-count="conv.unreadMessageCount"
-          :muted="conv.muted"
-          :closed="conv.isClosed"
-          :selected="isSelected(conv)"
-          @open="open(conv)"
-        />
-        <QItem
-          v-if="!asPopover && canFetchPastConversations"
-          class="row justify-center"
-        >
-          <QBtn
-            size="sm"
-            :loading="fetchingPastConversations"
-            @click="fetchPastConversations"
-          >
-            {{ $t('BUTTON.SHOW_MORE') }}
-          </QBtn>
-        </QItem>
-      </QList>
-      <QList
-        v-if="threads.length > 0"
-        no-border
-      >
-        <QItemSeparator />
-        <QListHeader>
-          {{ $t('CONVERSATION.REPLIES') }}
-        </QListHeader>
-        <LatestMessageItem
-          v-for="conv in threads"
-          :key="'thread' + conv.id"
-          :thread="conv"
-          :message="conv.latestMessage"
-          :unread-count="conv.threadMeta.unreadReplyCount"
-          :muted="conv.threadMeta.muted"
-          :selected="isSelected(conv)"
-          @open="openForThread(conv)"
-        />
-        <QItem
-          v-if="!asPopover && canFetchPastThreads"
-          class="row justify-center"
-        >
-          <QBtn
-            size="sm"
-            :loading="fetchingPastThreads"
-            @click="fetchPastThreads"
-          >
-            {{ $t('BUTTON.SHOW_MORE') }}
-          </QBtn>
-        </QItem>
-        <div
-          v-if="asPopover"
-          class="row justify-end q-mt-sm q-mr-sm"
-        >
-          <QBtn
-            v-close-overlay
-            size="sm"
-            color="secondary"
-            :to="{ name: 'messages' }"
-          >
-            {{ $t('BUTTON.SHOW_MORE') }}
-          </QBtn>
-        </div>
-      </QList>
+  <div>
+    <QTabs
+      v-model="selected"
+      inverted
+      class="k-message-tabs"
+    >
+      <Component
+        :is="asPage ? 'QRouteTab' : 'QTab'"
+        slot="title"
+        name="conversations"
+        :to="{ name: 'latestConversations' }"
+        :label="$t('CONVERSATION.CONVERSATIONS')"
+        :count="unseenConversationsCount > 9 ? '9+' : unseenConversationsCount"
+      />
+      <Component
+        :is="asPage ? 'QRouteTab' : 'QTab'"
+        slot="title"
+        name="threads"
+        :to="{ name: 'latestThreads' }"
+        :label="$t('CONVERSATION.REPLIES')"
+        :count="unseenThreadsCount > 9 ? '9+' : unseenThreadsCount"
+      />
+    </QTabs>
+    <RouterView
+      v-if="asPage"
+    />
+    <template
+      v-else
+    >
+      <LatestConversations
+        v-if="selected === 'conversations'"
+        as-popover
+      />
+      <LatestThreads
+        v-if="selected === 'threads'"
+        as-popover
+      />
     </template>
-  </Component>
+  </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 import {
-  QCard,
-  QList,
-  QListHeader,
-  QItemSeparator,
-  QItem,
-  QBtn,
+  QTabs,
+  QTab,
+  QRouteTab,
 } from 'quasar'
-import { mapGetters, mapActions } from 'vuex'
-import LatestMessageItem from './LatestMessageItem'
-import KSpinner from '@/utils/components/KSpinner'
+import LatestConversations from './LatestConversations'
+import LatestThreads from './LatestThreads'
 
 export default {
   components: {
-    QCard,
-    QList,
-    QListHeader,
-    QItemSeparator,
-    QItem,
-    QBtn,
-    LatestMessageItem,
-    KSpinner,
+    QTabs,
+    QTab,
+    QRouteTab,
+    LatestConversations,
+    LatestThreads,
   },
   props: {
     asPage: {
       type: Boolean,
       default: false,
     },
-    asPopover: {
-      type: Boolean,
-      default: false,
-    },
+  },
+  data () {
+    return {
+      selected: 'conversations',
+    }
   },
   computed: {
     ...mapGetters({
-      conversations: 'latestMessages/conversations',
-      canFetchPastConversations: 'latestMessages/canFetchPastConversations',
-      fetchingPastConversations: 'latestMessages/fetchingPastConversations',
-      threads: 'latestMessages/threads',
-      canFetchPastThreads: 'latestMessages/canFetchPastThreads',
-      fetchingPastThreads: 'latestMessages/fetchingPastThreads',
-      fetchInitialPending: 'latestMessages/fetchInitialPending',
-      selectedConversation: 'detail/conversation',
+      unseenConversationsCount: 'latestMessages/unseenConversationsCount',
+      unseenThreadsCount: 'latestMessages/unseenThreadsCount',
     }),
+    hasOnlyUnseenThreads () {
+      return Boolean(this.unseenThreadsCount && !this.unseenConversationsCount)
+    },
   },
   mounted () {
-    this.fetchInitial()
-    this.markAllSeen()
-  },
-  methods: {
-    ...mapActions({
-      openForPickup: 'detail/openForPickup',
-      openForUser: 'detail/openForUser',
-      openForThread: 'detail/openForThread',
-      openForApplication: 'detail/openForApplication',
-      fetchPastConversations: 'latestMessages/fetchPastConversations',
-      fetchPastThreads: 'latestMessages/fetchPastThreads',
-      fetchInitial: 'latestMessages/fetchInitial',
-      markAllSeen: 'latestMessages/markAllSeen',
-    }),
-    open (conv) {
-      const { type, target } = conv
-      switch (type) {
-        case 'group': return this.$router.push({ name: 'group', params: { groupId: target.id } })
-        case 'place': return this.$router.push({ name: 'placeWall', params: { groupId: target.group.id, placeId: target.id } })
-        case 'pickup': return this.openForPickup(target)
-        case 'private': return this.openForUser(target)
-        case 'application': return this.openForApplication(target)
-        case 'issue': return this.$router.push({ name: 'issueChat', params: { groupId: target.group.id, issueId: target.id } })
-      }
-    },
-    isSelected (conv) {
-      if (!this.selectedConversation) return false
-      if (Boolean(conv.thread) !== Boolean(this.selectedConversation.thread)) return false
-      return conv.id === this.selectedConversation.id
-    },
+    if (this.hasOnlyUnseenThreads) {
+      this.selected = 'threads'
+    }
   },
 }
 </script>
+
+<style lang="stylus" scoped>
+@import '~variables'
+
+.k-message-tabs >>> .q-tab .q-chip
+  background alpha($secondary, 0.85)
+</style>

--- a/src/messages/components/LatestThreads.vue
+++ b/src/messages/components/LatestThreads.vue
@@ -14,7 +14,7 @@
         </QItem>
         <LatestMessageItem
           v-for="conv in threads"
-          :key="'thread' + conv.id"
+          :key="conv.id"
           :thread="conv"
           :message="conv.latestMessage"
           :unread-count="conv.threadMeta.unreadReplyCount"

--- a/src/messages/components/LatestThreads.vue
+++ b/src/messages/components/LatestThreads.vue
@@ -1,0 +1,109 @@
+<template>
+  <div
+    class="bg-white relative-position"
+  >
+    <KSpinner v-show="fetchInitialPending" />
+    <template v-if="!fetchInitialPending">
+      <QList
+        no-border
+      >
+        <QItem
+          v-if="threads.length === 0"
+        >
+          {{ $t('CONVERSATION.NO_CONVERSATIONS') }}
+        </QItem>
+        <LatestMessageItem
+          v-for="conv in threads"
+          :key="'thread' + conv.id"
+          :thread="conv"
+          :message="conv.latestMessage"
+          :unread-count="conv.threadMeta.unreadReplyCount"
+          :muted="conv.threadMeta.muted"
+          :selected="isSelected(conv)"
+          @open="openForThread(conv)"
+        />
+        <QItem
+          v-if="!asPopover && canFetchPastThreads"
+          class="row justify-center"
+        >
+          <QBtn
+            size="sm"
+            :loading="fetchingPastThreads"
+            @click="fetchPastThreads"
+          >
+            {{ $t('BUTTON.SHOW_MORE') }}
+          </QBtn>
+        </QItem>
+        <div
+          v-if="asPopover"
+          class="row justify-end q-mt-sm q-mr-sm"
+        >
+          <QBtn
+            v-close-overlay
+            size="sm"
+            color="secondary"
+            :to="{ name: 'latestThreads' }"
+          >
+            {{ $t('BUTTON.SHOW_MORE') }}
+          </QBtn>
+        </div>
+      </QList>
+    </template>
+  </div>
+</template>
+
+<script>
+import {
+  QList,
+  QItem,
+  QBtn,
+} from 'quasar'
+import { mapGetters, mapActions } from 'vuex'
+import LatestMessageItem from './LatestMessageItem'
+import KSpinner from '@/utils/components/KSpinner'
+
+export default {
+  components: {
+    QList,
+    QItem,
+    QBtn,
+    LatestMessageItem,
+    KSpinner,
+  },
+  props: {
+    asPopover: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    ...mapGetters({
+      threads: 'latestMessages/threads',
+      canFetchPastThreads: 'latestMessages/canFetchPastThreads',
+      fetchingPastThreads: 'latestMessages/fetchingPastThreads',
+      fetchInitialPending: 'latestMessages/fetchInitialPending',
+      selectedConversation: 'detail/conversation',
+    }),
+  },
+  mounted () {
+    this.fetchInitial()
+    setTimeout(() => this.markThreadsSeen(), 3 * 1000)
+  },
+  destroyed () {
+    this.markThreadsSeen()
+  },
+  methods: {
+    ...mapActions({
+      openForThread: 'detail/openForThread',
+      fetchPastThreads: 'latestMessages/fetchPastThreads',
+      fetchInitial: 'latestMessages/fetchInitial',
+      markThreadsSeen: 'latestMessages/markThreadsSeen',
+    }),
+    isSelected (conv) {
+      if (!this.selectedConversation) return false
+      if (Boolean(conv.thread) !== Boolean(this.selectedConversation.thread)) return false
+      return conv.id === this.selectedConversation.id
+    },
+  },
+}
+</script>

--- a/src/messages/datastore/latestMessages.js
+++ b/src/messages/datastore/latestMessages.js
@@ -12,7 +12,8 @@ function initialState () {
     threadMessages: {},
     fetchInitialDone: false,
     entryMeta: {
-      markedAt: null,
+      conversationsMarkedAt: null,
+      threadsMarkedAt: null,
     },
   }
 }
@@ -42,10 +43,17 @@ export default {
       ) === 0
     },
     unseenCount: (state, getters) => {
-      const { markedAt } = state.entryMeta
+      return getters.unseenConversationsCount + getters.unseenThreadsCount
+    },
+    unseenConversationsCount: (state, getters) => {
+      const { conversationsMarkedAt } = state.entryMeta
 
-      return getters.unread.conversations.filter(c => c.latestMessage.createdAt > markedAt).length +
-        getters.unread.threads.filter(t => t.latestMessage.createdAt > markedAt).length
+      return getters.unread.conversations.filter(c => c.latestMessage.createdAt > conversationsMarkedAt).length
+    },
+    unseenThreadsCount: (state, getters) => {
+      const { threadsMarkedAt } = state.entryMeta
+
+      return getters.unread.threads.filter(t => t.latestMessage.createdAt > threadsMarkedAt).length
     },
     conversations: (state, getters, rootState, rootGetters) => {
       const enrichConversation = rootGetters['conversations/enrichConversation']
@@ -99,10 +107,15 @@ export default {
       async clear ({ commit }) {
         commit('clear')
       },
-      async markAllSeen ({ getters }) {
+      async markConversationsSeen ({ getters }) {
         // we can skip marking if there are only seen notifications
-        if (!getters.unseenCount) return
-        conversationsAPI.markAllSeen()
+        if (!getters.unseenConversationsCount) return
+        conversationsAPI.markConversationsSeen()
+      },
+      async markThreadsSeen ({ getters }) {
+        // we can skip marking if there are only seen notifications
+        if (!getters.unseenThreadsCount) return
+        conversationsAPI.markThreadsSeen()
       },
     }),
     async fetch ({ dispatch }, { excludeRead = false } = {}) {

--- a/src/messages/pages/Messages.vue
+++ b/src/messages/pages/Messages.vue
@@ -1,7 +1,7 @@
 <template>
   <LatestMessages
     class="k-messages"
-    :as-page="!$q.platform.is.mobile"
+    as-page
   />
 </template>
 


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/1230

## What does this PR do?
Introduces tabs for conversations and threads respectively. By that makes thread replies more visible.
![image](https://user-images.githubusercontent.com/17573771/57972447-e840dc00-799a-11e9-888b-a776f8ed62d6.png)

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [x] asked someone for a code review
- [x] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
