### PR TITLE
Group messages from same author (#1093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Added
+- Group messages from same author @teemukaaria
 
 ## [8.1.2] - 2019-11-05
 ### Fixed

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -373,7 +373,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 0!</p>
             </div>
@@ -407,7 +407,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 1!</p>
           </div>
@@ -441,7 +441,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
 </div></small></span>
         <!---->
       </div>
-      <div class="content">
+      <div title="Dec 24, 2017, 12:00 PM" class="content">
         <div class="markdown">
           <p>hello 2!</p>
         </div>
@@ -475,7 +475,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
 </div></small></span>
       <!---->
     </div>
-    <div class="content">
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
       <div class="markdown">
         <p>hello 3!</p>
       </div>
@@ -546,7 +546,7 @@ exports[`Storyshots ChatConversation default 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 0!</p>
             </div>
@@ -580,7 +580,7 @@ exports[`Storyshots ChatConversation default 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 1!</p>
           </div>
@@ -614,7 +614,7 @@ exports[`Storyshots ChatConversation default 1`] = `
 </div></small></span>
         <!---->
       </div>
-      <div class="content">
+      <div title="Dec 24, 2017, 12:00 PM" class="content">
         <div class="markdown">
           <p>hello 2!</p>
         </div>
@@ -648,7 +648,7 @@ exports[`Storyshots ChatConversation default 1`] = `
 </div></small></span>
       <!---->
     </div>
-    <div class="content">
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
       <div class="markdown">
         <p>hello 3!</p>
       </div>
@@ -708,7 +708,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 0!</p>
             </div>
@@ -742,7 +742,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 1!</p>
           </div>
@@ -776,7 +776,7 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
 </div></small></span>
         <!---->
       </div>
-      <div class="content">
+      <div title="Dec 24, 2017, 12:00 PM" class="content">
         <div class="markdown">
           <p>hello 2!</p>
         </div>
@@ -810,12 +810,336 @@ exports[`Storyshots ChatConversation fetching past 1`] = `
 </div></small></span>
       <!---->
     </div>
-    <div class="content">
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
       <div class="markdown">
         <p>hello 3!</p>
       </div>
     </div>
     <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="a reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<!---->
+<!---->
+</div>
+</div>
+<!---->
+</div>
+`;
+
+exports[`Storyshots ChatConversation message groups 1`] = `
+<div>
+  <div class="full-width text-center generic-padding" style="display:none;"><svg fill="currentColor" width="40" height="40" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" class="q-spinner">
+      <circle cx="15" cy="15" r="15">
+        <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+        <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+      </circle>
+      <circle cx="60" cy="15" r="9" fill-opacity=".3">
+        <animate attributeName="r" from="9" to="9" begin="0s" dur="0.8s" values="9;15;9" calcMode="linear" repeatCount="indefinite"></animate>
+        <animate attributeName="fill-opacity" from=".5" to=".5" begin="0s" dur="0.8s" values=".5;1;.5" calcMode="linear" repeatCount="indefinite"></animate>
+      </circle>
+      <circle cx="105" cy="15" r="15">
+        <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
+        <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
+      </circle>
+    </svg></div>
+  <div class="q-infinite-scroll">
+    <div class="bg-white q-list">
+      <div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+        <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+          <!---->
+          <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+            <div tabindex="-1" class="q-focus-helper"></div>
+            <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+              <!---->
+            </div>
+          </button></div>
+        <!---->
+        <div class="q-item__section column q-item__section--main justify-center">
+          <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Mira Bellenbaum</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:50 AM">
+  9 minutes ago
+</div></small></span>
+            <!---->
+          </div>
+          <div title="Dec 24, 2017, 11:50 AM" class="content">
+            <div class="markdown">
+              <p>first messsage</p>
+            </div>
+          </div>
+          <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+        </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+          <div tabindex="-1" class="q-focus-helper"></div>
+          <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+            <!---->
+          </div>
+        </button>
+        <!----></span>
+        <!---->
+      </div>
+    </div>
+    <div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+      <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+        <!---->
+        <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+          <div tabindex="-1" class="q-focus-helper"></div>
+          <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+            <!---->
+          </div>
+        </button></div>
+      <!---->
+      <div class="q-item__section column q-item__section--main justify-center">
+        <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:54 AM">
+  6 minutes ago
+</div></small></span>
+          <!---->
+        </div>
+        <div title="Dec 24, 2017, 11:54 AM" class="content">
+          <div class="markdown">
+            <p>second messsage</p>
+          </div>
+        </div>
+        <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+      </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+        <div tabindex="-1" class="q-focus-helper"></div>
+        <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+          <!---->
+        </div>
+      </button>
+      <!----></span>
+      <!---->
+    </div>
+  </div>
+  <div class="q-item q-item-type row no-wrap conversation-message relative-position slim continuation">
+    <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+      <!---->
+      <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+        <div tabindex="-1" class="q-focus-helper"></div>
+        <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+          <!---->
+        </div>
+      </button></div>
+    <!---->
+    <div class="q-item__section column q-item__section--main justify-center">
+      <!---->
+      <div title="Dec 24, 2017, 11:55 AM" class="content">
+        <div class="markdown">
+          <p>first messsage</p>
+        </div>
+      </div>
+      <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+    </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button>
+    <!----></span>
+    <!---->
+  </div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:56 AM">
+  3 minutes ago
+</div></small></span>
+      <!---->
+    </div>
+    <div title="Dec 24, 2017, 11:56 AM" class="content">
+      <div class="markdown">
+        <p>welcome to fs chat</p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Karl Karlson</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:59 AM">
+  1 minute ago
+</div></small></span>
+      <!---->
+    </div>
+    <div title="Dec 24, 2017, 11:59 AM" class="content">
+      <div class="markdown">
+        <p>heyo!</p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:59 AM">
+  less than a minute ago
+</div></small></span>
+      <!---->
+    </div>
+    <div title="Dec 24, 2017, 11:59 AM" class="content">
+      <div class="markdown">
+        <p>you made it!</p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Mona Mohnblume</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 11:59 AM">
+  less than a minute ago
+</div></small></span>
+      <!---->
+    </div>
+    <div title="Dec 24, 2017, 11:59 AM" class="content">
+      <div class="markdown">
+        <p>amazing!</p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim continuation">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <!---->
+    <div title="Dec 24, 2017, 11:59 AM" class="content">
+      <div class="markdown">
+        <p>oh let me try something <img class="emoji" draggable="false" alt="😃" src="https://twemoji.maxcdn.com/v/12.1.3/72x72/1f603.png" /></p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
+  </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
+    <div tabindex="-1" class="q-focus-helper"></div>
+    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
+  </span>
+      <!---->
+    </div>
+  </button>
+  <!----></span>
+  <!---->
+</div>
+</div>
+<div class="q-item q-item-type row no-wrap conversation-message relative-position slim">
+  <div class="q-btn-group row no-wrap inline hover-button k-message-controls bg-white q-btn-group--outline">
+    <!---->
+    <!----> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline q-btn--outline q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable">
+      <div tabindex="-1" class="q-focus-helper"></div>
+      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:1;"><i class="far fa-smile"></i> +
+  </span>
+        <!---->
+      </div>
+    </button></div>
+  <!---->
+  <div class="q-item__section column q-item__section--main justify-center">
+    <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">Max Mustermann</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
+  less than a minute ago
+</div></small></span>
+      <!---->
+    </div>
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
+      <div class="markdown">
+        <p>I dont think we need to implement another UI, this is fine right?</p>
+      </div>
+    </div>
+    <!----> <span class="conversation-reactions" style="display:block;"><span class="reactions"><button tabindex="0" type="button" title="Mira Bellenbaum reacted with :thumbsup:" class="q-btn inline q-btn-item non-selectable no-outline row no-wrap items-center reaction-box q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable"><div tabindex="-1" class="q-focus-helper"></div><div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><div class="emoji"></div> <span class="reactions-number">1</span>
   </div></button></span> <button tabindex="0" type="button" class="q-btn inline q-btn-item non-selectable no-outline add-button reaction-box q-btn--outline q-btn--rectangle text-black q-btn--actionable q-focusable q-hoverable">
     <div tabindex="-1" class="q-focus-helper"></div>
     <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span style="opacity:0.5;"><i class="far fa-smile"></i> +
@@ -870,7 +1194,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 0!</p>
             </div>
@@ -904,7 +1228,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 1!</p>
           </div>
@@ -938,7 +1262,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
 </div></small></span>
         <!---->
       </div>
-      <div class="content">
+      <div title="Dec 24, 2017, 12:00 PM" class="content">
         <div class="markdown">
           <p>hello 2!</p>
         </div>
@@ -972,7 +1296,7 @@ exports[`Storyshots ChatConversation not participant 1`] = `
 </div></small></span>
       <!---->
     </div>
-    <div class="content">
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
       <div class="markdown">
         <p>hello 3!</p>
       </div>
@@ -1032,7 +1356,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 5!</p>
             </div>
@@ -1066,7 +1390,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 6!</p>
           </div>
@@ -1100,7 +1424,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
 </div></small></span>
         <!---->
       </div>
-      <div class="content">
+      <div title="Dec 24, 2017, 12:00 PM" class="content">
         <div class="markdown">
           <p>hello 7!</p>
         </div>
@@ -1519,7 +1843,7 @@ exports[`Storyshots ConversationMessage slim 1`] = `
 </div></small></span>
       <!---->
     </div>
-    <div class="content">
+    <div title="Dec 24, 2017, 12:00 PM" class="content">
       <div class="markdown">
         <p>This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test.</p>
       </div>
@@ -1798,7 +2122,7 @@ exports[`Storyshots Detail application 1`] = `
 </div></small></span>
                 <!---->
               </div>
-              <div class="content">
+              <div title="Dec 24, 2017, 12:00 PM" class="content">
                 <div class="markdown">
                   <p>hello 16!</p>
                 </div>
@@ -1832,7 +2156,7 @@ exports[`Storyshots Detail application 1`] = `
 </div></small></span>
               <!---->
             </div>
-            <div class="content">
+            <div title="Dec 24, 2017, 12:00 PM" class="content">
               <div class="markdown">
                 <p>hello 15!</p>
               </div>
@@ -1866,7 +2190,7 @@ exports[`Storyshots Detail application 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 14!</p>
             </div>
@@ -1900,7 +2224,7 @@ exports[`Storyshots Detail application 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 13!</p>
           </div>
@@ -2025,7 +2349,7 @@ exports[`Storyshots Detail pickup 1`] = `
 </div></small></span>
                 <!---->
               </div>
-              <div class="content">
+              <div title="Dec 24, 2017, 12:00 PM" class="content">
                 <div class="markdown">
                   <p>hello 16!</p>
                 </div>
@@ -2059,7 +2383,7 @@ exports[`Storyshots Detail pickup 1`] = `
 </div></small></span>
               <!---->
             </div>
-            <div class="content">
+            <div title="Dec 24, 2017, 12:00 PM" class="content">
               <div class="markdown">
                 <p>hello 15!</p>
               </div>
@@ -2093,7 +2417,7 @@ exports[`Storyshots Detail pickup 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 14!</p>
             </div>
@@ -2127,7 +2451,7 @@ exports[`Storyshots Detail pickup 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 13!</p>
           </div>
@@ -2254,7 +2578,7 @@ exports[`Storyshots Detail private 1`] = `
 </div></small></span>
                 <!---->
               </div>
-              <div class="content">
+              <div title="Dec 24, 2017, 12:00 PM" class="content">
                 <div class="markdown">
                   <p>hello 16!</p>
                 </div>
@@ -2288,7 +2612,7 @@ exports[`Storyshots Detail private 1`] = `
 </div></small></span>
               <!---->
             </div>
-            <div class="content">
+            <div title="Dec 24, 2017, 12:00 PM" class="content">
               <div class="markdown">
                 <p>hello 15!</p>
               </div>
@@ -2322,7 +2646,7 @@ exports[`Storyshots Detail private 1`] = `
 </div></small></span>
             <!---->
           </div>
-          <div class="content">
+          <div title="Dec 24, 2017, 12:00 PM" class="content">
             <div class="markdown">
               <p>hello 14!</p>
             </div>
@@ -2356,7 +2680,7 @@ exports[`Storyshots Detail private 1`] = `
 </div></small></span>
           <!---->
         </div>
-        <div class="content">
+        <div title="Dec 24, 2017, 12:00 PM" class="content">
           <div class="markdown">
             <p>hello 13!</p>
           </div>
@@ -5559,7 +5883,7 @@ exports[`Storyshots Latest Messages type: issue chat 1`] = `
     <div class="q-item__label row no-wrap justify-between items-baseline">
       <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" title="Issues" class="fas fa-fw fa-vote-yea q-icon q-mr-sm"> </i>
         <div class="ellipsis">
-          User 183
+          User 185
         </div>
         <!---->
         <!---->

--- a/src/messages/components/ChatConversation.story.js
+++ b/src/messages/components/ChatConversation.story.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/vue'
 import ChatConversation from './ChatConversation'
 import * as factories from '>/enrichedFactories'
 import { statusMocks, storybookDefaults as defaults } from '>/helpers'
+import { messagesMock } from '>/mockdata'
 
 const conversation = factories.makeConversation()
 const thread = factories.makeThread()
@@ -58,4 +59,19 @@ storiesOf('ChatConversation', module)
         conversation: thread,
       }),
     }),
+  }))
+  .add('message groups', () => defaults({
+    render: h => {
+      const timeDiff = new Date() - messagesMock[messagesMock.length - 1].createdAt.getTime()
+      return h(ChatConversation, {
+        props: defaultProps({
+          conversation: {
+            ...conversation,
+            messages: messagesMock.map(
+              message => ({ ...message, createdAt: new Date(message.createdAt.getTime() + timeDiff) }),
+            ),
+          },
+        }),
+      })
+    },
   }))

--- a/src/messages/components/ChatConversation.vue
+++ b/src/messages/components/ChatConversation.vue
@@ -13,7 +13,7 @@
         class="bg-white"
       >
         <ConversationMessage
-          v-for="message in conversation.messages"
+          v-for="message in groupedMessages"
           :key="message.id"
           :message="message"
           slim
@@ -61,6 +61,7 @@
 import ConversationMessage from '@/messages/components/ConversationMessage'
 import ConversationCompose from '@/messages/components/ConversationCompose'
 import KSpinner from '@/utils/components/KSpinner'
+import groupedMessagesMixin from '@/utils/mixins/groupedMessagesMixin'
 import {
   scroll,
   dom,
@@ -93,6 +94,7 @@ export default {
     QScrollObserver,
     QInfiniteScroll,
   },
+  mixins: [groupedMessagesMixin(['conversation', 'messages'])],
   props: {
     conversation: { type: Object, default: null },
     away: { type: Boolean, required: true },

--- a/src/messages/components/ConversationMessage.vue
+++ b/src/messages/components/ConversationMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <QItem
     v-if="!editMode"
-    :class="{ isUnread: message.isUnread, slim }"
+    :class="{ isUnread: message.isUnread, slim, continuation: !!message.continuation }"
     class="conversation-message relative-position"
   >
     <QBtnGroup
@@ -45,6 +45,7 @@
     </QItemSection>
     <QItemSection>
       <QItemLabel
+        v-if="!message.continuation"
         class="no-wrap k-message-meta"
       >
         <RouterLink :to="{ name: 'user', params: { userId: message.author.id } }">
@@ -62,7 +63,10 @@
           :title="$t('WALL.RECEIVED_VIA_EMAIL')"
         />
       </QItemLabel>
-      <div class="content">
+      <div
+        class="content"
+        :title="slim && tooltipDate"
+      >
         <Markdown :source="message.content" />
       </div>
       <QItemLabel
@@ -181,6 +185,9 @@ export default {
     showReplies () {
       return this.message.threadMeta && !this.slim
     },
+    tooltipDate () {
+      return this.$d(this.message.createdAt, 'long')
+    },
   },
   methods: {
     toggleReaction (name) {
@@ -211,6 +218,10 @@ export default {
 
 .isUnread
   background linear-gradient(to right, $lightGreen, $lighterGreen)
+
+.continuation
+  padding-top 0
+  min-height auto
 
 body.mobile .conversation-message
   .k-message-meta

--- a/src/utils/mixins/groupedMessagesMixin.js
+++ b/src/utils/mixins/groupedMessagesMixin.js
@@ -1,0 +1,40 @@
+import differenceInSeconds from 'date-fns/differenceInSeconds'
+import dateFnsHelper from '@/utils/dateFnsHelper'
+
+// time difference in seconds of any two messages to be included into the same group
+const MESSAGE_GROUP_DISTANCE = 60
+// time difference in seconds of subsequent messages to be included into the same group
+const SUBSEQUENT_MESSAGE_DISTANCE = 30
+
+export default function groupedMessagesMixin (path) {
+  return ({
+    computed: {
+      groupedMessages () {
+        const messages = path.reduce((acc, key) => acc[key], this)
+        let groupHeading = { timestamp: '', createdAt: 0 }
+        let prevMessage = { createdAt: 0, author: { id: -1 } }
+        for (const message of messages) {
+          const timestamp = dateFnsHelper.formatDistanceToNow(message.createdAt)
+          // group messages together if their author is the same and:
+          // 1. their "... ago" label is the same
+          // 2. the difference to last group heading is small enough
+          //    (prevents messages from jumping from one group to another)
+          // 3. two subsequent messages are close enough
+          if (message.author.id === prevMessage.author.id &&
+          (timestamp === groupHeading.timestamp ||
+            differenceInSeconds(message.createdAt, groupHeading.createdAt) < MESSAGE_GROUP_DISTANCE ||
+            differenceInSeconds(message.createdAt, prevMessage.createdAt) < SUBSEQUENT_MESSAGE_DISTANCE
+          )) {
+            message.continuation = true
+          }
+          else {
+            message.continuation = false
+            groupHeading = { timestamp, createdAt: message.createdAt }
+          }
+          prevMessage = message
+        }
+        return messages
+      },
+    },
+  })
+}


### PR DESCRIPTION
* group close by messages together

* add grouped messages story

Closes #1093

## What does this PR do?

Groups together messages based on their send time difference so that close by messages seem to belong to the same group.

Grouping is done if the author is the same and:
1. The "... ago" labels are the same (Messages from several months back will be grouped together)
2. Messages within a minute will be grouped together (Messages don't jump from one group to another)
3. Subsequent messages within 30 seconds will be grouped (no funny group breaks in the middle)

![image](https://user-images.githubusercontent.com/33418391/67511447-ea534900-f664-11e9-90b2-25ae7d9c38e7.png)

## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
