### PR TITLE
Use address autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@storybook/addon-actions": "5.2.6",
     "@storybook/addon-links": "5.2.6",
     "@storybook/vue": "5.2.6",
+    "@types/jest": "^24.0.23",
     "@vue/test-utils": "1.0.0-beta.29",
     "autoprefixer": "^9.7.0",
     "axios-mock-adapter": "^1.17.0",

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1,21 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots AddressPicker Default 1`] = `
-<div>
-  <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true"></i></div>
-      <div class="q-field__inner relative-position col self-stretch column justify-center">
-        <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-          <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-            <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
-            <div class="q-field__label no-pointer-events absolute ellipsis"></div>
-          </div>
-        </div>
-        <div class="q-field__bottom row items-start q-field__bottom--animated">
-          <div class="q-field__messages col"></div>
+<div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true"></i></div>
+    <div class="q-field__inner relative-position col self-stretch column justify-center">
+      <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+        <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+          <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+          <div class="q-field__label no-pointer-events absolute ellipsis"></div>
         </div>
       </div>
-    </label></div>
+      <div class="q-field__bottom row items-start q-field__bottom--animated">
+        <div class="q-field__messages col"></div>
+      </div>
+    </div>
+  </label>
   <div class="vue2leaflet-map k-map map">
     <!---->
   </div>
@@ -3229,22 +3228,21 @@ It would make sense if it was markdown
           </label>
           <!---->
         </div>
-        <div>
-          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-fw fa-map-marker q-icon"> </i></div>
-              <div class="q-field__inner relative-position col self-stretch column justify-center">
-                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-select__input q-placeholder col q-select__input--padding"></div>
-                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  </div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" class="material-icons q-icon cursor-pointer">cancel</i></div>
+        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-fw fa-map-marker q-icon"> </i></div>
+            <div class="q-field__inner relative-position col self-stretch column justify-center">
+              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                  <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
                 </div>
-                <div class="q-field__bottom row items-start q-field__bottom--animated">
-                  <div class="q-field__messages col"></div>
-                </div>
+                <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" class="material-icons q-icon cursor-pointer">cancel</i></div>
               </div>
-            </label></div>
+              <div class="q-field__bottom row items-start q-field__bottom--animated">
+                <div class="q-field__messages col"></div>
+              </div>
+            </div>
+          </label>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>
@@ -9031,21 +9029,20 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
           </label>
           <!---->
         </div>
-        <div>
-          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
-              <div class="q-field__inner relative-position col self-stretch column justify-center">
-                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
-                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  </div>
-                </div>
-                <div class="q-field__bottom row items-start q-field__bottom--animated">
-                  <div class="q-field__messages col"></div>
+        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
+            <div class="q-field__inner relative-position col self-stretch column justify-center">
+              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                  <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
                 </div>
               </div>
-            </label></div>
+              <div class="q-field__bottom row items-start q-field__bottom--animated">
+                <div class="q-field__messages col"></div>
+              </div>
+            </div>
+          </label>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>
@@ -9164,21 +9161,20 @@ exports[`Storyshots Places PlaceEdit 1`] = `
           </label>
           <!---->
         </div>
-        <div>
-          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
-              <div class="q-field__inner relative-position col self-stretch column justify-center">
-                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
-                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  </div>
-                </div>
-                <div class="q-field__bottom row items-start q-field__bottom--animated">
-                  <div class="q-field__messages col"></div>
+        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
+            <div class="q-field__inner relative-position col self-stretch column justify-center">
+              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                  <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
                 </div>
               </div>
-            </label></div>
+              <div class="q-field__bottom row items-start q-field__bottom--animated">
+                <div class="q-field__messages col"></div>
+              </div>
+            </div>
+          </label>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -9371,7 +9371,7 @@ exports[`Storyshots Profile member 1`] = `
         </div>
       </button></div>
     <div class="photoAndName row no-wrap ellipsis">
-      <div name="turn-in" appear="" class="photo q-pa-sm q-ma-md bg-white shadow-4">
+      <div class="photo q-pa-sm q-ma-md bg-white shadow-4">
         <div class="wrapper" style="width:180px;height:180px;">
           <div text="User 162" seed="162" class="randomArt fill"></div>
         </div>
@@ -9510,7 +9510,7 @@ exports[`Storyshots Profile non-member 1`] = `
       <!---->
     </div>
     <div class="photoAndName row no-wrap ellipsis">
-      <div name="turn-in" appear="" class="photo q-pa-sm q-ma-md bg-white shadow-4">
+      <div class="photo q-pa-sm q-ma-md bg-white shadow-4">
         <div class="wrapper" style="width:180px;height:180px;">
           <div text="User 161" seed="161" class="randomArt fill"></div>
         </div>
@@ -9716,18 +9716,14 @@ exports[`Storyshots Settings Page Default 1`] = `
               </div>
             </div>
           </label>
-          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
+          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
               <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
               <div class="q-field__inner relative-position col self-stretch column justify-center">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Where you are from (not required)" placeholder="Search" id="qf_80008000-8000-8000-8000-800080008000" type="text" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__native q-placeholder">
+                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-select__input q-placeholder col q-select__input--padding"></div>
                     <div class="q-field__label no-pointer-events absolute ellipsis">Where you are from (not required)</div>
-                    <!---->
                   </div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" title="Search" class="q-btn inline q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable" style="font-size:10px;">
-                      <div tabindex="-1" class="q-focus-helper"></div>
-                      <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" class="fas fa-search q-icon"> </i></div>
-                    </button></div>
                   <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" class="material-icons q-icon cursor-pointer">cancel</i></div>
                 </div>
                 <div class="q-field__bottom row items-start q-field__bottom--animated">

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots AddressPicker Default 1`] = `
-<div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true"></i></div>
-    <div class="q-field__inner relative-position col self-stretch column justify-center">
-      <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-        <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" placeholder="Search" id="qf_80008000-8000-8000-8000-800080008000" type="text" value="" class="q-field__native q-placeholder">
-          <div class="q-field__label no-pointer-events absolute ellipsis"></div>
-          <!---->
+<div>
+  <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true"></i></div>
+      <div class="q-field__inner relative-position col self-stretch column justify-center">
+        <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+          <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+            <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+            <div class="q-field__label no-pointer-events absolute ellipsis"></div>
+          </div>
         </div>
-        <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
+        <div class="q-field__bottom row items-start q-field__bottom--animated">
+          <div class="q-field__messages col"></div>
+        </div>
       </div>
-      <div class="q-field__bottom row items-start q-field__bottom--animated">
-        <div class="q-field__messages col"></div>
-      </div>
-    </div>
-  </label>
+    </label></div>
   <div class="vue2leaflet-map k-map map">
     <!---->
   </div>
@@ -3229,25 +3229,22 @@ It would make sense if it was markdown
           </label>
           <!---->
         </div>
-        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-fw fa-map-marker q-icon"> </i></div>
-            <div class="q-field__inner relative-position col self-stretch column justify-center">
-              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Address" placeholder="Search" id="qf_80008000-8000-8000-8000-800080008000" type="text" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__native q-placeholder">
-                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  <!---->
+        <div>
+          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-fw fa-map-marker q-icon"> </i></div>
+              <div class="q-field__inner relative-position col self-stretch column justify-center">
+                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
+                  </div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" class="material-icons q-icon cursor-pointer">cancel</i></div>
                 </div>
-                <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" title="Search" class="q-btn inline q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable" style="font-size:10px;">
-                    <div tabindex="-1" class="q-focus-helper"></div>
-                    <div class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" class="fas fa-search q-icon"> </i></div>
-                  </button></div>
-                <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" class="material-icons q-icon cursor-pointer">cancel</i></div>
+                <div class="q-field__bottom row items-start q-field__bottom--animated">
+                  <div class="q-field__messages col"></div>
+                </div>
               </div>
-              <div class="q-field__bottom row items-start q-field__bottom--animated">
-                <div class="q-field__messages col"></div>
-              </div>
-            </div>
-          </label>
+            </label></div>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>
@@ -9034,21 +9031,21 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
           </label>
           <!---->
         </div>
-        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
-            <div class="q-field__inner relative-position col self-stretch column justify-center">
-              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Address" placeholder="Search" id="qf_80008000-8000-8000-8000-800080008000" type="text" value="" class="q-field__native q-placeholder">
-                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  <!---->
+        <div>
+          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
+              <div class="q-field__inner relative-position col self-stretch column justify-center">
+                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
+                  </div>
                 </div>
-                <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
+                <div class="q-field__bottom row items-start q-field__bottom--animated">
+                  <div class="q-field__messages col"></div>
+                </div>
               </div>
-              <div class="q-field__bottom row items-start q-field__bottom--animated">
-                <div class="q-field__messages col"></div>
-              </div>
-            </div>
-          </label>
+            </label></div>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>
@@ -9167,21 +9164,21 @@ exports[`Storyshots Places PlaceEdit 1`] = `
           </label>
           <!---->
         </div>
-        <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
-            <div class="q-field__inner relative-position col self-stretch column justify-center">
-              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Address" placeholder="Search" id="qf_80008000-8000-8000-8000-800080008000" type="text" value="" class="q-field__native q-placeholder">
-                  <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
-                  <!---->
+        <div>
+          <div><label for="qf_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-select q-field--auto-height q-select--with-input q-field--standard q-field--labeled q-field--with-bottom">
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" class="fas fa-map-marker q-icon"> </i></div>
+              <div class="q-field__inner relative-position col self-stretch column justify-center">
+                <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                  <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
+                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" tabindex="0" id="qf_80008000-8000-8000-8000-800080008000" value="" class="q-select__input q-placeholder col q-select__input--padding"></div>
+                    <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
+                  </div>
                 </div>
-                <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
+                <div class="q-field__bottom row items-start q-field__bottom--animated">
+                  <div class="q-field__messages col"></div>
+                </div>
               </div>
-              <div class="q-field__bottom row items-start q-field__bottom--animated">
-                <div class="q-field__messages col"></div>
-              </div>
-            </div>
-          </label>
+            </label></div>
           <div class="vue2leaflet-map k-map map">
             <!---->
           </div>

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -6,6 +6,7 @@
     "NOT_CONNECTED": "You aren't connected to the server",
     "INVALID_LINK": "Sorry, the link you've opened is invalid.",
     "GENERIC_ERROR": "Sorry, something went wrong",
+    "SEARCH_RESULTS": "Search results",
     "SEARCH_NOT_FOUND": "Not Found",
     "ABOUT_KARROT": "About Karrot"
   },

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -653,6 +653,11 @@
     },
     "NO_ONGOING": "No ongoing issues."
   },
+  "ADDRESS_PICKER": {
+    "SET_AS": "Set address as",
+    "KEEP_EXISTING_LOCATION": "keep existing location on map",
+    "CHOOSE_LOCATION": "choose location on map"
+  },
   "UNSUBSCRIBE": {
     "HEADER": "Unsubscribe",
     "ALL": "Unsubscribe all",

--- a/src/maps/components/AddressPicker.vue
+++ b/src/maps/components/AddressPicker.vue
@@ -1,61 +1,59 @@
 <template>
   <div>
-    <div>
-      <QSelect
-        use-input
-        fill-input
-        clearable
-        hide-dropdown-icon
-        :label="label"
-        :error="error"
-        :error-message="errorMessage"
-        :options="options"
-        :placeholder="$t('BUTTON.SEARCH')"
-        :value="value.address"
-        :input-debounce="1000"
-        @input="input"
-        @filter="search"
-      >
-        <template #before>
-          <QIcon :name="icon" />
-        </template>
-        <template #selected-item />
-        <template #option="{ index, itemProps, itemEvents, opt: { label: itemLabel, useSearchTerm } }">
-          <QItem
-            :key="index"
-            v-bind="itemProps"
-            v-on="itemEvents"
-          >
-            <QItemSection>
-              <QItemLabel v-if="useSearchTerm">
-                Set address as
-                <strong>{{ itemLabel }}</strong>
-                <span v-if="hasLocation">(keep existing location on map)</span>
-                <span v-else>(choose location manually on map)</span>
-              </QItemLabel>
-              <QItemLabel v-else>
-                {{ itemLabel }}
-              </QItemLabel>
-            </QItemSection>
-          </QItem>
-          <QSeparator v-if="useSearchTerm" />
-          <QItemLabel
-            v-if="useSearchTerm"
-            v-t="'GLOBAL.SEARCH_RESULTS'"
-            header
-          />
-          <QItem
-            v-if="useSearchTerm && options.length === 1"
-          >
-            <QItemSection>
-              <QItemLabel>
-                {{ $t('GLOBAL.SEARCH_NOT_FOUND') }}
-              </QItemLabel>
-            </QItemSection>
-          </QItem>
-        </template>
-      </QSelect>
-    </div>
+    <QSelect
+      use-input
+      fill-input
+      clearable
+      hide-dropdown-icon
+      :label="label"
+      :error="error"
+      :error-message="errorMessage"
+      :options="options"
+      :placeholder="$t('BUTTON.SEARCH')"
+      :value="value.address"
+      :input-debounce="1000"
+      @input="input"
+      @filter="search"
+    >
+      <template #before>
+        <QIcon :name="icon" />
+      </template>
+      <template #selected-item />
+      <template #option="{ index, itemProps, itemEvents, opt: { label: itemLabel, useSearchTerm } }">
+        <QItem
+          :key="index"
+          v-bind="itemProps"
+          v-on="itemEvents"
+        >
+          <QItemSection>
+            <QItemLabel v-if="useSearchTerm">
+              Set address as
+              <strong>{{ itemLabel }}</strong>
+              <span v-if="hasLocation">(keep existing location on map)</span>
+              <span v-else>(choose location manually on map)</span>
+            </QItemLabel>
+            <QItemLabel v-else>
+              {{ itemLabel }}
+            </QItemLabel>
+          </QItemSection>
+        </QItem>
+        <QSeparator v-if="useSearchTerm" />
+        <QItemLabel
+          v-if="useSearchTerm"
+          v-t="'GLOBAL.SEARCH_RESULTS'"
+          header
+        />
+        <QItem
+          v-if="useSearchTerm && options.length === 1"
+        >
+          <QItemSection>
+            <QItemLabel>
+              {{ $t('GLOBAL.SEARCH_NOT_FOUND') }}
+            </QItemLabel>
+          </QItemSection>
+        </QItem>
+      </template>
+    </QSelect>
     <StandardMap
       class="map"
       :markers="marker ? [marker] : []"

--- a/src/maps/components/AddressPicker.vue
+++ b/src/maps/components/AddressPicker.vue
@@ -27,10 +27,10 @@
         >
           <QItemSection>
             <QItemLabel v-if="useSearchTerm">
-              Set address as
+              {{ $t('ADDRESS_PICKER.SET_AS') }}
               <strong>{{ itemLabel }}</strong>
-              <span v-if="hasLocation">(keep existing location on map)</span>
-              <span v-else>(choose location manually on map)</span>
+              <span v-if="hasLocation">({{ $t('ADDRESS_PICKER.KEEP_EXISTING_LOCATION') }})</span>
+              <span v-else>({{ $t('ADDRESS_PICKER.CHOOSE_LOCATION') }})</span>
             </QItemLabel>
             <QItemLabel v-else>
               {{ itemLabel }}

--- a/src/maps/components/AddressPicker.vue
+++ b/src/maps/components/AddressPicker.vue
@@ -1,52 +1,51 @@
 <template>
   <div>
-    <QInput
-      :value="value.address"
-      clearable
-      :placeholder="$t('BUTTON.SEARCH')"
-      :label="label"
-      :error="error"
-      :error-message="errorMessage"
-      @input="input"
-      @keyup.esc="$refs.menu.hide()"
-      @keyup.enter.prevent.stop="search"
-    >
-      <template v-slot:append>
-        <QBtn
-          v-if="value.address"
-          icon="fas fa-search"
-          :title="$t('BUTTON.SEARCH')"
-          flat
-          round
-          size="sm"
-          @click="search"
-        />
-      </template>
-      <template v-slot:before>
-        <QIcon :name="icon" />
-      </template>
-      <QMenu
-        ref="menu"
-        fit
-        no-parent-event
-        square
+    <div>
+      <QSelect
+        use-input
+        fill-input
+        clearable
+        hide-dropdown-icon
+        :label="label"
+        :error="error"
+        :error-message="errorMessage"
+        :options="options"
+        :placeholder="$t('BUTTON.SEARCH')"
+        :value="value.address"
+        :input-debounce="1000"
+        @input="input"
+        @filter="search"
       >
-        <QList>
+        <template #before>
+          <QIcon :name="icon" />
+        </template>
+        <template #selected-item />
+        <template #option="{ index, itemProps, itemEvents, opt: { label: itemLabel, useSearchTerm } }">
           <QItem
-            v-for="(result, idx) in options"
-            :key="idx"
-            v-close-popup
-            clickable
-            @click="select(result)"
+            :key="index"
+            v-bind="itemProps"
+            v-on="itemEvents"
           >
             <QItemSection>
-              <QItemLabel>
-                {{ result.label }}
+              <QItemLabel v-if="useSearchTerm">
+                Set address as
+                <strong>{{ itemLabel }}</strong>
+                <span v-if="hasLocation">(keep existing location on map)</span>
+                <span v-else>(choose location manually on map)</span>
+              </QItemLabel>
+              <QItemLabel v-else>
+                {{ itemLabel }}
               </QItemLabel>
             </QItemSection>
           </QItem>
+          <QSeparator v-if="useSearchTerm" />
+          <QItemLabel
+            v-if="useSearchTerm"
+            v-t="'GLOBAL.SEARCH_RESULTS'"
+            header
+          />
           <QItem
-            v-if="options.length < 1"
+            v-if="useSearchTerm && options.length === 1"
           >
             <QItemSection>
               <QItemLabel>
@@ -54,13 +53,14 @@
               </QItemLabel>
             </QItemSection>
           </QItem>
-        </QList>
-      </QMenu>
-    </QInput>
+        </template>
+      </QSelect>
+    </div>
     <StandardMap
       class="map"
       :markers="marker ? [marker] : []"
       :prevent-zoom="preventZoom"
+      :default-center="defaultMapCentre"
       @markerMoved="mapMarkerMoved"
       @mapClick="mapMarkerMoved"
     />
@@ -69,30 +69,27 @@
 
 <script>
 import {
-  QInput,
-  QBtn,
   QIcon,
-  QMenu,
-  QList,
   QItem,
   QItemSection,
   QItemLabel,
+  QSelect,
+  QSeparator,
 } from 'quasar'
 import StandardMap from '@/maps/components/StandardMap'
 import L from 'leaflet'
 
 import geocoding from '@/maps/api/geocoding'
+import { filterTruthy } from '@/utils/utils'
 
 export default {
   components: {
-    QInput,
-    QBtn,
     QIcon,
-    QMenu,
-    QList,
     QItem,
     QItemSection,
     QItemLabel,
+    QSelect,
+    QSeparator,
     StandardMap,
   },
   props: {
@@ -124,6 +121,10 @@ export default {
       default: null,
       type: String,
     },
+    defaultMapCentre: {
+      default: null,
+      type: Object,
+    },
   },
   data () {
     return {
@@ -144,45 +145,49 @@ export default {
       }
       return null
     },
+    hasLocation () {
+      const { latitude, longitude } = this.value
+      return Boolean(latitude && longitude)
+    },
   },
   methods: {
-    async search () {
-      const terms = this.value.address
-      if (!terms) {
-        this.options = []
-      }
+    async search (terms, update) {
+      if (!terms) return update(() => { this.options = [] })
 
-      this.options = (await geocoding.lookupAddress(terms)).map(result => {
+      const searchResults = (await geocoding.lookupAddress(terms)).map(result => {
         const { address } = result
         return {
           result,
+          value: address,
           label: address,
+          useSearchTerm: false,
         }
       })
-      this.$refs.menu.show()
+      update(() => {
+        // A special option that allows us to select the literal search term as the address with no geocoding
+        this.options = [{
+          result: { address: terms },
+          value: terms,
+          label: terms,
+          useSearchTerm: true,
+          hasSearchResults: searchResults.length > 0,
+        }, ...searchResults]
+      })
     },
     input (value) {
       if (!value) {
         this.reset()
         return
       }
-      this.$emit('input', { ...this.value, address: value })
-    },
-    select (value) {
-      if (!value) {
-        this.reset()
-        return
-      }
       const { result: { address, latitude, longitude } } = value
       this.preventZoom = false
-      this.$emit('input', { ...this.value, latitude, longitude, address })
+      this.$emit('input', { ...this.value, ...filterTruthy({ latitude, longitude, address }) })
     },
     mapMarkerMoved ({ lat: latitude, lng: longitude }) {
       this.preventZoom = true
       this.$emit('input', { ...this.value, latitude, longitude })
     },
     reset () {
-      this.$refs.menu.hide()
       this.$emit('input', { ...this.value, latitude: null, longitude: null, address: null })
     },
   },
@@ -192,7 +197,7 @@ export default {
 <style scoped lang="stylus">
 .map
   height 260px
-  margin-left 42px
+  margin-left 37px
   margin-top -10px
   width calc(100% - 42px)
 </style>

--- a/src/maps/components/AddressPicker.vue
+++ b/src/maps/components/AddressPicker.vue
@@ -58,7 +58,7 @@
       class="map"
       :markers="marker ? [marker] : []"
       :prevent-zoom="preventZoom"
-      :default-center="defaultMapCentre"
+      :default-center="defaultMapCenter"
       @markerMoved="mapMarkerMoved"
       @mapClick="mapMarkerMoved"
     />
@@ -119,7 +119,7 @@ export default {
       default: null,
       type: String,
     },
-    defaultMapCentre: {
+    defaultMapCenter: {
       default: null,
       type: Object,
     },

--- a/src/maps/components/AddressPicker.vue
+++ b/src/maps/components/AddressPicker.vue
@@ -37,21 +37,20 @@
             </QItemLabel>
           </QItemSection>
         </QItem>
-        <QSeparator v-if="useSearchTerm" />
-        <QItemLabel
-          v-if="useSearchTerm"
-          v-t="'GLOBAL.SEARCH_RESULTS'"
-          header
-        />
-        <QItem
-          v-if="useSearchTerm && options.length === 1"
-        >
-          <QItemSection>
-            <QItemLabel>
-              {{ $t('GLOBAL.SEARCH_NOT_FOUND') }}
-            </QItemLabel>
-          </QItemSection>
-        </QItem>
+        <template v-if="useSearchTerm">
+          <QSeparator />
+          <QItemLabel
+            v-t="'GLOBAL.SEARCH_RESULTS'"
+            header
+          />
+          <QItem v-if="options.length === 1">
+            <QItemSection>
+              <QItemLabel>
+                {{ $t('GLOBAL.SEARCH_NOT_FOUND') }}
+              </QItemLabel>
+            </QItemSection>
+          </QItem>
+        </template>
       </template>
     </QSelect>
     <StandardMap

--- a/src/places/components/PlaceEdit.vue
+++ b/src/places/components/PlaceEdit.vue
@@ -86,6 +86,7 @@
             :label="$t('STOREEDIT.ADDRESS')"
             :error="hasAddressError"
             :error-message="addressError"
+            :default-map-centre="defaultMapCentre"
           />
 
           <div>
@@ -269,6 +270,11 @@ export default {
     },
     markerColor () {
       if (this.edit) return optionsFor(this.edit).color
+      return null
+    },
+    defaultMapCentre () {
+      const { latitude: lat, longitude: lng } = this.edit.group || {}
+      if (lat && lng) return { lat, lng }
       return null
     },
   },

--- a/src/places/components/PlaceEdit.vue
+++ b/src/places/components/PlaceEdit.vue
@@ -86,7 +86,7 @@
             :label="$t('STOREEDIT.ADDRESS')"
             :error="hasAddressError"
             :error-message="addressError"
-            :default-map-centre="defaultMapCentre"
+            :default-map-center="defaultMapCenter"
           />
 
           <div>
@@ -272,7 +272,7 @@ export default {
       if (this.edit) return optionsFor(this.edit).color
       return null
     },
-    defaultMapCentre () {
+    defaultMapCenter () {
       const { latitude: lat, longitude: lng } = this.edit.group || {}
       if (lat && lng) return { lat, lng }
       return null

--- a/src/storyshots.spec.js
+++ b/src/storyshots.spec.js
@@ -23,15 +23,13 @@ import lolex from 'lolex'
 import { createRenderer } from 'vue-server-renderer'
 import Vue from 'vue'
 import configureQuasar from '@/base/configureQuasar'
-import { mount, RouterLinkStub, TransitionStub, TransitionGroupStub } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import i18n from '@/base/i18n'
 import routerMocks from '>/routerMocks'
 
 i18n.locale = 'en'
 configureQuasar(Vue)
 Vue.component('RouterLink', RouterLinkStub)
-Vue.component('Transition', TransitionStub)
-Vue.component('TransitionGroup', TransitionGroupStub)
 
 // To get properly faked dates, install fake Date object before importing stories
 const now = new Date('2017-12-24T12:00:00Z')
@@ -92,6 +90,7 @@ for (const group of mockStories) {
           const component = story.render()
 
           const wrapper = mount(component, {
+            sync: false,
             mocks: {
               ...routerMocks,
             },

--- a/src/utils/datastore/refresh.spec.js
+++ b/src/utils/datastore/refresh.spec.js
@@ -66,7 +66,7 @@ describe('refresh', () => {
     datastore.commit('auth/setUser', { id: 1 })
 
     // wait until plugins ran (e.g. latestMessages)
-    await nextTicks(3)
+    await nextTicks(4)
     mockListMyThreads.mockClear()
     mockConversationsList.mockClear()
     mockNotificationsList.mockClear()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,6 +2202,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^24.0.23":
+  version "24.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.23.tgz#046f8e2ade026fe831623e361a36b6fb9a4463e4"
+  integrity sha512-L7MBvwfNpe7yVPTXLn32df/EK+AMBFAFvZrRuArGs7npEWnlziUXK+5GMIUTI4NIuwok3XibsjXCs5HxviYXjg==
+  dependencies:
+    jest-diff "^24.3.0"
+
 "@types/long@*", "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -8263,7 +8270,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.9.0:
+jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==


### PR DESCRIPTION
## What does this PR do?

Use autocomplete for address picker again as it used to. I made it so it gives you an explicit option to use the search term as the address without adding/changing any existing map marker.

Also defaults place edit map to be group centre if available.

I didn't add everything into translation strings, just as maybe there are some language changes in review (plus, I'm tired and about to go to bed ;) )

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
