### PR TITLE
Add create new group link

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -4332,12 +4332,11 @@ exports[`Storyshots GroupGallery signup view 1`] = `
           Log in to see your groups!
         </a></span></div>
     </div>
-    <p class="text-primary header">
-      Which group do you want to join?
-      or
-      <a class="underline text-lowercase">
-        Create new group
-      </a></p>
+    <p class="text-primary header"><span>
+          Which group do you want to join?
+         or <a class="underline text-lowercase">
+            Create new group
+          </a></span></p>
     <div class="row items-start no-wrap q-mt-md">
       <div class="col"><label for="f_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-pl-sm q-input q-field--filled q-field--dense">
           <div class="q-field__inner relative-position col self-stretch column justify-center">
@@ -4720,12 +4719,11 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
         </div>
       </div>
     </div>
-    <p class="text-primary header">
-      Which group do you want to join?
-      or
-      <a class="underline text-lowercase">
-        Create new group
-      </a></p>
+    <p class="text-primary header"><span>
+          Which group do you want to join?
+         or <a class="underline text-lowercase">
+            Create new group
+          </a></span></p>
     <div>
       <div><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
         <div class="inline-block" style="width:100%;">

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -4334,7 +4334,10 @@ exports[`Storyshots GroupGallery signup view 1`] = `
     </div>
     <p class="text-primary header">
       Which group do you want to join?
-    </p>
+      or
+      <a class="underline text-lowercase">
+        Create new group
+      </a></p>
     <div class="row items-start no-wrap q-mt-md">
       <div class="col"><label for="f_80008000-8000-8000-8000-800080008000" class="q-field row no-wrap items-start q-pl-sm q-input q-field--filled q-field--dense">
           <div class="q-field__inner relative-position col self-stretch column justify-center">
@@ -4719,7 +4722,10 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
     </div>
     <p class="text-primary header">
       Which group do you want to join?
-    </p>
+      or
+      <a class="underline text-lowercase">
+        Create new group
+      </a></p>
     <div>
       <div><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
         <div class="inline-block" style="width:100%;">

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -40,6 +40,13 @@
         class="text-primary header"
       >
         {{ $t('JOINGROUP.WHICHGROUP') }}
+        or
+        <router-link
+          :to="{ name: 'groupCreate' }"
+          class="underline text-lowercase"
+        >
+          {{ $t('GROUP.CREATE_TITLE') }}
+        </router-link>
       </p>
       <div class="row items-start no-wrap q-mt-md">
         <div class="col">
@@ -104,6 +111,13 @@
         class="text-primary header"
       >
         {{ $t('JOINGROUP.WHICHGROUP') }}
+        or
+        <router-link
+          :to="{ name: 'groupCreate' }"
+          class="underline text-lowercase"
+        >
+          {{ $t('GROUP.CREATE_TITLE') }}
+        </router-link>
       </p>
       <div v-if="hasOtherGroupsToShow">
         <GroupGalleryCards

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -39,14 +39,19 @@
         v-if="!hasJoinedGroups"
         class="text-primary header"
       >
-        {{ $t('JOINGROUP.WHICHGROUP') }}
-        or
-        <router-link
-          :to="{ name: 'groupCreate' }"
-          class="underline text-lowercase"
-        >
-          {{ $t('GROUP.CREATE_TITLE') }}
-        </router-link>
+        <i18n path="JOINGROUP.OR">
+          <template #joinGroup>
+            {{ $t('JOINGROUP.WHICHGROUP') }}
+          </template>
+          <template #createGroup>
+            <router-link
+              :to="{ name: 'groupCreate' }"
+              class="underline text-lowercase"
+            >
+              {{ $t('GROUP.CREATE_TITLE') }}
+            </router-link>
+          </template>
+        </i18n>
       </p>
       <div class="row items-start no-wrap q-mt-md">
         <div class="col">
@@ -110,14 +115,19 @@
         v-if="hasJoinedGroups && hasOtherGroupsToShow"
         class="text-primary header"
       >
-        {{ $t('JOINGROUP.WHICHGROUP') }}
-        or
-        <router-link
-          :to="{ name: 'groupCreate' }"
-          class="underline text-lowercase"
-        >
-          {{ $t('GROUP.CREATE_TITLE') }}
-        </router-link>
+        <i18n path="JOINGROUP.OR">
+          <template #joinGroup>
+            {{ $t('JOINGROUP.WHICHGROUP') }}
+          </template>
+          <template #createGroup>
+            <router-link
+              :to="{ name: 'groupCreate' }"
+              class="underline text-lowercase"
+            >
+              {{ $t('GROUP.CREATE_TITLE') }}
+            </router-link>
+          </template>
+        </i18n>
       </p>
       <div v-if="hasOtherGroupsToShow">
         <GroupGalleryCards

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -254,6 +254,7 @@
   },
   "JOINGROUP": {
     "WHICHGROUP": "Which group do you want to join?",
+    "OR": "{joinGroup} or {createGroup}",
     "NUM_MEMBERS": "Member | Members",
     "NO_PUBLIC_DESCRIPTION": "(This group has no public description... yet)",
     "ALL_GROUPS": "All groups",


### PR DESCRIPTION
#1940 

## What does this PR do?

This adds a "create new group" link on the group gallery page.

I did not handle the case that there are no groups the user can join. In that case the link won't show. But I don't _think_ that should be too common.... I just wanted to make the simplest possible thing. I mean, it might actually be nicer to make another group gallery card with a "create your group" kind of thing (like the new offer thing)... but maybe that is just an optimization.

![createnewgroup](https://user-images.githubusercontent.com/31616/70561939-bc31b600-1b8b-11ea-93c0-a65e2a45d3ae.png)

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
