### PR TITLE
Freeze some objects to improve performance

### DIFF
--- a/src/authuser/datastore/auth.js
+++ b/src/authuser/datastore/auth.js
@@ -202,7 +202,7 @@ export default {
   },
   mutations: {
     setUser (state, user) {
-      state.user = user
+      state.user = Object.freeze(user)
     },
 
     // Redirect
@@ -238,7 +238,7 @@ export default {
     },
 
     setFailedEmailDeliveries (state, events) {
-      state.failedEmailDeliveries = events
+      state.failedEmailDeliveries = Object.freeze(events)
     },
 
     setMaybeLoggedOut (state, value) {

--- a/src/base/datastore/i18n.js
+++ b/src/base/datastore/i18n.js
@@ -60,7 +60,7 @@ export default {
   },
   mutations: {
     set (state, locale) {
-      state.locale = locale
+      state.locale = Object.freeze(locale)
     },
   },
 }

--- a/src/base/routes/main.spec.js
+++ b/src/base/routes/main.spec.js
@@ -2,8 +2,10 @@ import { createLocalVue, mount } from '@vue/test-utils'
 import { nextTicks } from '>/helpers'
 import createMockModules from '>/createMockModules'
 
+const mockJoin = jest.fn()
+
 jest.mock('@/group/api/groups', () => ({
-  join: jest.fn(),
+  join: mockJoin,
 }))
 
 jest.mock('@/base/router', () => {
@@ -146,7 +148,7 @@ describe('main routes', () => {
 
       await nextTicks(2)
 
-      expect(group.members).toContain(user.id)
+      expect(mockJoin).toBeCalledWith(group.id)
 
       expect(routedPaths).toEqual([
         '/groupPreview',

--- a/src/group/datastore/currentGroup.js
+++ b/src/group/datastore/currentGroup.js
@@ -206,7 +206,7 @@ export default {
       state.id = value
     },
     set (state, group) {
-      state.current = group
+      state.current = Object.freeze(group)
     },
     clear (state) {
       Object.assign(state, initialState())

--- a/src/groupInfo/datastore/groups.js
+++ b/src/groupInfo/datastore/groups.js
@@ -69,13 +69,11 @@ export default {
 
       async join ({ commit, rootGetters }, groupId) {
         await groups.join(groupId)
-        commit('join', { groupId, userId: rootGetters['auth/userId'] })
         router.push({ name: 'group', params: { groupId } }).catch(() => {})
       },
 
       async leave ({ commit, dispatch, getters, rootGetters }, groupId) {
         await groups.leave(groupId)
-        commit('leave', { groupId, userId: rootGetters['auth/userId'] })
         dispatch('toasts/show', {
           message: 'GROUP.LEAVE_CONFIRMATION',
           messageParams: { groupName: getters.get(groupId).name },
@@ -126,19 +124,10 @@ export default {
       state.activePreviewId = previewId
     },
     set (state, groups) {
-      state.entries = indexById(groups)
+      state.entries = Object.freeze(indexById(groups))
     },
     update (state, groups) {
-      state.entries = { ...state.entries, ...indexById(groups) }
-    },
-    join (state, { groupId, userId }) {
-      const { members } = state.entries[groupId]
-      if (!members.includes(userId)) members.push(userId)
-    },
-    leave (state, { groupId, userId }) {
-      const { members } = state.entries[groupId]
-      const idx = members.indexOf(userId)
-      if (idx !== -1) members.splice(idx, 1)
+      state.entries = Object.freeze({ ...state.entries, ...indexById(groups) })
     },
   },
 }

--- a/src/groupInfo/datastore/groups.spec.js
+++ b/src/groupInfo/datastore/groups.spec.js
@@ -134,14 +134,14 @@ describe('groups', () => {
       expect(datastore.getters['groups/mine'].map(e => e.id)).toEqual([group2.id, group3.id])
       await datastore.dispatch('groups/join', group1.id)
       expect(mockRouterPush).toBeCalledWith({ name: 'group', params: { groupId: group1.id } })
-      expect(datastore.getters['groups/mine'].map(e => e.id)).toEqual([group1.id, group2.id, group3.id])
+      expect(mockJoin).toBeCalledWith(group1.id)
     })
 
     it('can leave a group', async () => {
       mockLeave.mockReturnValueOnce({})
       expect(datastore.getters['groups/mine'].map(e => e.id)).toEqual([group2.id, group3.id])
       await datastore.dispatch('groups/leave', group2.id)
-      expect(datastore.getters['groups/mine'].map(e => e.id)).toEqual([group3.id])
+      expect(mockLeave).toBeCalledWith(group2.id)
       expect(auth.actions.maybeBackgroundSave).toBeCalled()
       expect(auth.actions.maybeBackgroundSave.mock.calls[0][1]).toEqual({ currentGroup: null })
       expect(currentGroup.actions.clear).toBeCalled()

--- a/src/history/datastore/history.js
+++ b/src/history/datastore/history.js
@@ -91,10 +91,10 @@ export default {
       state.activeId = id
     },
     update (state, entries) {
-      state.entries = {
+      state.entries = Object.freeze({
         ...state.entries,
         ...indexById(entries),
-      }
+      })
     },
     clear (state) {
       Object.assign(state, initialState())

--- a/src/invitations/datastore/invitations.js
+++ b/src/invitations/datastore/invitations.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import invitations from '@/invitations/api/invitations'
 import router from '@/base/router'
 import { createMetaModule, withMeta, metaStatuses, indexById } from '@/utils/datastore/helpers'
@@ -139,10 +138,12 @@ export default {
   },
   mutations: {
     update (state, invitations) {
-      state.entries = { ...state.entries, ...indexById(invitations) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(invitations) })
     },
     delete (state, id) {
-      Vue.delete(state.entries, id)
+      const { [id]: _, ...rest } = state.entries
+      Object.freeze(rest)
+      state.entries = rest
     },
     clear (state) {
       Object.assign(state, initialState())

--- a/src/issues/datastore/issues.js
+++ b/src/issues/datastore/issues.js
@@ -1,5 +1,4 @@
 import router from '@/base/router'
-import Vue from 'vue'
 import issuesAPI from '@/issues/api/issues'
 import { createMetaModule, createPaginationModule, withMeta, metaStatuses, indexById } from '@/utils/datastore/helpers'
 
@@ -117,14 +116,15 @@ export default {
       state.currentId = issueId
     },
     update (state, issues) {
-      state.entries = { ...state.entries, ...indexById(issues) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(issues) })
     },
     clear (state) {
       Object.assign(state, initialState())
     },
     clearForGroup (state, groupId) {
-      const toClear = Object.entries(state.entries).filter(([_, v]) => v.group === groupId).map(([k]) => k)
-      toClear.forEach(idx => Vue.delete(state.entries, idx))
+      const rest = Object.fromEntries(Object.entries(state.entries).filter(([_, v]) => v.group !== groupId))
+      Object.freeze(rest)
+      state.entries = rest
     },
   },
 }

--- a/src/messages/datastore/conversations.js
+++ b/src/messages/datastore/conversations.js
@@ -466,14 +466,14 @@ export default {
       Vue.set(
         state.messages,
         conversationId,
-        stateMessages ? insertSorted(stateMessages, messages) : messages,
+        Object.freeze(stateMessages ? insertSorted(stateMessages, messages) : messages),
       )
     },
     setCursor (state, { conversationId, cursor }) {
       Vue.set(state.cursors, conversationId, cursor)
     },
     setConversation (state, conversation) {
-      Vue.set(state.entries, conversation.id, conversation)
+      Vue.set(state.entries, conversation.id, Object.freeze(conversation))
     },
   },
 }

--- a/src/messages/datastore/currentThread.js
+++ b/src/messages/datastore/currentThread.js
@@ -131,7 +131,7 @@ export default {
       state.id = id
     },
     setThread (state, thread) {
-      state.thread = thread
+      state.thread = Object.freeze(thread)
     },
     setMuted (state, muted) {
       state.thread.muted = muted
@@ -139,10 +139,10 @@ export default {
     update (state, messages) {
       const stateMessages = state.messages
       if (!stateMessages) {
-        state.messages = messages
+        state.messages = Object.freeze(messages)
         return
       }
-      state.messages = insertSorted(stateMessages, messages, true)
+      state.messages = Object.freeze(insertSorted(stateMessages, messages, true))
     },
     clear (state) {
       Object.assign(state, initialState())

--- a/src/messages/datastore/latestMessages.js
+++ b/src/messages/datastore/latestMessages.js
@@ -208,7 +208,7 @@ export default {
       Object.assign(state, initialState())
     },
     updateConversations (state, conversations) {
-      state.conversations = { ...state.conversations, ...indexById(conversations) }
+      state.conversations = Object.freeze({ ...state.conversations, ...indexById(conversations) })
     },
     updateConversationMessages (state, messages) {
       for (const message of messages) {
@@ -217,7 +217,7 @@ export default {
         Vue.set(
           state.conversationMessages,
           conversationId,
-          stateMessages ? insertSorted(stateMessages, [message]) : [message],
+          Object.freeze(stateMessages ? insertSorted(stateMessages, [message]) : [message]),
         )
       }
     },
@@ -225,7 +225,7 @@ export default {
       state.conversationsCursor = cursor
     },
     updateThreads (state, threads) {
-      state.threads = { ...state.threads, ...indexById(threads) }
+      state.threads = Object.freeze({ ...state.threads, ...indexById(threads) })
     },
     updateThreadMessages (state, messages) {
       for (const message of messages) {
@@ -234,20 +234,21 @@ export default {
         Vue.set(
           state.threadMessages,
           threadId,
-          stateMessages ? insertSorted(stateMessages, [message]) : [message],
+          Object.freeze(stateMessages ? insertSorted(stateMessages, [message]) : [message]),
         )
       }
     },
     updateRelated (state, { type, items }) {
-      Vue.set(state.related, type, { ...state.related[type], ...indexById(items) })
+      Vue.set(state.related, type, Object.freeze({ ...state.related[type], ...indexById(items) }))
     },
     deleteRelated (state, { type, ids }) {
       if (!state.related[type]) return
-      for (const id of ids) {
-        Vue.delete(state.related[type], id)
-      }
-      if (Object.keys(state.related[type]).length === 0) {
+      const rest = Object.fromEntries(Object.entries(state.related[type]).filter(([k, _]) => !ids.include(k)))
+      if (rest.length === 0) {
         Vue.delete(state.related, type)
+      }
+      else {
+        Vue.set(state.related, type, rest)
       }
     },
     setThreadsCursor (state, cursor) {

--- a/src/notifications/datastore/notifications.js
+++ b/src/notifications/datastore/notifications.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import { createMetaModule, createPaginationModule, indexById, withMeta } from '@/utils/datastore/helpers'
 import notificationsAPI from '@/notifications/api/notifications'
 import reactiveNow from '@/utils/reactiveNow'
@@ -106,13 +105,15 @@ export default {
       state.pageVisible = visible
     },
     setEntryMeta (state, data) {
-      state.entryMeta = data
+      state.entryMeta = Object.freeze(data)
     },
     update (state, entries) {
-      state.entries = { ...state.entries, ...indexById(entries) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(entries) })
     },
     delete (state, id) {
-      Vue.delete(state.entries, id)
+      const { [id]: _, ...rest } = state.entries
+      Object.freeze(rest)
+      state.entries = rest
     },
     clear (state) {
       Object.assign(state, initialState())

--- a/src/offers/datastore/currentOffer.js
+++ b/src/offers/datastore/currentOffer.js
@@ -68,14 +68,14 @@ export default {
       state.id = value
     },
     set (state, offer) {
-      state.current = offer
+      state.current = Object.freeze(offer)
     },
     clear (state) {
       Object.assign(state, initialState())
     },
     update (state, offer) {
       if (state.id === offer.id) {
-        state.current = offer
+        state.current = Object.freeze(offer)
       }
     },
     delete (state, offerId) {

--- a/src/offers/datastore/offers.js
+++ b/src/offers/datastore/offers.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import offers from '@/offers/api/offers'
 import {
   createMetaModule,
@@ -127,10 +126,13 @@ export default {
       Object.assign(state, initialState())
     },
     update (state, offers) {
-      state.entries = { ...state.entries, ...indexById(offers) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(offers) })
     },
     delete (state, id) {
-      if (state.entries[id]) Vue.delete(state.entries, id)
+      if (!state.entries[id]) return
+      const { [id]: _, ...rest } = state.entries
+      Object.freeze(rest)
+      state.entries = rest
     },
     setFilter (state, data) {
       state.entries = {}

--- a/src/pickups/datastore/pickupSeries.js
+++ b/src/pickups/datastore/pickupSeries.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import pickupSeries from '@/pickups/api/pickupSeries'
 import { createMetaModule, withMeta, metaStatusesWithId, metaStatuses, indexById } from '@/utils/datastore/helpers'
 
@@ -87,16 +86,19 @@ export default {
   },
   mutations: {
     set (state, list) {
-      state.entries = indexById(list)
+      state.entries = Object.freeze(indexById(list))
     },
     clearList (state) {
       state.entries = {}
     },
     update (state, seriesList) {
-      state.entries = { ...state.entries, ...indexById(seriesList) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(seriesList) })
     },
     delete (state, seriesId) {
-      if (state.entries[seriesId]) Vue.delete(state.entries, seriesId)
+      if (!state.entries[seriesId]) return
+      const { [seriesId]: _, ...rest } = state.entries
+      Object.freeze(rest)
+      state.entries = rest
     },
   },
 }

--- a/src/pickups/datastore/pickups.spec.js
+++ b/src/pickups/datastore/pickups.spec.js
@@ -141,14 +141,12 @@ describe('pickups', () => {
     it('can join a pickup', async () => {
       expect(vstore.getters['pickups/joined'].map(getId)).not.toContain(pickup1.id)
       await vstore.dispatch('pickups/join', pickup1.id)
-      expect(vstore.getters['pickups/joined'].map(getId)).toContain(pickup1.id)
       expect(mockJoin).toBeCalledWith(pickup1.id)
     })
 
     it('can leave a pickup', async () => {
       expect(vstore.getters['pickups/joined'].map(getId)).toContain(pickup2.id)
       await vstore.dispatch('pickups/leave', pickup2.id)
-      expect(vstore.getters['pickups/joined'].map(getId)).not.toContain(pickup2.id)
       expect(mockLeave).toBeCalledWith(pickup2.id)
     })
 

--- a/src/places/datastore/places.js
+++ b/src/places/datastore/places.js
@@ -149,16 +149,16 @@ export default {
       state.activePlaceId = null
     },
     set (state, places) {
-      state.entries = indexById(places)
+      state.entries = Object.freeze(indexById(places))
     },
     clear (state) {
       Object.assign(state, initialState())
     },
     update (state, places) {
-      state.entries = { ...state.entries, ...indexById(places) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(places) })
     },
     setStatistics (state, { id, data }) {
-      Vue.set(state.statistics, id, data)
+      Vue.set(state.statistics, id, Object.freeze(data))
     },
   },
 }

--- a/src/users/datastore/users.js
+++ b/src/users/datastore/users.js
@@ -159,13 +159,13 @@ export default {
   },
   mutations: {
     setProfile (state, userProfile) {
-      state.activeUserProfile = userProfile
+      state.activeUserProfile = Object.freeze(userProfile)
     },
     setProfileId (state, id) {
       state.activeUserProfileId = id
     },
     update (state, users) {
-      state.entries = { ...state.entries, ...indexById(users) }
+      state.entries = Object.freeze({ ...state.entries, ...indexById(users) })
     },
     resendVerificationCodeSuccess (state, status) {
       Vue.set(state, 'resendVerificationCodeSuccess', status)


### PR DESCRIPTION
Related to https://github.com/yunity/karrot-frontend/issues/1914

- freeze most objects and arrays in Vuex
- replace objects instead of modifying them (no Vue.set/delete on frozen objects)

I also got rid of group and pickup join/leave mutations because they are also done vie websockets. I know that @nicksellen prefers to have basic functionality working without websockets, so I would consider adding it back later after deploy when there's a performance improvement.