### PR TITLE
Add rough measure-peformance script

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "postcss-styl": "^0.5.1",
     "postcss-syntax": "^0.36.2",
     "preload-webpack-plugin": "3.0.0-beta.3",
+    "puppeteer": "^2.0.0",
     "raf": "^3.4.0",
     "shx": "^0.3.2",
     "style-loader": "^1.0.1",

--- a/scripts/measure-performance.js
+++ b/scripts/measure-performance.js
@@ -1,0 +1,43 @@
+const puppeteer = require('puppeteer');
+const axios = require('axios');
+const cookie = require('cookie');
+
+puppeteer.launch({ headless: false }).then(async browser => {
+
+  // log in directly via API
+  const data = await axios.post('http://localhost:8080/api/auth/', {
+    email: 'foo@foo.com',
+    password: 'foofoo'
+  })
+
+  // suck out the cookies (pretty crappy/flakey implementation)
+  const cookies = data.headers['set-cookie'].map(cookie.parse).map(d => {
+    return {
+      name: d.csrftoken ? 'csrftoken' : 'sessionid',
+      value: d.csrftoken || d.sessionid,
+      domain: 'localhost:8080',
+      path: d.Path,
+      sameSite: d.SameSite,
+      expires: new Date(d.expires).getTime() / 1000
+    }
+  });
+
+  console.log('cookies', cookies);
+
+  const page = await browser.newPage();
+
+  page.setCookie(...cookies);
+
+  await page.exposeFunction('onCustomEvent', ({ type, detail }) => {
+      console.log(detail);
+      browser.close();
+  });
+  
+  await page.evaluateOnNewDocument(() => {
+      window.addEventListener('measured', ({ type, detail }) => {
+          window.onCustomEvent({ type, detail });
+      });
+  });
+
+  await page.goto('http://localhost:8080/');
+});

--- a/scripts/measure-performance.js
+++ b/scripts/measure-performance.js
@@ -1,13 +1,12 @@
-const puppeteer = require('puppeteer');
-const axios = require('axios');
-const cookie = require('cookie');
+const puppeteer = require('puppeteer')
+const axios = require('axios')
+const cookie = require('cookie')
 
 puppeteer.launch({ headless: false }).then(async browser => {
-
   // log in directly via API
   const data = await axios.post('http://localhost:8080/api/auth/', {
     email: 'foo@foo.com',
-    password: 'foofoo'
+    password: 'foofoo',
   })
 
   // suck out the cookies (pretty crappy/flakey implementation)
@@ -18,26 +17,26 @@ puppeteer.launch({ headless: false }).then(async browser => {
       domain: 'localhost:8080',
       path: d.Path,
       sameSite: d.SameSite,
-      expires: new Date(d.expires).getTime() / 1000
+      expires: new Date(d.expires).getTime() / 1000,
     }
-  });
+  })
 
-  console.log('cookies', cookies);
+  console.log('cookies', cookies)
 
-  const page = await browser.newPage();
+  const page = await browser.newPage()
 
-  page.setCookie(...cookies);
+  page.setCookie(...cookies)
 
   await page.exposeFunction('onCustomEvent', ({ type, detail }) => {
-      console.log(detail);
-      browser.close();
-  });
-  
-  await page.evaluateOnNewDocument(() => {
-      window.addEventListener('measured', ({ type, detail }) => {
-          window.onCustomEvent({ type, detail });
-      });
-  });
+    console.log(detail)
+    browser.close()
+  })
 
-  await page.goto('http://localhost:8080/');
-});
+  await page.evaluateOnNewDocument(() => {
+    window.addEventListener('measured', ({ type, detail }) => {
+      window.onCustomEvent({ type, detail })
+    })
+  })
+
+  await page.goto('http://localhost:8080/')
+})

--- a/scripts/measure-performance.js
+++ b/scripts/measure-performance.js
@@ -21,8 +21,6 @@ puppeteer.launch({ headless: false }).then(async browser => {
     }
   })
 
-  console.log('cookies', cookies)
-
   const page = await browser.newPage()
 
   page.setCookie(...cookies)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4563,7 +4563,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -6281,6 +6281,16 @@ extract-from-css@^0.4.4:
   dependencies:
     css "^2.1.0"
 
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
+  dependencies:
+    concat-stream "1.6.2"
+    debug "2.6.9"
+    mkdirp "0.5.1"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -6363,6 +6373,13 @@ fbjs@^0.8.0:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
+  dependencies:
+    pend "~1.2.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -9897,7 +9914,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.2, mime@^2.4.4:
+mime@^2.0.3, mime@^2.4.2, mime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -11417,6 +11434,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -12111,7 +12133,7 @@ progress@2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -12318,6 +12340,20 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.0.0.tgz#0612992e29ec418e0a62c8bebe61af1a64d7ec01"
+  integrity sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^3.0.0"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
 
 q@1.5.0:
   version "1.5.0"
@@ -15971,7 +16007,7 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.0.0, ws@^6.2.1:
+ws@^6.0.0, ws@^6.1.0, ws@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
@@ -16151,3 +16187,10 @@ yargs@^3.10.0:
     string-width "^1.0.1"
     window-size "^0.1.4"
     y18n "^3.2.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
+  dependencies:
+    fd-slicer "~1.0.1"


### PR DESCRIPTION
Pretty rough and ready right now... run it with `node scripts/measure-performance.js`. It'll launch chrome, then output something like:

```
cookies [
  {
    name: 'csrftoken',
    value: 'Q7dimOuGudVLPNjlnrPCH7OU2gW5uN8IFqZuk5VkoPHl5zNvP02jDbFA9SBVrjxz',
    domain: 'localhost:8080',
    path: '/',
    sameSite: 'Lax',
    expires: 1608061976
  },
  {
    name: 'sessionid',
    value: '13ro4fc2x62wf7pq21fhlo97lr9qsug4',
    domain: 'localhost:8080',
    path: '/',
    sameSite: 'Lax',
    expires: 1577821976
  }
]
{
  firstLoad: true,
  ms: 3666,
  msResources: 15860,
  loggedIn: true,
  group: 1,
  routeName: 'group',
  routePath: '/group/1/wall',
  mobile: false,
  browser: 'chrome',
  os: 'linux',
  dev: true,
  app: false
}
```