### PR TITLE
Remove concept of accepted offers

### DIFF
--- a/src/locales/locale-de.json
+++ b/src/locales/locale-de.json
@@ -665,14 +665,11 @@
     "NAME": "Name",
     "NAME_HELPER": "Short name for the item you are offering",
     "DESCRIPTION": "Description",
-    "MARK_AS_ACCEPTED": "Mark as accepted",
-    "MARK_AS_ACCEPTED_DESCRIPTION": "Mark this offer as accepted to show to others that it is not available any more.",
     "MARK_AS_ARCHIVED": "Archive",
     "MARK_AS_ARCHIVED_DESCRIPTION": "Mark this is offer as archived to remove it from the available listings.",
     "FILTER": {
       "STATUS": {
         "ACTIVE": "Available",
-        "ACCEPTED": "My accepted offers",
         "ARCHIVED": "My archived offers"
       }
     }

--- a/src/offers/api/offers.js
+++ b/src/offers/api/offers.js
@@ -64,10 +64,6 @@ export default {
     return convert((await axios.patch(`/api/offers/${offer.id}/`, await toFormData(offer))).data)
   },
 
-  async accept (offerId) {
-    return convert((await axios.post(`/api/offers/${offerId}/accept/`)).data)
-  },
-
   async archive (offerId) {
     return convert((await axios.post(`/api/offers/${offerId}/archive/`)).data)
   },

--- a/src/offers/components/OfferDetailBody.vue
+++ b/src/offers/components/OfferDetailBody.vue
@@ -30,8 +30,7 @@
       </QCarousel>
       <div
         v-if="!isDefaultStatus"
-        class="q-pa-md text-center text-h6 text-white"
-        :class="`bg-${offer.status === 'accepted' ? 'positive' : 'negative'}`"
+        class="q-pa-md text-center text-h6 text-white bg-negative"
       >
         {{ offer.status }}
       </div>
@@ -39,29 +38,6 @@
         v-if="offer.canEdit && offer.status === 'active'"
         class="row justify-end"
       >
-        <QBtnDropdown
-          flat
-          no-caps
-          :label="$t('OFFER.MARK_AS_ACCEPTED')"
-        >
-          <div
-            class="q-pa-lg"
-            style="max-width: 300px;"
-          >
-            <div
-              v-t="'OFFER.MARK_AS_ACCEPTED_DESCRIPTION'"
-              class="text-body1 q-mb-lg"
-            />
-            <div class="row justify-end">
-              <QBtn
-                color="positive"
-                @click="accept({ offerId: offer.id })"
-              >
-                <span v-t="'OFFER.MARK_AS_ACCEPTED'" />
-              </QBtn>
-            </div>
-          </div>
-        </QBtnDropdown>
         <QBtnDropdown
           flat
           no-caps
@@ -164,7 +140,6 @@ export default {
       toggleReaction: 'conversations/toggleReaction',
       fetchPast: 'conversations/fetchPast',
       saveConversation: 'conversations/maybeSave',
-      accept: 'offers/accept',
       archive: 'offers/archive',
     }),
   },

--- a/src/offers/datastore/offers.js
+++ b/src/offers/datastore/offers.js
@@ -104,13 +104,6 @@ export default {
     }),
 
     ...withMeta({
-      async accept ({ state, commit, dispatch }, { offerId }) {
-        const updatedOffer = await offers.accept(offerId)
-        commit('update', [updatedOffer])
-        commit('currentOffer/update', updatedOffer, { root: true })
-        dispatch('refresh')
-      },
-
       async archive ({ state, commit, dispatch }, { offerId }) {
         const updatedOffer = await offers.archive(offerId)
         commit('update', [updatedOffer])

--- a/src/offers/pages/GroupOffers.vue
+++ b/src/offers/pages/GroupOffers.vue
@@ -115,10 +115,6 @@ export default {
           value: 'active',
         },
         {
-          label: this.$t('OFFER.FILTER.STATUS.ACCEPTED'),
-          value: 'accepted',
-        },
-        {
           label: this.$t('OFFER.FILTER.STATUS.ARCHIVED'),
           value: 'archived',
         },


### PR DESCRIPTION
## What does this PR do?

Removes the concept of accepted offers.

Makes no attempt to gracefully degrade when used with a backend that still has accepted offers, so should be updated together. Associated backend PR is https://github.com/yunity/karrot-backend/pull/910

## Links to related issues

See https://github.com/yunity/karrot-frontend/issues/1908 and https://community.foodsaving.world/t/new-feature-available-offers/357/17.

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined #karrot-dev channel at https://slackin.yunity.org
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
