### PR TITLE
Fix usernames in application chat

### DIFF
--- a/src/messages/datastore/conversations.js
+++ b/src/messages/datastore/conversations.js
@@ -213,29 +213,37 @@ export default {
         })
         dispatch('receiveMessage', message)
       },
-      async fetch ({ commit }, conversationId) {
+      async fetch ({ commit, dispatch }, conversationId) {
         const data = await messageAPI.list(conversationId)
+        const messages = data.results
         commit('updateMessages', {
           conversationId,
-          messages: data.results,
+          messages,
         })
         commit('setCursor', {
           conversationId,
           cursor: data.next,
         })
+
+        const authorIds = messages.map(m => m.author)
+        dispatch('users/maybeFetchInfo', authorIds, { root: true })
       },
 
-      async fetchPast ({ state, commit }, conversationId) {
+      async fetchPast ({ state, commit, dispatch }, conversationId) {
         const currentCursor = state.cursors[conversationId]
         const data = await messageAPI.listMore(currentCursor)
+        const messages = data.results
         commit('updateMessages', {
           conversationId,
-          messages: data.results,
+          messages,
         })
         commit('setCursor', {
           conversationId,
           cursor: data.next,
         })
+
+        const authorIds = messages.map(m => m.author)
+        dispatch('users/maybeFetchInfo', authorIds, { root: true })
       },
 
       async fetchConversation ({ dispatch }, id) {

--- a/src/messages/datastore/conversations.js
+++ b/src/messages/datastore/conversations.js
@@ -225,8 +225,7 @@ export default {
           cursor: data.next,
         })
 
-        const authorIds = messages.map(m => m.author)
-        dispatch('users/maybeFetchInfo', authorIds, { root: true })
+        dispatch('fetchRelatedUserInfo', messages)
       },
 
       async fetchPast ({ state, commit, dispatch }, conversationId) {
@@ -242,6 +241,10 @@ export default {
           cursor: data.next,
         })
 
+        dispatch('fetchRelatedUserInfo', messages)
+      },
+
+      async fetchRelatedUserInfo ({ dispatch }, messages) {
         const authorIds = messages.map(m => m.author)
         dispatch('users/maybeFetchInfo', authorIds, { root: true })
       },

--- a/src/messages/datastore/latestMessages.js
+++ b/src/messages/datastore/latestMessages.js
@@ -161,9 +161,7 @@ export default {
         commit('updateRelated', { type: 'offer', items: offers })
       }
       if (usersInfo) {
-        // contains only limited user info, so only update if we don't have the user already
-        const users = usersInfo.filter(user => !rootState.users.entries[user.id])
-        commit('users/update', users, { root: true })
+        commit('users/updateInfo', usersInfo, { root: true })
       }
 
       if (meta) {

--- a/src/users/datastore/users.js
+++ b/src/users/datastore/users.js
@@ -7,8 +7,8 @@ import router from '@/base/router'
 
 function initialState () {
   return {
-    entries: {}, // all known users
-    infoEntries: {},  // barebone user information, if we don't have access to full data
+    entries: {}, // fully-visible users (fellow group members)
+    infoEntries: {}, // barely-visible users (e.g. group members for applicants)
     activeUserProfileId: null,
     activeUserProfile: null,
     resetPasswordSuccess: false,


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/1941

We need to make sure we have all usernames every time a new message comes in. This only affects application chats for the applicant, so it might seem overblown to do this for every chat. But maybe it's okay - and it seemed the easiest way to implement.

~~We should also run the check on websocket update, this is still TODO.~~ It works on websocket updates, unsure why exactly...

We will get a lot of `404 not found` requests when scrolling back on the group wall, as people have left the group and it still tries to get the usernames. Maybe this can be avoided by storing which users are inaccessible.

This whole design is a bit unfortunate as it leads to so much complexity. I wonder how to make it better...

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
