### PR TITLE
Redirect to group gallery not landing if logged in

### DIFF
--- a/src/base/datastore/routerPlugin.js
+++ b/src/base/datastore/routerPlugin.js
@@ -29,6 +29,9 @@ export default datastore => {
       if (groupId) {
         next = { name: 'group', params: { groupId } }
       }
+      else if (isLoggedIn()) {
+        next = { name: 'groupsGallery' }
+      }
     }
 
     // check meta.requireLoggedIn

--- a/src/base/routes/main.spec.js
+++ b/src/base/routes/main.spec.js
@@ -147,7 +147,7 @@ describe('main routes', () => {
       expect(mockJoin).toBeCalledWith(group.id)
 
       expect(routedPaths).toEqual([
-        '/',
+        '/groupPreview',
         `/groupPreview/${group.id}`,
         `/group/${group.id}`,
       ])
@@ -165,7 +165,7 @@ describe('main routes', () => {
       await nextTicks(2)
 
       expect(routedPaths).toEqual([
-        '/',
+        '/groupPreview',
         `/groupPreview/${group.id}`,
         `/group/${group.id}`,
       ])


### PR DESCRIPTION
## What does this PR do?

Sometimes logged in users ended up the landing page, if they didn't have a group selected (just signed up, or just left a group), but they should be redirected to the group gallery instead.

The concept is the landing page is _only_ for logged out users.

Fixes issues introduced in #1998 