### PR TITLE
Allow rotation in multi croppa for new images

### DIFF
--- a/src/offers/components/MultiCroppa.vue
+++ b/src/offers/components/MultiCroppa.vue
@@ -38,6 +38,16 @@
           rounded
           class="q-ma-xs"
           size="sm"
+          icon="rotate_right"
+          :text-color="isExisting(item) ? 'grey' : 'green'"
+          :disable="!hasImage(item) || isExisting(item)"
+          @click="rotateImage(item)"
+        />
+        <QBtn
+          v-if="hasImage(item)"
+          rounded
+          class="q-ma-xs"
+          size="sm"
           icon="delete"
           text-color="red"
           :disable="!hasImage(item)"
@@ -218,6 +228,12 @@ export default {
       itemRight.source.position = --itemRight.position
       item.source.position = ++item.position
       this.recalculatePositions()
+    },
+    rotateImage (item) {
+      const croppa = this.croppaFor(item)
+      if (croppa) {
+        croppa.rotate(1)
+      }
     },
     removeImage (item) {
       if (this.isExisting(item)) {


### PR DESCRIPTION
## What does this PR do?

Allows you to rotate newly uploaded images in the multi-croppa component - used in offers.

It doesn't let you rotate existing images as that would need to be done server side, and the multicroppa can only process images client-side, before they are sent.
