### PR TITLE
Show toast when notification settings saved

### DIFF
--- a/src/group/datastore/currentGroup.js
+++ b/src/group/datastore/currentGroup.js
@@ -107,6 +107,13 @@ export default {
         else {
           await groups.removeNotificationType(getters.id, notificationType)
         }
+        dispatch('toasts/show', {
+          message: 'NOTIFICATIONS.CHANGES_SAVED',
+          config: {
+            timeout: 2000,
+            icon: 'thumb_up',
+          },
+        }, { root: true })
       },
     }, {
       findId: ({ notificationType }) => notificationType,


### PR DESCRIPTION
Just a minor thing I noticed, is a bit nicer to confirm with a toast when the notification settings have been saved.