### PR TITLE
Improve activity history display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Please document your changes in this format:
 
 ## [Unreleased]
 
+### Changed
+- Improve activity history display @nicksellen
+
 ## [8.6.0] - 2020-07-17
 ### Changed
 - All group members (instead of just editors) can now access conflict resolution issues, write messages and vote. Issues can still only be created by editors. [#2062] @tiltec

--- a/src/history/api/history.js
+++ b/src/history/api/history.js
@@ -2,7 +2,7 @@ import axios, { parseCursor } from '@/base/api/axios'
 
 export default {
   async get (id) {
-    return (await axios.get(`/api/history/${id}/`)).data
+    return convert((await axios.get(`/api/history/${id}/`)).data)
   },
 
   async list (filter) {
@@ -35,7 +35,7 @@ export function convert (val) {
     if (payload) {
       // convert some known payload dates
       const dates = {};
-      ['date', 'startDate', 'invitedAt'].forEach(k => {
+      ['date', 'startDate', 'invitedAt', 'feedbackDue'].forEach(k => {
         if (payload[k]) {
           if (Array.isArray(payload[k])) {
             dates[k] = payload[k].map(d => new Date(d))

--- a/src/history/components/HistoryDetail.vue
+++ b/src/history/components/HistoryDetail.vue
@@ -22,7 +22,7 @@
         </QItemSection>
         <QItemSection>
           <QItemLabel>
-            {{ $d(new Date(entry.date), 'long') }},
+            {{ $d(entry.date, 'long') }},
             <DateAsWords
               :date="entry.date"
               style="display: inline"
@@ -134,6 +134,8 @@ import {
 import ProfilePicture from '@/users/components/ProfilePicture'
 import DateAsWords from '@/utils/components/DateAsWords'
 import HistoryPayloadDetail from '@/history/components/HistoryPayloadDetail'
+import dateFnsHelper from '@/utils/dateFnsHelper'
+import { convert as convertActivity } from '@/activities/api/activities'
 
 export default {
   components: {

--- a/src/history/components/HistoryDetail.vue
+++ b/src/history/components/HistoryDetail.vue
@@ -104,7 +104,9 @@
         <QItemSection>
           <QItemLabel>
             {{ $d(activityPayload.date, 'long') }}
-            <template v-if="activityPayload.hasDuration"> &mdash; {{ $d(activityPayload.dateEnd, 'hourMinute') }}</template>
+            <template v-if="activityPayload.hasDuration">
+              &mdash; {{ $d(activityPayload.dateEnd, 'hourMinute') }}
+            </template>
           </QItemLabel>
         </QItemSection>
       </QItem>

--- a/src/history/components/HistoryDetail.vue
+++ b/src/history/components/HistoryDetail.vue
@@ -27,6 +27,16 @@
               :date="entry.date"
               style="display: inline"
             />
+            <template v-if="entry.typus === 'ACTIVITY_LEAVE'">
+              (<em
+                v-t="{
+                  path: 'HISTORY.ACTIVITY_LEAVE_DISTANCE',
+                  args: {
+                    distance: formatDistanceStrict(entry.date, activityPayload.date),
+                  }
+                }"
+              />)
+            </template>
           </QItemLabel>
         </QItemSection>
       </QItem>
@@ -81,6 +91,20 @@
             <RouterLink :to="{name: 'place', params: { groupId: entry.place.group.id, placeId: entry.place.id }}">
               {{ entry.place.name }}
             </RouterLink>
+          </QItemLabel>
+        </QItemSection>
+      </QItem>
+
+      <QItem
+        v-if="activityPayload"
+      >
+        <QItemSection side>
+          <QIcon :name="$icon('activity_fw')" />
+        </QItemSection>
+        <QItemSection>
+          <QItemLabel>
+            {{ $d(activityPayload.date, 'long') }}
+            <template v-if="activityPayload.hasDuration"> &mdash; {{ $d(activityPayload.dateEnd, 'hourMinute') }}</template>
           </QItemLabel>
         </QItemSection>
       </QItem>
@@ -161,9 +185,23 @@ export default {
       raw: false,
     }
   },
+  computed: {
+    activityPayload () {
+      if ([
+        'ACTIVITY_JOIN',
+        'ACTIVITY_LEAVE',
+      ].includes(this.entry.typus)) {
+        return convertActivity(this.entry.payload)
+      }
+      return null
+    },
+  },
   methods: {
     toggleRaw () {
       this.raw = !this.raw
+    },
+    formatDistanceStrict (...args) {
+      return dateFnsHelper.formatDistanceStrict(...args)
     },
   },
 }

--- a/src/history/components/HistoryPayloadDetail.vue
+++ b/src/history/components/HistoryPayloadDetail.vue
@@ -24,7 +24,7 @@
   >
     <QItemSection>
       <QItemLabel>
-        {{ $d(new Date(Array.isArray(value) ? value[0] : value), 'long') }}
+        {{ $d(firstValue, 'long') }}
       </QItemLabel>
       <QItemLabel caption>
         {{ $t('CREATEACTIVITY.DATE') }}
@@ -37,9 +37,14 @@
   >
     <QItemSection>
       <QItemLabel
-        v-if="value"
+        v-if="value !== null || value !== undefined"
       >
-        {{ value }}
+        <template v-if="firstValue instanceof Date">
+          {{ $d(firstValue, 'long') }}
+        </template>
+        <template v-else>
+          {{ value }}
+        </template>
       </QItemLabel>
       <QItemLabel
         v-else
@@ -71,11 +76,14 @@ export default {
       type: String,
     },
     value: {
-      type: [Array, String, Date, Number],
+      type: [Array, String, Date, Number, Boolean],
       required: true,
     },
   },
   computed: {
+    firstValue () {
+      return Array.isArray(this.value) ? this.value[0] : this.value
+    },
     convertedLabel () {
       if (this.label === 'description') return this.$t('GROUP.DESCRIPTION')
       return this.label

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -403,6 +403,7 @@
     "ACTIVITY_ENABLE": "enabled a pickup",
     "ACTIVITY_JOIN": "signed up to do a pick-up at {storeName}",
     "ACTIVITY_LEAVE": "stepped back from doing a pick-up at {storeName}",
+    "ACTIVITY_LEAVE_DISTANCE": "{distance} before scheduled time",
     "ACTIVITY_MISSED": "A pickup at {storeName} was missed!",
     "ACTIVITY_MODIFY": "changed the settings of a pick-up",
     "APPLICATION_DECLINED": "declined an application from {applicantName}",


### PR DESCRIPTION
Implements suggestion from https://community.foodsaving.world/t/how-do-you-handle-late-drop-outs-from-pickups/213/10

## What does this PR do?

Shows more history information concerning activities:
- for activity join and leave, shows a basket icon in the history detail with the pickup date range
- for activity leave shows when they stepped back in relation to the activity start date

... also refined a bit of the history display more generally:
- run `convert` when getting individual history entries from the API (previously only ran for the list)
- ... could then remove a few `new Date(date)` type calls in the template
- displays boolean values properly (previously didn't accept the type, and any false value would cause it not to be displayed at all (now do a `null|undefined` check)
- always format dates as dates regardless of the label (by checking `value instanceof Date`)

![activityhistory](https://user-images.githubusercontent.com/31616/90235147-1a045500-de21-11ea-92a3-718ef60af50c.png)
