### PR TITLE
Sort feedback by activity date

### DIFF
--- a/src/feedback/datastore/feedback.js
+++ b/src/feedback/datastore/feedback.js
@@ -31,7 +31,7 @@ export default {
         group: activity && activity.group,
       }
     },
-    all: (state, getters) => Object.values(state.entries).map(getters.enrich).sort(sortByCreatedAt),
+    all: (state, getters) => Object.values(state.entries).map(getters.enrich).sort(sortByActivityDateOrCreated),
     byCurrentGroup: (state, getters) => {
       return getters.all.filter(({ group }) => group && group.isCurrentGroup)
     },
@@ -120,8 +120,12 @@ export default {
   },
 }
 
-export function sortByCreatedAt (a, b) {
-  return b.createdAt - a.createdAt
+function sortDateFor (feedback) {
+  return feedback.about ? feedback.about.date : feedback.createdAt
+}
+
+export function sortByActivityDateOrCreated (a, b) {
+  return sortDateFor(b) - sortDateFor(a)
 }
 
 export const plugin = datastore => {


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/2157

## What does this PR do?

The backend was already switched (in https://github.com/yunity/karrot-backend/pull/1044), but the frontend _also_ does sorting, so this PR fixes that... it would fallback to feedback created at date if there is no activity (which would be odd...).