### PR TITLE
Fix white over yellow text in signup form.

### DIFF
--- a/src/authuser/components/Signup.vue
+++ b/src/authuser/components/Signup.vue
@@ -47,7 +47,7 @@
           />
           <QBanner
             v-if="joinPlayground"
-            class="bg-info text-white q-my-sm rounded-borders"
+            class="bg-info text-black q-my-sm rounded-borders"
           >
             {{ $t('JOINGROUP.PROFILE_NOTE' ) }}
             <template #avatar>


### PR DESCRIPTION
Closes #2169.

## What does this PR do?

Before:
![image](https://user-images.githubusercontent.com/309908/91479790-4baa0100-e8a2-11ea-8f5f-6c3b6cffd046.png)

After:
![image](https://user-images.githubusercontent.com/309908/91480617-895b5980-e8a3-11ea-9c25-597d911bf98a.png)

## Links to related issues
#2169. 
## Checklist

- [x] no test, only CSS changes
- [x] no unrelated changes
- [ ] asked someone for a code review -> funnily enough I don't seem to be able to do it as GitHub normally does (with the menu on the right hand side).
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] no entry in CHANGELOG, not worth it I would say
