### PR TITLE
Use the Luxembourgish locale of date-fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Please document your changes in this format:
 
 ## [Unreleased]
 ### Changed
-- Enable the Luxembourgish locale of Quasar when this language is selected @dwaxweiler
+- Enable the Luxembourgish locale of Quasar and date-fns when this language is selected @dwaxweiler
 
 ## [8.7.1] - 2020-08-27
 ### Added

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -86,7 +86,7 @@ const locales = {
     locale: 'lb',
     messages: () => import('@/locales/locale-lb.json'),
     intlLocale: () => import('intl/locale-data/jsonp/lb'),
-    dateFnsLocale: () => import('date-fns/locale/de'), // TODO switch when translated
+    dateFnsLocale: () => import('date-fns/locale/lb'),
     quasar: () => import('quasar/lang/lu'),
   },
 


### PR DESCRIPTION
Second and final part of #2156

## What does this PR do?

The Luxembourgish locale of date-fns is used after its release of 2.16.0.
I assume a test is not needed as the loading of Quasar's selected locale is not tested in general.

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
