### PR TITLE
make application form input more visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Changed
+- Highlight application form input @tiltec
 
 ## [8.8.1] - 2020-10-12
 ### Fixed

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -2315,10 +2315,10 @@ exports[`Storyshots Applications ApplicationForm 1`] = `
           </div>
         </div>
       </div>
-      <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--with-bottom">
+      <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--filled q-field--with-bottom">
           <div class="q-field__inner relative-position col self-stretch column justify-center">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-              <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea></div>
+              <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Reply to message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea></div>
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
               <transition-stub name="q-transition--field-message">

--- a/src/applications/components/ApplicationFormUI.vue
+++ b/src/applications/components/ApplicationFormUI.vue
@@ -23,6 +23,8 @@
         </QItem>
         <MarkdownInput
           v-model="applicationAnswers"
+          filled
+          :placeholder="$t('CONVERSATION.REPLY_TO_MESSAGE')"
           @keyup.ctrl.enter="apply"
         />
         <div


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/2146

## What does this PR do?

Make input "filled" and add placeholder (text borrowed from conversation input)

![image](https://user-images.githubusercontent.com/4410802/96996898-f7816d00-1530-11eb-9303-8f369f1812e6.png)


## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
