### PR TITLE
Add/statistics to beginning

### DIFF
--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -633,6 +633,7 @@
     "FILTER_TIME_LABEL": "Time period",
     "FILTER_TIME_PREVIOUS_DAYS": "Previous {count} days",
     "FILTER_TIME_PREVIOUS_MONTHS": "Previous {count} months",
+    "FILTER_TIME_FOREVER": "Forever",
     "COLUMN_PLACE": "Place",
     "COLUMN_ACTIVITY_DONE": "Done",
     "COLUMN_ACTIVITY_LEFT": "Left",


### PR DESCRIPTION
Closes #2218

## What does this PR do?

Implements three things:
1. allow to filter forever so long as you don't have a user selected
2. user list sorted by name
3. you can filter the users by typing into the box

![forevertimefilter](https://user-images.githubusercontent.com/31616/98526515-22322c00-227a-11eb-997e-86ed69c33c3a.png)
_filtering forever_

![foreverdisabled](https://user-images.githubusercontent.com/31616/98526513-21999580-227a-11eb-84f4-bb72bbce5d8d.png)
_forever is disabled when a user is selected_

![filterbyname](https://user-images.githubusercontent.com/31616/98526506-20686880-227a-11eb-9f04-69a5f31c5533.png)
_filtering by name_

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
