### PR TITLE
Fix actionsToEvents casing in small group map

### DIFF
--- a/src/sidenav/components/SidenavMap.vue
+++ b/src/sidenav/components/SidenavMap.vue
@@ -14,8 +14,8 @@ export default connect({
     isEditor: 'currentGroup/isEditor',
   },
   actionsToEvents: {
-    togglePlaces: 'sidenavBoxes/toggle/placesOnMap',
-    toggleUsers: 'sidenavBoxes/toggle/usersOnMap',
+    'toggle-places': 'sidenavBoxes/toggle/placesOnMap',
+    'toggle-users': 'sidenavBoxes/toggle/usersOnMap',
   },
 })('SidenavMap', SidenavMapUI)
 </script>


### PR DESCRIPTION
Closes #2219

## What does this PR do?

A while back there was a change to vuex-connect that required us to be explicit about the casing for events (`my-event` not `myEvent`), but this one got skipped from the change, this PR fixes that!

The symptom was the small map toggles did nothing.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
