### PR TITLE
Support activity type updates

### DIFF
--- a/src/activities/datastore/activityTypes.js
+++ b/src/activities/datastore/activityTypes.js
@@ -49,6 +49,12 @@ export default {
     update (state, activityTypes) {
       state.entries = Object.freeze({ ...state.entries, ...indexById(activityTypes) })
     },
+    delete (state, activityTypeId) {
+      if (!state.entries[activityTypeId]) return
+      const { [activityTypeId]: _, ...rest } = state.entries
+      Object.freeze(rest)
+      state.entries = rest
+    },
   },
 }
 

--- a/src/boot/socket.js
+++ b/src/boot/socket.js
@@ -222,6 +222,12 @@ export default async function ({ store: datastore }) {
     else if (topic === 'activities:series_deleted') {
       datastore.commit('activitySeries/delete', convertSeries(camelizeKeys(payload)).id)
     }
+    else if (topic === 'activities:type') {
+      datastore.commit('activityTypes/update', [camelizeKeys(payload)])
+    }
+    else if (topic === 'activities:type_deleted') {
+      datastore.commit('activityTypes/delete', payload.id)
+    }
     else if (topic === 'offers:offer') {
       const offer = convertOffer(camelizeKeys(payload))
       datastore.commit('offers/update', [offer])


### PR DESCRIPTION
Backend PR: https://github.com/yunity/karrot-backend/pull/1081

Just updates activity types from websocket updates for now.