### PR TITLE
Fix sorting by distance

### DIFF
--- a/src/groupInfo/datastore/groups.js
+++ b/src/groupInfo/datastore/groups.js
@@ -140,12 +140,17 @@ function applicationsFirstThenSortByName (a, b) {
   return a.name.localeCompare(b.name)
 }
 
-// Not sure how to best handle when only some have distance...
-// It also might put the playground group way too high as it currently has
-// loads of members...
+// Puts ones with distance at the top in order of distance
+// ... then ones without distance below, ordered by member count
 function sortByDistanceOrMemberCount (a, b) {
   if (a.distance && b.distance) {
     return a.distance - b.distance
+  }
+  else if (a.distance === null) {
+    return 1
+  }
+  else if (b.distance === null) {
+    return -1
   }
   return b.members.length - a.members.length
 }


### PR DESCRIPTION
## What does this PR do?

The sorting algorithm was bad. Maybe not stable or something. Now it puts all the ones with a distance first, ordered by distance. And all the ones without distance last, ordered by member count.

In the future we'll probably display "local" ones in a seperate panel anyway, so probably wouldn't be sorting at this point, but for now this fixes the case that sometimes your local places wouldn't be emphasized as the closest one wasn't always at the top of the list (which was assumed by the group map).

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
