### PR TITLE
Fix/question mark button

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "bugs": "https://github.com/yunity/karrot-frontend/issues",
   "scripts": {
     "dev": "quasar dev",
+    "dev:backend:dev": "cross-env BACKEND=https://dev.karrot.world quasar dev",
+    "dev:backend:local": "cross-env BACKEND=http://localhost:8000 quasar dev",
     "build": "quasar build -m pwa",
     "build:cordova:dev": "cross-env KARROT_THEME=dev BACKEND=https://dev.karrot.world quasar build -m android --skip-pkg",
     "build:cordova:prod": "cross-env BACKEND=https://karrot.world quasar build -m android --skip-pkg",

--- a/src/sidenav/components/SidenavMenu.vue
+++ b/src/sidenav/components/SidenavMenu.vue
@@ -30,6 +30,7 @@
           color="green"
           icon="fas fa-question-circle"
           :title="info.title"
+          @click.prevent
         >
           <QMenu
             square


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where clicking the help question mark would route to the activities page if you weren't on it, then you'd normally need a second click to open it.

![fixed](https://user-images.githubusercontent.com/31616/100603458-0e1f9e80-32fd-11eb-85e5-e7db809d55bd.png)

I also snuck in two extra scripts:
- `yarn dev:backend:local` runs `quasar dev` using http://localhost:8000 as the backend
- `yarn dev:backend:dev` runs `quasar dev` using https://dev.karrot.world as backend (it's the default, but this does it explicitly in a way that will override anything set in `.env`)

`yarn dev` still does what it did before, and we still load `.env` in all cases.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
