### PR TITLE
Don't use activity join hover when not hover available

### DIFF
--- a/src/activities/components/UserSlot.vue
+++ b/src/activities/components/UserSlot.vue
@@ -3,6 +3,7 @@
     class="user-slot-wrapper"
     :class="{ greyedOut: !showJoin, active: showJoin }"
     :style="{ width: size + 'px', height: size + 'px' }"
+    @click.stop="$emit('join')"
   >
     <div :class="{ hoverHide: showJoin }" />
     <div
@@ -14,7 +15,6 @@
         :user="hoverUser"
         :size="size"
         :is-link="false"
-        @click.native.stop="$emit('join')"
       />
     </div>
   </div>
@@ -67,14 +67,18 @@ export default {
   .hoverShow
     display none
 
-.user-slot-wrapper.active:hover
-  border 0
+// ios safari will require two clicks if we define a hover state
+// so only use the hover thing when the browser can support hover properly
+// see https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+@media (hover)
+  .user-slot-wrapper.active:hover
+    border 0
 
-  .hoverHide
-    display none
+    .hoverHide
+      display none
 
-  .hoverShow
-    display inline-block
+    .hoverShow
+      display inline-block
 
 .greyedOut
   cursor ini


### PR DESCRIPTION
Closes #2257

Branch deployment URL: https://fix-ios-no-hover.dev.karrot.world

## What does this PR do?

For joining an activity, we show the profile photo of the person joining (or an "x" for leaving) using hover states. In ios safari it sees that we use hover states and to allow the user to still access the "hover" state it makes the first click perform the "hover" and the second click the actual click.

This makes two changes:
1. use a `@media (hover)` query to not define anything for the `:hover` psuedoclass state (which means devices that don't really have a meaningful hover will not have it defined)
2. put the click handler on a higher up element (as the hover element is no longer shown)

It should be tested on a few devices (https://fix-ios-no-hover.dev.karrot.world) as I was bit unsure how the current site actually works on non-ios safari mobile browsers, e.g. chrome/firefox on android, as those don't have hover states either? or maybe they went a different route and it JustWorks :confused: 

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
