### PR TITLE
Fix group switcher image sizes

### DIFF
--- a/src/topbar/components/KTopbarUI.vue
+++ b/src/topbar/components/KTopbarUI.vue
@@ -32,10 +32,12 @@
               avatar
               class="groups"
             >
-              <img
+              <QAvatar
                 v-if="group.hasPhoto"
-                :src="group.photoUrls.thumbnail"
+                square
               >
+                <img :src="group.photoUrls.thumbnail">
+              </QAvatar>
               <QIcon
                 v-else
                 name="fas fa-users"
@@ -196,6 +198,7 @@
 
 <script>
 import {
+  QAvatar,
   QToolbar,
   QToolbarTitle,
   QBtn,
@@ -213,6 +216,7 @@ import NotificationButton from '@/notifications/components/NotificationButton'
 
 export default {
   components: {
+    QAvatar,
     QToolbar,
     QToolbarTitle,
     QBtn,


### PR DESCRIPTION
Fixes #2280

## What does this PR do?

The group images could be HUGE in the group switcher, this resolves that!

I noticed in the list/item examples for quasar [1] they always wrapped images with a QAvatar component, and that resolved the issue.

[1] https://quasar.dev/vue-components/list-and-list-items

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
