### PR TITLE
changed: use default group location for defaultMapCenter when creating a new place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Changed
+- use default group location for defaultMapCenter when creating a new place @larzon83 [#2293]
 
 ## [9.1.0] - 2020-01-06
 ### Fixed

--- a/src/places/components/PlaceEdit.vue
+++ b/src/places/components/PlaceEdit.vue
@@ -224,6 +224,11 @@ export default {
         status: 'created',
       }),
     },
+    currentGroup: {
+      required: false,
+      type: Object,
+      default: () => ({}),
+    },
     allPlaces: { required: true, type: Array },
   },
   computed: {
@@ -273,7 +278,7 @@ export default {
       return null
     },
     defaultMapCenter () {
-      const { latitude: lat, longitude: lng } = this.edit.group || {}
+      const { latitude: lat, longitude: lng } = this.edit.group || this.currentGroup || {}
       if (lat && lng) return { lat, lng }
       return null
     },

--- a/src/places/pages/Create.vue
+++ b/src/places/pages/Create.vue
@@ -6,6 +6,7 @@ import PlaceEdit from '@/places/components/PlaceEdit'
 export default connect({
   gettersToProps: {
     allPlaces: 'places/byCurrentGroup',
+    currentGroup: 'currentGroup/value',
     status: 'places/createStatus',
   },
   actionsToEvents: {


### PR DESCRIPTION
Closes #2288

## What does this PR do?

When creating a new place, use the location of the group instead of somewhere Darmstadt.
No tests atm, because we struggle with the test setup/usage. We try to add them in this PR.

## Links to related issues

https://github.com/yunity/karrot-frontend/issues/2288

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
