### PR TITLE
Remove disabled pickups on applied filters on pickups page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Changed
 - use default group location for defaultMapCenter when creating a new place @larzon83 [#2293]
+- Remove disabled pickups on applied filters on pickups page @pogopaule [#2271]
 
 ## [9.1.0] - 2020-01-06
 ### Fixed

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -231,8 +231,8 @@ export default {
       done()
     },
     slotFilter (activity) {
-      if (this.slots === 'free') return !activity.isFull
-      if (this.slots === 'empty') return activity.isEmpty
+      if (this.slots === 'free') return !activity.isFull && !activity.isDisabled
+      if (this.slots === 'empty') return activity.isEmpty && !activity.isDisabled
       return true
     },
     typeFilter (activity) {


### PR DESCRIPTION
Closes #2271

## What does this PR do?

If filter "With free slots" or "Only empty" is applied, disabled pickups are filtered out.

![](https://user-images.githubusercontent.com/576949/103487257-594d3580-4e04-11eb-84ab-2cdbcb04d7b7.gif)

No test has been added since there is no existing test setup for the page in quest. I'm not proficient enough with Vue testing to set one up by myself. But this is on the top of my todo list ;)

## Links to related issues

https://github.com/yunity/karrot-frontend/issues/2271

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
