### PR TITLE
fix(activities): only hover pictures if device supports it

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -976,8 +976,7 @@ exports[`Storyshots ActivityItem join 1`] = `
           </div>
           <!---->
           <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-            <div class="hoverHide"></div>
-            <div title="Join" class="hoverShow">
+            <div title="Join" class="show-picture-on-hover">
               <div class="wrapper" style="width:36px;height:36px;">
                 <div text="User 1" seed="1" class="randomArt fill"></div>
               </div>
@@ -1176,8 +1175,7 @@ exports[`Storyshots ActivityList Default 1`] = `
             <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
               <!---->
               <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div class="hoverHide"></div>
-                <div title="Join" class="hoverShow">
+                <div title="Join" class="show-picture-on-hover">
                   <div class="wrapper" style="width:36px;height:36px;">
                     <div text="User 11" seed="11" class="randomArt fill"></div>
                   </div>
@@ -1216,8 +1214,7 @@ exports[`Storyshots ActivityList Default 1`] = `
             <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
               <!---->
               <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div class="hoverHide"></div>
-                <div title="Join" class="hoverShow">
+                <div title="Join" class="show-picture-on-hover">
                   <div class="wrapper" style="width:36px;height:36px;">
                     <div text="User 11" seed="11" class="randomArt fill"></div>
                   </div>
@@ -1256,8 +1253,7 @@ exports[`Storyshots ActivityList Default 1`] = `
             <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
               <!---->
               <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div class="hoverHide"></div>
-                <div title="Join" class="hoverShow">
+                <div title="Join" class="show-picture-on-hover">
                   <div class="wrapper" style="width:36px;height:36px;">
                     <div text="User 11" seed="11" class="randomArt fill"></div>
                   </div>
@@ -1296,8 +1292,7 @@ exports[`Storyshots ActivityList Default 1`] = `
             <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
               <!---->
               <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div class="hoverHide"></div>
-                <div title="Join" class="hoverShow">
+                <div title="Join" class="show-picture-on-hover">
                   <div class="wrapper" style="width:36px;height:36px;">
                     <div text="User 11" seed="11" class="randomArt fill"></div>
                   </div>
@@ -1336,8 +1331,7 @@ exports[`Storyshots ActivityList Default 1`] = `
             <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
               <!---->
               <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div class="hoverHide"></div>
-                <div title="Join" class="hoverShow">
+                <div title="Join" class="show-picture-on-hover">
                   <div class="wrapper" style="width:36px;height:36px;">
                     <div text="User 11" seed="11" class="randomArt fill"></div>
                   </div>
@@ -2090,8 +2084,7 @@ exports[`Storyshots ActivityUsers empty 1`] = `
 <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
   <!---->
   <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-    <div class="hoverHide"></div>
-    <div title="Join" class="hoverShow">
+    <div title="Join" class="show-picture-on-hover">
       <div class="wrapper" style="width:36px;height:36px;">
         <div text="Current User" seed="5" class="randomArt fill"></div>
       </div>
@@ -2213,8 +2206,7 @@ exports[`Storyshots ActivityUsers joinable 1`] = `
   </div>
   <!---->
   <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-    <div class="hoverHide"></div>
-    <div title="Join" class="hoverShow">
+    <div title="Join" class="show-picture-on-hover">
       <div class="wrapper" style="width:36px;height:36px;">
         <div text="Current User" seed="5" class="randomArt fill"></div>
       </div>

--- a/src/activities/components/ActivityItem.vue
+++ b/src/activities/components/ActivityItem.vue
@@ -170,7 +170,6 @@ export default {
     },
     detail (event) {
       if (event.target.closest('a')) return // ignore actual links
-      if (event.target.classList.contains('user-slot-wrapper')) return // ignore actual links
       this.$emit('detail', this.activity)
     },
   },

--- a/src/activities/components/ActivityItem.vue
+++ b/src/activities/components/ActivityItem.vue
@@ -170,6 +170,7 @@ export default {
     },
     detail (event) {
       if (event.target.closest('a')) return // ignore actual links
+      if (event.target.classList.contains('user-slot-wrapper')) return // ignore actual links
       this.$emit('detail', this.activity)
     },
   },

--- a/src/activities/components/ActivityUsers.vue
+++ b/src/activities/components/ActivityUsers.vue
@@ -56,7 +56,7 @@
     <UserSlot
       v-if="canJoin"
       :size="size"
-      :hover-user="currentUser"
+      :user="currentUser"
       :show-join="!activity.isUserMember"
       @join="$emit('join')"
     />

--- a/src/activities/components/CurrentUser.vue
+++ b/src/activities/components/CurrentUser.vue
@@ -61,10 +61,11 @@ export default {
     border 2px dashed
     border-radius 0
 
-.user-slot-wrapper:hover
-  .leave-icon
-    visibility visible
+@media (hover)
+  .user-slot-wrapper:hover
+    .leave-icon
+      visibility visible
 
-  .profile-picture
-    visibility hidden
+    .profile-picture
+      visibility hidden
 </style>

--- a/src/activities/components/EmptySlot.vue
+++ b/src/activities/components/EmptySlot.vue
@@ -31,6 +31,6 @@ export default {
     vertical-align middle
 
 .greyedOut
-  cursor ini
+  cursor default
   border-color lightgrey
 </style>

--- a/src/activities/components/EmptySlot.vue
+++ b/src/activities/components/EmptySlot.vue
@@ -2,6 +2,7 @@
   <div
     class="user-slot-wrapper greyedOut"
     :style="{ width: size + 'px', height: size + 'px' }"
+    @click.stop
   />
 </template>
 

--- a/src/activities/components/UserSlot.vue
+++ b/src/activities/components/UserSlot.vue
@@ -3,18 +3,17 @@
     class="user-slot-wrapper"
     :class="{ greyedOut: !showJoin, active: showJoin }"
     :style="{ width: size + 'px', height: size + 'px' }"
+    @click.stop="showJoin ? $emit('join') : null"
   >
-    <div :class="{ hoverHide: showJoin }" />
     <div
-      v-if="hoverUser && showJoin"
-      :class="{ hoverShow: showJoin }"
+      v-if="user && showJoin"
+      :class="{ 'show-picture-on-hover': showJoin }"
       :title="$t('ACTIVITYLIST.ITEM.JOIN')"
     >
       <ProfilePicture
-        :user="hoverUser"
+        :user="user"
         :size="size"
         :is-link="false"
-        @click.native.stop="$emit('join')"
       />
     </div>
   </div>
@@ -32,7 +31,7 @@ export default {
       type: Number,
       default: 20,
     },
-    hoverUser: {
+    user: {
       default: null,
       type: Object,
     },
@@ -64,19 +63,20 @@ export default {
   text-align center
   cursor pointer
 
-  .hoverShow
+  .show-picture-on-hover
     display none
 
-.user-slot-wrapper.active:hover
-  border 0
+// ios safari will require two clicks if we define a hover state
+// so only use the hover thing when the browser can support hover properly
+// see https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+@media (hover)
+  .user-slot-wrapper.active:hover
+    border 0
 
-  .hoverHide
-    display none
-
-  .hoverShow
-    display inline-block
+    .show-picture-on-hover
+      display inline-block
 
 .greyedOut
-  cursor ini
+  cursor default
   border-color lightgrey
 </style>

--- a/src/activities/components/UserSlot.vue
+++ b/src/activities/components/UserSlot.vue
@@ -3,7 +3,7 @@
     class="user-slot-wrapper"
     :class="{ greyedOut: !showJoin, active: showJoin }"
     :style="{ width: size + 'px', height: size + 'px' }"
-    @click.stop="showJoin ? $emit('join') : null"
+    @click.stop="$emit('join')"
   >
     <div
       v-if="user && showJoin"


### PR DESCRIPTION
Closes #2257

## What does this PR do?

Optimization of this PR: https://github.com/yunity/karrot-frontend/pull/2258

`UserSlot.vue`:
- add `@media (hover)` to enable hover if device supports it
- remove `hoverHide` div and its style as it's not needed
- rename `hoverUser` prop to "user" for better readability
- rename `hoverShow` class to "show-picture-on-hover"
- fix wrong style declaration `cursor ini` in class `greyedOut` -> now it's `cursor default` as these boxes should not be clickable

`EmptySlot.vue`:
- fix wrong style declaration `cursor ini` in class `greyedOut` -> now it's `cursor default` as these boxes should not be clickable
- add `@click.stop` to stop going to activity detail when clicking on an empty slot

`CurrentUser.vue`:
- add `@media (hover)` to enable hover if device supports it (the leave icon in this case)


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
