### PR TITLE
fix zoom level for one active place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please document your changes in this format:
 
 ### Fixed
 - activities: only hover pictures if device supports it @larzon83 [#2297]
+- set map bounds correctly if there is only on place @pogopaule [#2290]
 
 ## [9.1.0] - 2020-01-06
 ### Fixed

--- a/src/maps/components/StandardMap.vue
+++ b/src/maps/components/StandardMap.vue
@@ -197,7 +197,7 @@ export default {
     bounds () {
       if (this.forceBounds) return this.forceBounds
       if (this.forceCenter && !Number.isNaN(this.forceCenter.lat)) return null
-      if (!this.preventZoom && this.hasMarkers && !this.hasOneMarker) {
+      if (!this.preventZoom && this.hasMarkers) {
         return L.latLngBounds(this.markersForBound.map(m => m.latLng)).pad(0.2)
       }
       return undefined


### PR DESCRIPTION
Closes #2290

## What does this PR do?

Removes condition (`!this.hasOneMarker`) in if-statement that causes bug.

If `!this.hasOneMarker` is present, the `bounds ()` method returns `undefined`.

This causes the [`zoom ()`](https://github.com/yunity/karrot-frontend/blob/66fac012705b9607ecd629aec14fe05e7e51d825/src/maps/components/StandardMap.vue#L226) method to return `undefined` which results in the 'zoomed out' bug described in #2290.

**Important note for the reviewer**: Digging through the git history and using the frontend I could not figure out why `!this.hasOneMarker` was part of the condition in the first place. To me it does not make any sense, but maybe there is an edge-case somewhere where it does?

![fix-zoom-level](https://user-images.githubusercontent.com/576949/108750933-e7f74c80-7541-11eb-86fa-f96ae6cbc9fa.gif)


## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
