### PR TITLE
fix(ActivityHistoryStatistics): replace hard coded string

### DIFF
--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -100,7 +100,7 @@ export default {
     userFilterOptions () {
       return [
         {
-          label: 'All users',
+          label: this.$t('STATISTICS.FILTER_ALL_USERS'),
           value: null,
         },
         ...this.usersAsOptions,


### PR DESCRIPTION
## What does this PR do?

The [translation key](https://github.com/yunity/karrot-frontend/blob/master/src/locales/locale-en.json#L681) is already present but was not used.
See https://www.transifex.com/yunity-1/karrot/translate/#de/frontend/300401807

## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
