### PR TITLE
Improve calculation of group gallery map bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please document your changes in this format:
 ### Changed
 - group: improve create/edit group form @larzon83 @layla19 @dpaque @pogopaule @brnsolikyl [#2306]
 - Landing page: change text and screenshots, add "about Karrot" component @brnsolikyl [#2317]
+- Improve calculation of map bounds on group gallery @nicksellen [#2333]
 
 ## [9.2.0] - 2020-03-23
 ### Added

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -6094,7 +6094,7 @@ exports[`Storyshots GroupGallery signup view 1`] = `
   <div class="vue2leaflet-map k-map group-gallery-map map-fixed">
     <!---->
   </div>
-  <div class="sidebar expanded">
+  <div class="sidebar expanded"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
     <div role="alert" class="q-banner row items-center q-ma-sm bg-warning text-white shadow-2" style="min-height:unset;">
       <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="material-icons q-icon notranslate text-white" style="font-size:24px;">star</i></div>
       <div class="q-banner__content col text-body2"> <span>You are currently logged out. <a class="underline">
@@ -6306,7 +6306,7 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
   <div class="vue2leaflet-map k-map group-gallery-map map-fixed">
     <!---->
   </div>
-  <div class="sidebar expanded">
+  <div class="sidebar expanded"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
     <!---->
     <!---->
     <div class="row items-start no-wrap q-mt-md">

--- a/src/groupInfo/components/GroupGalleryMap.vue
+++ b/src/groupInfo/components/GroupGalleryMap.vue
@@ -5,6 +5,7 @@
     :force-center="forceCenter"
     :force-zoom="forceZoom"
     :force-bounds="forceBounds"
+    :padding-top-left="paddingTopLeft"
     :show-attribution="false"
   />
 </template>
@@ -32,6 +33,10 @@ export default {
     myCoordinates: {
       default: null,
       type: Object,
+    },
+    paddingTopLeft: {
+      default: () => ([0, 0]),
+      type: Array,
     },
   },
   computed: {
@@ -61,15 +66,7 @@ export default {
       if (this.myCoordinates) {
         coordsForBounds.push(this.myCoordinates)
       }
-      const bounds = L.latLngBounds(coordsForBounds).pad(0.2)
-      if (this.offset.lat !== 0 || this.offset.lng !== 0) {
-        // we have an offset!
-        // make the bounds extended to incorporate the offset into the calculation
-        const sw = bounds.getSouthWest()
-        const offsetPoint = L.latLng(sw.lat + this.offset.lat, sw.lng + this.offset.lng)
-        return bounds.extend(offsetPoint)
-      }
-      return bounds
+      return L.latLngBounds(coordsForBounds).pad(0.2)
     },
     singleGroup () {
       if (this.groupsWithCoordinates.length === 1) {
@@ -90,12 +87,6 @@ export default {
       }
       return null
     },
-    offset () {
-      if (window.innerWidth > 767 && this.$q.platform.is.desktop) {
-        return this.expanded ? { lat: 0, lng: -0.4 } : { lat: 0.05, lng: 0 }
-      }
-      return { lat: 0.0, lng: 0.0 }
-    },
   },
   methods: {
     hasCoordinates (item) {
@@ -112,4 +103,11 @@ export default {
 </script>
 
 <style scoped lang="stylus">
+.debug
+  position fixed
+  top 40px
+  right 40px
+  z-index 10000000
+  padding 20px
+  background-color rgba(255, 255, 255, 0.5)
 </style>

--- a/src/groupInfo/components/GroupGalleryMap.vue
+++ b/src/groupInfo/components/GroupGalleryMap.vue
@@ -54,9 +54,9 @@ export default {
       const groups = this.groupsWithCoordinates.filter(this.hasDistance)
       if (groups.length === 0) return []
       // Any group with max 3x distance of the closest group
-      // Minimum "closest distance" is 30km, so it won't filter for unhelpful
+      // Minimum "closest distance" is 10km, so it won't filter for unhelpful
       // distances like <3km if you happen to be 1km from a group...
-      const closestDistance = Math.max(groups[0].distance, 30)
+      const closestDistance = Math.max(groups[0].distance, 10)
       const maxDistance = closestDistance * 3
       return groups.filter(group => group.distance < maxDistance)
     },

--- a/src/groupInfo/components/GroupGalleryMap.vue
+++ b/src/groupInfo/components/GroupGalleryMap.vue
@@ -101,13 +101,3 @@ export default {
   },
 }
 </script>
-
-<style scoped lang="stylus">
-.debug
-  position fixed
-  top 40px
-  right 40px
-  z-index 10000000
-  padding 20px
-  background-color rgba(255, 255, 255, 0.5)
-</style>

--- a/src/groupInfo/components/GroupGalleryMap.vue
+++ b/src/groupInfo/components/GroupGalleryMap.vue
@@ -35,7 +35,7 @@ export default {
       type: Object,
     },
     paddingTopLeft: {
-      default: () => ([0, 0]),
+      default: null,
       type: Array,
     },
   },

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -189,7 +189,7 @@ export default {
   },
   data () {
     return {
-      width: -1,
+      width: -1, // will get set by our QResizeObserver later
       search: '',
       expanded: true,
       showInactive: false,
@@ -224,7 +224,7 @@ export default {
     paddingTopLeft () {
       // when the sidebar is open on a wide enough desktop screen
       // we set the padding so the markers aren't displayed underneath the sidebar
-      if (this.expanded && this.$q.platform.is.desktop) {
+      if (this.expanded && this.$q.platform.is.desktop && this.width !== -1) {
         return [this.width, 0]
       }
       return null

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -224,7 +224,7 @@ export default {
     paddingTopLeft () {
       // when the sidebar is open on a wide enough desktop screen
       // we set the padding so the markers aren't displayed underneath the sidebar
-      if (this.expanded && window.innerWidth > 767 && this.$q.platform.is.desktop) {
+      if (this.expanded && this.$q.platform.is.desktop) {
         return [this.width, 0]
       }
       return null

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -227,7 +227,7 @@ export default {
       if (this.expanded && window.innerWidth > 767 && this.$q.platform.is.desktop) {
         return [this.width, 0]
       }
-      return [0, 0]
+      return null
     },
   },
   methods: {

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -8,12 +8,17 @@
       :filtered-my-groups="filteredMyGroups"
       :filtered-other-groups="filteredOtherGroups"
       :expanded="expanded"
-      :my-coordinates="myCoordinates"
+      :my-coordinates="false"
+      :padding-top-left="paddingTopLeft"
     />
     <div
       :class="{'expanded': expanded}"
       class="sidebar"
     >
+      <QResizeObserver
+        style="width: 100%"
+        @resize="onResize"
+      />
       <QBanner
         v-if="!isLoggedIn"
         class="q-ma-sm bg-warning text-white shadow-2"
@@ -144,6 +149,7 @@ import {
   QInput,
   QCheckbox,
   QIcon,
+  QResizeObserver,
 } from 'quasar'
 
 export default {
@@ -157,6 +163,7 @@ export default {
     QInput,
     QCheckbox,
     QIcon,
+    QResizeObserver,
   },
   props: {
     myGroups: {
@@ -182,6 +189,7 @@ export default {
   },
   data () {
     return {
+      width: -1,
       search: '',
       expanded: true,
       showInactive: false,
@@ -213,8 +221,19 @@ export default {
     hasOtherGroupsToShow () {
       return this.expanded && this.filteredOtherGroups.length > 0
     },
+    paddingTopLeft () {
+      // when the sidebar is open on a wide enough desktop screen
+      // we set the padding so the markers aren't displayed underneath the sidebar
+      if (this.expanded && window.innerWidth > 767 && this.$q.platform.is.desktop) {
+        return [this.width, 0]
+      }
+      return [0, 0]
+    },
   },
   methods: {
+    onResize ({ width }) {
+      this.width = width
+    },
     searchInName (term, list) {
       if (!term || term === '') return list
       return list.filter(group => {

--- a/src/groupInfo/components/GroupGalleryUI.vue
+++ b/src/groupInfo/components/GroupGalleryUI.vue
@@ -8,7 +8,7 @@
       :filtered-my-groups="filteredMyGroups"
       :filtered-other-groups="filteredOtherGroups"
       :expanded="expanded"
-      :my-coordinates="false"
+      :my-coordinates="myCoordinates"
       :padding-top-left="paddingTopLeft"
     />
     <div

--- a/src/maps/components/StandardMap.vue
+++ b/src/maps/components/StandardMap.vue
@@ -1,12 +1,12 @@
 <template>
   <LMap
+    ref="map"
     class="k-map"
     :bounds="bounds"
     :center="center"
     :zoom="zoom"
     :padding-top-left="paddingTopLeft"
     :min-zoom="2"
-    ref="map"
     @click="mapClick"
     @moveend="$emit('map-move-end', arguments[0].target)"
     @update:zoom="updateZoom"

--- a/src/maps/components/StandardMap.vue
+++ b/src/maps/components/StandardMap.vue
@@ -4,7 +4,9 @@
     :bounds="bounds"
     :center="center"
     :zoom="zoom"
+    :padding-top-left="paddingTopLeft"
     :min-zoom="2"
+    ref="map"
     @click="mapClick"
     @moveend="$emit('map-move-end', arguments[0].target)"
     @update:zoom="updateZoom"
@@ -160,6 +162,10 @@ export default {
       type: Object,
       default: null,
     },
+    paddingTopLeft: {
+      type: Array,
+      default: null,
+    },
   },
   data () {
     return {
@@ -234,6 +240,13 @@ export default {
   watch: {
     zoom (val) {
       if (Number.isInteger(val)) this.lastZoom = val
+    },
+    paddingTopLeft () {
+      if (this.bounds) {
+        // unfortunately it doesn't auto update when we change the padding, so we have to do it ourselves...
+        // the $nextTick improved the behaviour when resizing in practise
+        this.$nextTick(() => this.$refs.map.fitBounds(this.bounds))
+      }
     },
   },
   methods: {


### PR DESCRIPTION
Closes #2316 

Branch deployment: https://change-improve-map-bounds.dev.karrot.world/

## What does this PR do?

We can now make use of the new `paddingTopLeft` prop in calculating the map bounds for the group gallery using the actual pixel width of the sidebar (previously it only looked about right if using the same screen resolution as I had when I wrote it!).

Here's an example:

![mapboundsnew](https://user-images.githubusercontent.com/31616/113916135-87615d80-97d7-11eb-8622-a8c2f1e89f14.png)


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
