### PR TITLE
Use roboto font in latin ext variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please document your changes in this format:
 - group: improve create/edit group form @larzon83 @layla19 @dpaque @pogopaule @brnsolikyl [#2306]
 - Landing page: change text and screenshots, add "about Karrot" component @brnsolikyl [#2317]
 - Improve calculation of map bounds on group gallery @nicksellen [#2333]
+- Use roboto font in latin-ext variant @nicksellen [#2345]
 
 ## [9.2.0] - 2020-03-23
 ### Added

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -99,9 +99,9 @@ module.exports = configure(function (ctx) {
       // 'eva-icons',
       // 'themify',
       // 'line-awesome',
-      // 'roboto-font-latin-ext', // this or either 'roboto-font', NEVER both!
+      'roboto-font-latin-ext', // this or either 'roboto-font', NEVER both!
 
-      'roboto-font', // optional, you are not bound to it
+      // 'roboto-font', // optional, you are not bound to it
       'material-icons', // optional, you are not bound to it
     ],
 


### PR DESCRIPTION
See https://community.foodsaving.world/t/better-use-roboto-font/689
Branch deployment: https://change-use-latin-ext-font.dev.karrot.world/

## What does this PR do?

Switch to use the roboto font with latin-ext variant. Quasar extras provides this option right away, so very easy :)

I guess a bit bigger download size, but better font support.

(If we want to reduce bundlesize there are some other wins... _aside: I noticed way to many font libaries are being pulled in, despite us configuring quasar otherwise... needs investigation elsewhere!_)

Before:

![weight300](https://user-images.githubusercontent.com/31616/115008315-e2174b00-9ea2-11eb-8853-6f41e99eaa87.png)

After:

![weight300latinext](https://user-images.githubusercontent.com/31616/115008326-e479a500-9ea2-11eb-93f3-29bdf6e029a8.png)


## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible... - can't test font rendering...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)