### PR TITLE
adding functionality for filtering by days of the week

### DIFF
--- a/src/activities/api/activities.js
+++ b/src/activities/api/activities.js
@@ -29,6 +29,10 @@ export default {
     return this.list({ place: placeId, date_min: new Date() })
   },
 
+  async listByDay (dayID) {
+    return this.list({ day: dayId, date_min: new Date() })
+  },
+
   async listBySeriesId (seriesId) {
     return this.list({ series: seriesId, date_min: new Date() })
   },


### PR DESCRIPTION
Closes #2310 

## What does this PR do?
adds a filter by day of the week (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday) to the activities page as they can only be active on a few days of the week.


## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)