### PR TITLE
Implement more activity history statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please document your changes in this format:
 ### Changed
 - landingpage: reduce bundlesize for generated images @larzon83 [#2377]
 - use geo ip for edit/create group default map location @nicksellen [#2396]
+- implement more activity statistics @nicksellen [#2364]
 
 ### Fixed
 - place-header: correctly display linear-gradient in Safari @larzon83 [#2372]

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -695,8 +695,10 @@
     "FILTER_TIME_FOREVER": "Forever",
     "COLUMN_PLACE": "Place",
     "COLUMN_ACTIVITY_DONE": "Done",
+    "COLUMN_ACTIVITY_MISSED": "Missed",
     "COLUMN_ACTIVITY_LEFT": "Left",
-    "COLUMN_ACTIVITY_LEFT_LATE": "Left late",
+    "COLUMN_ACTIVITY_LATE": "Late",
+    "COLUMN_FEEDBACK": "Feedback",
     "COLUMN_FEEDBACK_WEIGHT": "Weight",
     "TOTAL_LABEL": "Total"
   },

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -696,7 +696,7 @@
     "COLUMN_PLACE": "Place",
     "COLUMN_ACTIVITY_DONE": "Done",
     "COLUMN_ACTIVITY_MISSED": "Missed",
-    "COLUMN_ACTIVITY_LEFT": "Left",
+    "COLUMN_ACTIVITY_LEFT": "Withdrew",
     "COLUMN_ACTIVITY_LATE": "Late",
     "COLUMN_FEEDBACK": "Feedback",
     "COLUMN_FEEDBACK_WEIGHT": "Weight",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -697,7 +697,6 @@
     "COLUMN_ACTIVITY_DONE": "Done",
     "COLUMN_ACTIVITY_MISSED": "Missed",
     "COLUMN_ACTIVITY_LEFT": "Withdrew",
-    "COLUMN_ACTIVITY_LATE": "Late",
     "COLUMN_FEEDBACK": "Feedback",
     "COLUMN_FEEDBACK_WEIGHT": "Weight",
     "TOTAL_LABEL": "Total",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -382,7 +382,7 @@
     "INVITATIONS": "Invitations",
     "INVITATION_ACCEPT_ERROR": "Ooops, could not accept the invitation!",
     "INVITATION_ACCEPT_SUCCESS": "Welcome! You successfully accepted the invitation.",
-    "INVITED_LIST": "Invitations have already been sent out to these e-mail addresses:",
+    "INVITED_LIST": "Invitations have already been sent STATISTICSout to these e-mail addresses:",
     "INVITE_EMAIL": "Enter an e-mail address",
     "INVITE_SEND": "Send invitation",
     "INVITE_SEND_ERROR": "Ooops, could not send the invitation!",
@@ -700,7 +700,12 @@
     "COLUMN_ACTIVITY_LATE": "Late",
     "COLUMN_FEEDBACK": "Feedback",
     "COLUMN_FEEDBACK_WEIGHT": "Weight",
-    "TOTAL_LABEL": "Total"
+    "TOTAL_LABEL": "Total",
+    "OPTIONS_LEFT": "Withdrew options",
+    "OPTIONS_MISSED_LABEL": "Missed",
+    "OPTIONS_MISSED_DESCRIPTION": "Only count if the activity was missed after they withdrew",
+    "OPTIONS_LATE_LABEL": "Late",
+    "OPTIONS_LATE_DESCRIPTION": "Only count if they withdrew less than 24 hours before"
   },
   "STOREDETAIL": {
     "ARCHIVED": "This place has been archived",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -382,7 +382,7 @@
     "INVITATIONS": "Invitations",
     "INVITATION_ACCEPT_ERROR": "Ooops, could not accept the invitation!",
     "INVITATION_ACCEPT_SUCCESS": "Welcome! You successfully accepted the invitation.",
-    "INVITED_LIST": "Invitations have already been sent STATISTICSout to these e-mail addresses:",
+    "INVITED_LIST": "Invitations have already been sent out to these e-mail addresses:",
     "INVITE_EMAIL": "Enter an e-mail address",
     "INVITE_SEND": "Send invitation",
     "INVITE_SEND_ERROR": "Ooops, could not send the invitation!",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -701,11 +701,11 @@
     "COLUMN_FEEDBACK": "Feedback",
     "COLUMN_FEEDBACK_WEIGHT": "Weight",
     "TOTAL_LABEL": "Total",
-    "OPTIONS_LEFT": "Withdrew options",
+    "OPTIONS_ANY": "Any",
     "OPTIONS_MISSED_LABEL": "Missed",
-    "OPTIONS_MISSED_DESCRIPTION": "Only count if the activity was missed after they withdrew",
+    "OPTIONS_MISSED_DESCRIPTION": "Only if the activity was missed",
     "OPTIONS_LATE_LABEL": "Late",
-    "OPTIONS_LATE_DESCRIPTION": "Only count if they withdrew less than 24 hours before"
+    "OPTIONS_LATE_DESCRIPTION": "Only if less than 24 hours before"
   },
   "STOREDETAIL": {
     "ARCHIVED": "This place has been archived",

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -41,7 +41,7 @@
             self="top right"
           >
             <div class="text-subtitle1 q-ma-md">
-              Left activities
+              Withdrew options
             </div>
             <QList>
               <QItem tag="label">
@@ -51,7 +51,7 @@
                 <QItemSection>
                   <QItemLabel>Missed</QItemLabel>
                   <QItemLabel caption>
-                    Only count if the activity ended up being missed after they left
+                    Only count if the activity was missed after they withdrew
                   </QItemLabel>
                 </QItemSection>
               </QItem>
@@ -62,7 +62,7 @@
                 <QItemSection>
                   <QItemLabel>Late</QItemLabel>
                   <QItemLabel caption>
-                    Only count if they left less than 24 hours before the activity started
+                    Only count if they withdrew less than 24 hours before
                   </QItemLabel>
                 </QItemSection>
               </QItem>

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -41,7 +41,7 @@
             self="top right"
           >
             <div class="text-subtitle1 q-ma-md">
-              Withdrew options
+              {{ $t('STATISTICS.OPTIONS_LEFT') }}
             </div>
             <QList>
               <QItem tag="label">
@@ -49,9 +49,9 @@
                   <QToggle v-model="leftFilter.missed" />
                 </QItemSection>
                 <QItemSection>
-                  <QItemLabel>Missed</QItemLabel>
+                  <QItemLabel>{{ $t('STATISTICS.OPTIONS_MISSED_LABEL') }}</QItemLabel>
                   <QItemLabel caption>
-                    Only count if the activity was missed after they withdrew
+                    {{ $t('STATISTICS.OPTIONS_MISSED_DESCRIPTION') }}
                   </QItemLabel>
                 </QItemSection>
               </QItem>
@@ -60,9 +60,9 @@
                   <QToggle v-model="leftFilter.late" />
                 </QItemSection>
                 <QItemSection>
-                  <QItemLabel>Late</QItemLabel>
+                  <QItemLabel>{{ $t('STATISTICS.OPTIONS_LATE_LABEL') }}</QItemLabel>
                   <QItemLabel caption>
-                    Only count if they withdrew less than 24 hours before
+                    {{ $t('STATISTICS.OPTIONS_LATE_DESCRIPTION') }}
                   </QItemLabel>
                 </QItemSection>
               </QItem>


### PR DESCRIPTION
Closes https://github.com/yunity/karrot-frontend/issues/2336
Branch deployment: https://add-more-activity-statistics.dev.karrot.world

## What does this PR do?

... implements some of the new activity statistics fields from the backend PR.

## Links to related issues

Backend PR https://github.com/yunity/karrot-backend/pull/1139
Forum thread https://community.foodsaving.world/t/more-statistics-display/489/8

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)