### PR TITLE
fix(place-header): correctly display linear-gradient in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Please document your changes in this format:
 - main-layout: use scaled down background-image @larzon83 [#2371]
 - Use roboto font in latin-ext variant @nicksellen [#2345]
 
+### Fixed
+- place-header: correctly display linear-gradient in Safari @larzon83 [#2372]
+
 ## [9.2.0] - 2020-03-23
 ### Added
 - enabled Hungarian locale @nicksellen [#2313]

--- a/src/places/components/PlaceHeader.vue
+++ b/src/places/components/PlaceHeader.vue
@@ -333,5 +333,5 @@ export default {
     width 100%
     height 100%
     content ''
-    background linear-gradient(transparent 90%, white)
+    background linear-gradient(rgba(255, 255, 255, 0) 90%, white 100%)
 </style>


### PR DESCRIPTION
## What does this PR do?

Safari (Desktop & mobile) doesn't displays linear gradients correctly if using `transparent` as a color-stop value.
Use `rgba(255, 255, 255, 0)` instead.

Screenshot:

<img width="1665" alt="safari-linear-gradient" src="https://user-images.githubusercontent.com/23213583/120245036-42542780-c26c-11eb-8b05-4492884ec3dc.png">



## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)