### PR TITLE
Restore redirect to last visited group

### DIFF
--- a/src/base/datastore/routerPlugin.js
+++ b/src/base/datastore/routerPlugin.js
@@ -32,6 +32,9 @@ export default datastore => {
       else if (isLoggedIn()) {
         next = { name: 'groupsGallery' }
       }
+      else {
+        next = { name: 'landing' }
+      }
     }
 
     // check meta.requireLoggedIn

--- a/src/base/routes/main.js
+++ b/src/base/routes/main.js
@@ -53,7 +53,6 @@ export default [
   {
     name: 'home',
     path: '/',
-    redirect: { name: 'landing' }, // default redirect, there is more logic in routerPlugin.js
   },
   {
     name: 'landing',

--- a/src/base/routes/main.spec.js
+++ b/src/base/routes/main.spec.js
@@ -13,7 +13,11 @@ jest.mock('@/router', () => {
   return new VueRouter({
     mode: 'hash',
     routes: [
-      // we always need this route as we often redirect to it immediately
+      // we always need these routes as we often redirect to them immediately
+      {
+        name: 'landing',
+        path: '/welcome',
+      },
       {
         name: 'groupsGallery',
         path: '/groupPreview',


### PR DESCRIPTION
## What does this PR do?

When the user is logged in, they usually want to visit their group wall when opening karrot.world. Right now, they always get redirected to the new landing page (by the way, congratulations for making it so nice!)

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)