### PR TITLE
Add string for history item about losing editing rights

### DIFF
--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -485,7 +485,8 @@
     "SERIES_MODIFY": "changed the settings of a series",
     "STORE_CREATE": "created place {name}",
     "STORE_DELETE": "deleted place {name}",
-    "STORE_MODIFY": "changed the settings of place {name}"
+    "STORE_MODIFY": "changed the settings of place {name}",
+    "USER_LOST_EDITOR_ROLE": "lost editing permissions"
   },
   "INACTIVITY": {
     "HELP": "Everyone who did not log into the group for {dayCount} days or more counts as inactive. These users will not receive notification emails anymore.",


### PR DESCRIPTION
Found a tiny thing to fix! ^_^

## What does this PR do?

It adds the missing words in locale-en.json to make HISTORY.USER_LOST_EDITOR_ROLE look nice.

## Links to related issues

Sorry, I didn't even check... :yum: 

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)