### PR TITLE
change(landingpage): reduce bundlesize for generated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Changed
+- landingpage: reduce bundlesize for generated images @larzon83 [#2377]
+
 ### Fixed
 - place-header: correctly display linear-gradient in Safari @larzon83 [#2372]
 - Redirect again to last visited group @tiltec #2373

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -171,29 +171,6 @@ module.exports = configure(function (ctx) {
           exclude: /node_modules/,
         })
 
-        // FIXME: delete, if not using the chainWebpack way
-        // disable inlining of small images as base64 when required with "?disableinline"
-        // const imageRule = cfg.module.rules.find(rule => rule.use.find(use => use.loader === 'url-loader' && use.options.name.startsWith('img/')))
-        // if (imageRule) {
-        //   const urlLoader = imageRule.use.find(use => use.loader === 'url-loader')
-        //   const useOriginal = imageRule.use
-        //   delete imageRule.use
-        //   imageRule.oneOf = [
-        //     {
-        //       resourceQuery: /disableinline/,
-        //       use: [
-        //         {
-        //           loader: 'file-loader',
-        //           options: urlLoader.options,
-        //         },
-        //       ],
-        //     },
-        //     {
-        //       use: useOriginal,
-        //     },
-        //   ]
-        // }
-
         cfg.resolve.alias = {
           ...cfg.resolve.alias, // This adds the existing alias
 

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -138,6 +138,28 @@ module.exports = configure(function (ctx) {
           exclude: /node_modules/,
         })
 
+        // disable inlining of small images as base64 when required with "?disableinline"
+        const imageRule = cfg.module.rules.find(rule => rule.use.find(use => use.loader === 'url-loader' && use.options.name.startsWith('img/')))
+        if (imageRule) {
+          const urlLoader = imageRule.use.find(use => use.loader === 'url-loader')
+          const useOriginal = imageRule.use
+          delete imageRule.use
+          imageRule.oneOf = [
+            {
+              resourceQuery: /disableinline/,
+              use: [
+                {
+                  loader: 'file-loader',
+                  options: urlLoader.options,
+                },
+              ],
+            },
+            {
+              use: useOriginal,
+            },
+          ]
+        }
+
         cfg.resolve.alias = {
           ...cfg.resolve.alias, // This adds the existing alias
 

--- a/src/base/pages/Landing.vue
+++ b/src/base/pages/Landing.vue
@@ -362,7 +362,7 @@ export default {
       return images
     },
     requireImage ({ fileName, ext, width, dirName } = {}) {
-      return require(`@/base/pages/images/${dirName}/${fileName}-${width}${ext}`)
+      return require(`@/base/pages/images/${dirName}/${fileName}-${width}${ext}?disableinline`)
     },
   },
 }

--- a/src/base/pages/Landing.vue
+++ b/src/base/pages/Landing.vue
@@ -362,6 +362,8 @@ export default {
       return images
     },
     requireImage ({ fileName, ext, width, dirName } = {}) {
+      // use "?disableinline" to disable inlining of small images as base64 which would result in a huge js-chunk
+      // see: https://github.com/yunity/karrot-frontend/issues/2370
       return require(`@/base/pages/images/${dirName}/${fileName}-${width}${ext}?disableinline`)
     },
   },


### PR DESCRIPTION
Closes ___ #2370

## What does this PR do?

Changes the quasar webpack rule for images. It's now possible to require an image with `?disableinline` at the end. A small image will then not be base64 inlined.

## TODO

- [ ] decide on implementation (chainWebpack or extendWebpack)
- [ ] Delete commented out implementation

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)