### PR TITLE
fix: remove iconpicker-app-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please document your changes in this format:
 ### Fixed
 - place-header: correctly display linear-gradient in Safari @larzon83 [#2372]
 - Redirect again to last visited group @tiltec #2373
+- remove iconpicker-app-extension @larzon83 [#2387]
 
 ## [9.3.0] - 2021-06-03
 ### Added

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@octokit/rest": "^18.6.0",
     "@quasar/app": "^2.2.10",
     "@quasar/quasar-app-extension-dotenv": "^1.1.0",
-    "@quasar/quasar-app-extension-qiconpicker": "^1.3.2",
+    "@quasar/quasar-ui-qiconpicker": "^1.3.2",
     "@sentry/cli": "^1.66.0",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-links": "^6.2.9",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -71,7 +71,6 @@ module.exports = configure(function (ctx) {
       'pwa',
       'helloDeveloper',
       'addressbar-color',
-      'extensions',
       'socket',
       'sentry',
       'cordova',

--- a/quasar.extensions.json
+++ b/quasar.extensions.json
@@ -5,6 +5,5 @@
     "common_root_object": "none",
     "create_env_files": true,
     "add_env_to_gitignore": false
-  },
-  "@quasar/qiconpicker": {}
+  }
 }

--- a/src/boot/extensions.js
+++ b/src/boot/extensions.js
@@ -1,5 +1,0 @@
-import Vue from 'vue'
-import Plugin from '@quasar/quasar-ui-qiconpicker'
-import '@quasar/quasar-ui-qiconpicker/dist/index.css'
-
-Vue.use(Plugin)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,13 +2091,6 @@
     dotenv-parse-variables "^2.0.0"
     fs "^0.0.2"
 
-"@quasar/quasar-app-extension-qiconpicker@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@quasar/quasar-app-extension-qiconpicker/-/quasar-app-extension-qiconpicker-1.3.2.tgz#2dabbfe0c98653a38e9a6fb575250f0e86db8c43"
-  integrity sha512-u5DcE5qHEuSDTFWmWvU8x1CPBeeHBzJv02UMhAr0mkLCAUfFFYiFp8YNjPz8uTgMPtZkEfCMdGfH6rQ4CkdaDA==
-  dependencies:
-    "@quasar/quasar-ui-qiconpicker" "^1.3.2"
-
 "@quasar/quasar-ui-qiconpicker@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@quasar/quasar-ui-qiconpicker/-/quasar-ui-qiconpicker-1.3.2.tgz#79475261d492dfcebece254cee60d66edfcf731c"


### PR DESCRIPTION
Closes #2385

## What does this PR do?

This PR removes `@quasar/quasar-app-extension-qiconpicker` and instead adds `@quasar/quasar-ui-qiconpicker"`.

The app-extension pushes all icons to the quasar boot config and therefor all icon-sets are included in the main app bundle thus massively increasing bundle size.

The ui-qiconpicker on the other hand can be used on a component level. So, a separate bundle is created and only loads when needed. See this screencast:

https://user-images.githubusercontent.com/23213583/122192156-acd3ad00-ce93-11eb-9438-fee4ad999c7a.mp4

Bundle size before and after:
<img width="46%" alt="size-1-before" src="https://user-images.githubusercontent.com/23213583/122192330-da205b00-ce93-11eb-974b-89f4980f1d77.png"> <img width="46%" alt="size-2-after" src="https://user-images.githubusercontent.com/23213583/122192336-db518800-ce93-11eb-997c-6157a3f6aa93.png">


## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)