### PR TITLE
Switch references to new chat url

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -3,7 +3,7 @@ If you want to contribute code to the frontend repository, you should first read
 
 ## General
 
-Have a look through the issues. If there's something that is interesting to you, assign it to yourself. Usually you will need additional information, so feel free to comment on the issue before you start writing code. Even better: join our [group chat](https://chat.foodsaving.world/channel/karrot-dev) and get in direct contact with us!
+Have a look through the issues. If there's something that is interesting to you, assign it to yourself. Usually you will need additional information, so feel free to comment on the issue before you start writing code. Even better: join our [group chat](https://chat.karrot.world/channel/karrot-dev) and get in direct contact with us!
 
 ## Feature development
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you want to use an eslint plugin for your editor, please keep in mind that yo
 We have a forum for Karrot developers and users at https://community.foodsaving.world/c/karrot.
 
 If you are interested in contributing, you may -
-- join us in the [#karrot-dev chatroom on chat.foodsaving.world](https://chat.foodsaving.world/channel/karrot-dev)
+- join us in the [#karrot-dev chatroom on chat.karrot.world](https://chat.karrot.world/channel/karrot-dev)
 - join our weekly call; previous minutes can be found in [this thread](https://community.foodsaving.world/t/weekly-call-about-karrot-development/289)
 
 The most important information is written down in our [contribution guidelines](CONTRIBUTE.md).

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -25,7 +25,7 @@ Purposes would/could be to document:
   - **user docs** (_coming soon_)
   - **API docs** [dev.karrot.world/docs/](https://dev.karrot.world/docs/) (create account and login to see more
 - Chat
-  - [**chat.foodsaving.world/channel/karrot-dev**](https://chat.foodsaving.world/channel/karrot-dev)
+  - [**chat.karrot.world/channel/karrot-dev**](https://chat.karrot.world/channel/karrot-dev)
 - Deployments
   - **dev** [dev.karrot.world](https://dev.karrot.world) - master branch using dev backend/db
   - **production** [karrot.world](https://karrot.world) -  production backend/db

--- a/docs/src/features/groups.md
+++ b/docs/src/features/groups.md
@@ -2,7 +2,7 @@
 
 Groups are at the heart of Karrot. Each group is independent from the rest and will usually represent an in-person community of people. They normally have their own organisational name and structure.
 
-They are not part of the karrot organisation, they just use karrot. Ideally one of more of the community members participate in our [community forum](https://community.foodsaving.world/), or via [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)/[GitHub](https://github.com/yunity/karrot-frontend)/etc.
+They are not part of the karrot organisation, they just use karrot. Ideally one of more of the community members participate in our [community forum](https://community.foodsaving.world/), or via [chat.karrot.world/channel/karrot-dev](https://chat.karrot.world/channel/karrot-dev)/[GitHub](https://github.com/yunity/karrot-frontend)/etc.
 
 ## Group Gallery
 

--- a/docs/src/mobile.md
+++ b/docs/src/mobile.md
@@ -63,7 +63,7 @@ Run!
 ./run android dev release <password>
 ```
 
-... where `<password>` is a common yunity password. Ask in [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev) if you'd like to know it.
+... where `<password>` is a common yunity password. Ask in [chat.karrot.world/channel/karrot-dev](https://chat.karrot.world/channel/karrot-dev) if you'd like to know it.
 
 If you have an android device connected in USB debugging mode it will install it on that,
 otherwise it will try and start an emulator, but you might have to run one yourself if the default does not work.
@@ -93,7 +93,7 @@ Use our wrapper script
 ./build android dev release <password>
 ```
 
-... where `<password>` is a common yunity password. Ask in [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev) if you'd like to know it.
+... where `<password>` is a common yunity password. Ask in [chat.karrot.world/channel/karrot-dev](https://chat.karrot.world/channel/karrot-dev) if you'd like to know it.
 
 If you connect your phone to your computer, you can use the chrome debugging tools with this.
 

--- a/src/base/pages/Landing.vue
+++ b/src/base/pages/Landing.vue
@@ -170,7 +170,7 @@
               <a
                 slot="chat"
                 v-t="'ABOUT_KARROT.LINKS.CHAT'"
-                href="https://chat.foodsaving.world/channel/karrot-dev"
+                href="https://chat.karrot.world/channel/karrot-dev"
               />
               <a
                 slot="translations"

--- a/src/boot/helloDeveloper.js
+++ b/src/boot/helloDeveloper.js
@@ -15,7 +15,7 @@ export default async () => {
         Community forum → https://community.foodsaving.world
                 Project → https://foodsaving.world
                    Code → https://github.com/yunity/karrot-frontend
-                   Chat → https://chat.foodsaving.world/channel/karrot-dev
+                   Chat → https://chat.karrot.world/channel/karrot-dev
       `.trim().replace(/^ {6}/gm, '').replace(/%c\n/g, '%c'),
       style({
         ...sansSerif,


### PR DESCRIPTION
## What does this PR do?

Change all references to chat.foodsaving.world to refer to chat.karrot.world.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)