### PR TITLE
remove duplicate changelog headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,17 +23,14 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Added
 - Users can revoke trust @pogopaule [#2352]
+- meta-tags: added title variable to quasar.conf.js and og_site_name for meta description [#2405]
 
 ### Changed
 - Remove invitation by e-mail at members page @brnsolikyl [#2349]
+- meta-tags: site description update in composer.json update for og:title [#2405]
 
 ### Fixed
 - add explicit host in ics url @amengsk [#2406]
-
-### Added
-- meta-tags: added title variable to quasar.conf.js and og_site_name for meta description [#2405]
-### Changed
-- meta-tags: site description update in composer.json update for og:title [#2405]
 
 ## [9.4.0] - 2021-06-24
 ### Changed


### PR DESCRIPTION
## What does this PR do?

I have removed the duplications of both headings `added` and `changed` of the unreleased version.

## Checklist

- [x] added a test, or explain why one is not needed/possible... - Not needed for changelog.
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)