### PR TITLE
only expose joined activities in ics export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please document your changes in this format:
 - Remove invitation by e-mail at members page @brnsolikyl [#2349]
 - Redirect to place feedback page after saving, highlight entry @tiltec #2417
 - meta-tags: site description update in composer.json update for og:title [#2405]
+- activities: ics subscription only exposes joined events [#2428]
 
 ### Fixed
 - add explicit host in ics url @amengsk [#2406]

--- a/src/activities/datastore/activities.js
+++ b/src/activities/datastore/activities.js
@@ -51,10 +51,10 @@ export default {
       return getters.byCurrentGroup.filter(({ place }) => place && place.isActivePlace)
     },
     icsUrlForCurrentGroup: (state, getters, rootState, rootGetters) => {
-      return activities.icsUrl({ group: rootGetters['currentGroup/id'] })
+      return activities.icsUrl({ group: rootGetters['currentGroup/id'], joined: true })
     },
     icsUrlForCurrentPlace: (state, getters, rootState, rootGetters) => {
-      return activities.icsUrl({ place: rootGetters['places/activePlaceId'] })
+      return activities.icsUrl({ place: rootGetters['places/activePlaceId'], joined: true })
     },
     joined: (state, getters) => getters.byCurrentGroup.filter(e => e.isUserMember),
     available: (state, getters) =>

--- a/src/activities/datastore/activities.spec.js
+++ b/src/activities/datastore/activities.spec.js
@@ -6,7 +6,7 @@ jest.mock('@/activities/api/activities', () => ({
   get: mockGet,
   join: mockJoin,
   leave: mockLeave,
-  icsUrl: mockIcsUrl
+  icsUrl: mockIcsUrl,
 }))
 
 import { createDatastore, defaultActionStatusesFor } from '>/helpers'
@@ -70,15 +70,15 @@ describe('activities', () => {
             get () {
               return id => ({ id, group, isSubscribed: true })
             },
-            activePlaceId: () => 1234
+            activePlaceId: () => 1234,
           },
         },
         currentGroup: {
           getters: {
             id () {
               return 666
-            }
-          }
+            },
+          },
         },
         users: {
           getters: {
@@ -194,7 +194,7 @@ describe('activities', () => {
     it('can get upcoming and started', () => {
       expect(vstore.getters['activities/upcomingAndStarted'].map(getId)).toEqual([startedActivity1, startedActivity2, activity1, activity2, activity3].map(getId))
     })
- 
+
     it('generates an ics url for the current group', () => {
       expect(vstore.getters['activities/icsUrlForCurrentGroup']).toEqual('/ics?group=666&joined=true')
     })
@@ -202,7 +202,6 @@ describe('activities', () => {
     it('generates an ics url for the current place', () => {
       expect(vstore.getters['activities/icsUrlForCurrentPlace']).toEqual('/ics?place=1234&joined=true')
     })
-
   })
 
   it('filters by active place', () => {

--- a/src/activities/datastore/activities.spec.js
+++ b/src/activities/datastore/activities.spec.js
@@ -1,10 +1,12 @@
 const mockGet = jest.fn()
 const mockJoin = jest.fn()
 const mockLeave = jest.fn()
+const mockIcsUrl = jest.fn(filters => '/ics?' + new URLSearchParams(filters).toString())
 jest.mock('@/activities/api/activities', () => ({
   get: mockGet,
   join: mockJoin,
   leave: mockLeave,
+  icsUrl: mockIcsUrl
 }))
 
 import { createDatastore, defaultActionStatusesFor } from '>/helpers'
@@ -68,7 +70,15 @@ describe('activities', () => {
             get () {
               return id => ({ id, group, isSubscribed: true })
             },
+            activePlaceId: () => 1234
           },
+        },
+        currentGroup: {
+          getters: {
+            id () {
+              return 666
+            }
+          }
         },
         users: {
           getters: {
@@ -184,6 +194,15 @@ describe('activities', () => {
     it('can get upcoming and started', () => {
       expect(vstore.getters['activities/upcomingAndStarted'].map(getId)).toEqual([startedActivity1, startedActivity2, activity1, activity2, activity3].map(getId))
     })
+ 
+    it('generates an ics url for the current group', () => {
+      expect(vstore.getters['activities/icsUrlForCurrentGroup']).toEqual('/ics?group=666&joined=true')
+    })
+
+    it('generates an ics url for the current place', () => {
+      expect(vstore.getters['activities/icsUrlForCurrentPlace']).toEqual('/ics?place=1234&joined=true')
+    })
+
   })
 
   it('filters by active place', () => {

--- a/src/locales/locale-ar.json
+++ b/src/locales/locale-ar.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-da.json
+++ b/src/locales/locale-da.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-el.json
+++ b/src/locales/locale-el.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "Μπορείς να δημιουργήσεις μια νέα δραστηριότητα στην σελίδα 'Διαχείριση δράσεων/δραστηριοτήτων' ",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-eo.json
+++ b/src/locales/locale-eo.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "Vi povas krei novan aktivaĵon en la \"Agordu aktivaĵojn\"-a paĝo.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-es.json
+++ b/src/locales/locale-es.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "Puedes crear una nueva actividad en la página \"Gestionar actividades\".",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-fa.json
+++ b/src/locales/locale-fa.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-fa_IR.json
+++ b/src/locales/locale-fa_IR.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-fr.json
+++ b/src/locales/locale-fr.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-gu.json
+++ b/src/locales/locale-gu.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-he_IL.json
+++ b/src/locales/locale-he_IL.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-hi.json
+++ b/src/locales/locale-hi.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-hr.json
+++ b/src/locales/locale-hr.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-hu.json
+++ b/src/locales/locale-hu.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "Új tevékenységet a 'Tevékenységek kezelése' oldalon tudsz létrehozni.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-it.json
+++ b/src/locales/locale-it.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-ja.json
+++ b/src/locales/locale-ja.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-mr.json
+++ b/src/locales/locale-mr.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-nl.json
+++ b/src/locales/locale-nl.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-no.json
+++ b/src/locales/locale-no.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-pt.json
+++ b/src/locales/locale-pt.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-pt_BR.json
+++ b/src/locales/locale-pt_BR.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-ro.json
+++ b/src/locales/locale-ro.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-ru.json
+++ b/src/locales/locale-ru.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-sv.json
+++ b/src/locales/locale-sv.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "Du kan skapa en ny aktivitet på \"Redigera aktiviteter\".",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-zh_Hans.json
+++ b/src/locales/locale-zh_Hans.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",

--- a/src/locales/locale-zh_Hant.json
+++ b/src/locales/locale-zh_Hant.json
@@ -97,7 +97,7 @@
     "STORE_NONE_HINT": "You can create a new activity on the 'Manage Activities' page.",
     "ICS_DIALOG": {
       "TITLE": "Add to calendar",
-      "INTRO": "Add these activities to your calendar by using one of the following options:",
+      "INTRO": "Add your activities to your calendar by using one of the following options:",
       "DOWNLOAD_TITLE": "Download",
       "DOWNLOAD_TEXT": "Download the ICS-file to manually import it into your calendar:",
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",


### PR DESCRIPTION
Closes #2428

## What does this PR do?

as suggested by @tiltec this only selects joined activities in the ics export/subscription feature

## Links to related issues

#2428

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)